### PR TITLE
docs: define ui/ux patterns for notifications and banners

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -1,0 +1,102 @@
+# Credence Frontend — Notification Patterns
+
+Rules for notifications, banners, and toasts across the Credence UI.
+
+## Component Types
+
+### Banner (`src/components/Banner.tsx`)
+
+Inline, persistent notification for contextual or global alerts.
+
+- Renders inside page content flow
+- Stays visible until dismissed (if `dismissible`) or permanently
+- Use for: page-level context, global protocol alerts, form guidance
+
+### Toast (`src/components/Toast.tsx` + `ToastProvider.tsx`)
+
+Ephemeral overlay notification triggered by user actions or system events.
+
+- Renders fixed top-right, stacked vertically
+- Auto-dismisses based on severity timeout
+- Use for: action confirmations, transient status updates
+
+## Severity Levels
+
+| Severity | Use case | Example events |
+|----------|----------|---------------|
+| `info` | Neutral context | Bond lock period reminder, score epoch note |
+| `success` | Positive outcome | Bond created, score retrieved, vote submitted |
+| `warning` | Non-critical concern | Bond nearing slash threshold, low balance |
+| `danger` | Critical / destructive | Bond slashed, protocol paused, transaction failed |
+
+## Placement Rules
+
+| Type | Position | Scope |
+|------|----------|-------|
+| Global banner | Between header and `<main>` in Layout | Protocol-wide alerts (e.g. "Protocol paused") |
+| Contextual banner | Inline within page content | Page-specific guidance or warnings |
+| Toast | Fixed top-right overlay | Action confirmations and transient feedback |
+
+## Timeouts
+
+| Severity | Auto-dismiss | Rationale |
+|----------|-------------|-----------|
+| `info` | 5 seconds | Low urgency, informational |
+| `success` | 5 seconds | Confirmation — user can move on |
+| `warning` | 8 seconds | Needs attention but not blocking |
+| `danger` | Manual only | Must be acknowledged explicitly |
+
+## Stacking Rules
+
+- Maximum **3** toasts visible simultaneously
+- When a 4th toast arrives, the oldest is removed (FIFO)
+- Each toast can also be manually dismissed
+
+## Accessibility
+
+- Banners use `role="alert"` for `warning`/`danger` and `role="status"` for `info`/`success`
+- Toast container uses `aria-live="polite"` so screen readers announce new toasts
+- Dismiss buttons have `aria-label` text
+- Icons are marked `aria-hidden="true"` (decorative)
+- Dismiss buttons are keyboard-focusable and respond to Enter/Space
+
+## Event → Notification Mapping
+
+| Event | Type | Severity |
+|-------|------|----------|
+| Bond created | Toast | `success` |
+| Bond slashed | Banner (contextual) + Toast | `danger` |
+| Score updated | Toast | `success` |
+| Score lookup completed | Toast | `info` |
+| Governance vote submitted | Toast | `success` |
+| Protocol paused | Banner (global, sticky) | `danger` |
+| Low wallet balance | Banner (contextual) | `warning` |
+| Transaction failed | Toast | `danger` |
+
+## Usage
+
+### Banner
+
+```tsx
+import Banner from '@/components/Banner'
+
+<Banner severity="warning" dismissible onDismiss={() => {}}>
+  Your bond is approaching the slash threshold.
+</Banner>
+```
+
+### Toast
+
+```tsx
+import { useToast } from '@/components/ToastProvider'
+
+const { addToast } = useToast()
+addToast('success', 'Bond created successfully.')
+```
+
+## Guidelines
+
+- Avoid showing more than one banner per page section
+- Toasts are for transient feedback — do not use for persistent state
+- Danger-severity toasts require manual dismiss to ensure acknowledgment
+- Keep toast messages under ~80 characters

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import ToastProvider from './components/ToastProvider'
 import Layout from './components/Layout'
 import Home from './pages/Home'
 import Bond from './pages/Bond'
@@ -7,13 +8,15 @@ import TrustScore from './pages/TrustScore'
 function App() {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<Layout />}>
-          <Route index element={<Home />} />
-          <Route path="bond" element={<Bond />} />
-          <Route path="trust" element={<TrustScore />} />
-        </Route>
-      </Routes>
+      <ToastProvider>
+        <Routes>
+          <Route path="/" element={<Layout />}>
+            <Route index element={<Home />} />
+            <Route path="bond" element={<Bond />} />
+            <Route path="trust" element={<TrustScore />} />
+          </Route>
+        </Routes>
+      </ToastProvider>
     </BrowserRouter>
   )
 }

--- a/src/components/Banner.css
+++ b/src/components/Banner.css
@@ -1,0 +1,62 @@
+.banner {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    border-left: 4px solid;
+    border-radius: 6px;
+    font-size: 0.875rem;
+    line-height: 1.5;
+}
+
+.banner--info {
+    background: #eff6ff;
+    border-color: #3b82f6;
+    color: #1e40af;
+}
+
+.banner--success {
+    background: #f0fdf4;
+    border-color: #22c55e;
+    color: #166534;
+}
+
+.banner--warning {
+    background: #fffbeb;
+    border-color: #f59e0b;
+    color: #92400e;
+}
+
+.banner--danger {
+    background: #fef2f2;
+    border-color: #ef4444;
+    color: #991b1b;
+}
+
+.banner__icon {
+    flex-shrink: 0;
+    font-size: 1.125rem;
+    line-height: 1;
+    margin-top: 1px;
+}
+
+.banner__content {
+    flex: 1;
+    min-width: 0;
+}
+
+.banner__dismiss {
+    flex-shrink: 0;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1.125rem;
+    line-height: 1;
+    padding: 0;
+    color: inherit;
+    opacity: 0.6;
+}
+
+.banner__dismiss:hover {
+    opacity: 1;
+}

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from 'react'
+import './Banner.css'
+
+export type BannerSeverity = 'info' | 'success' | 'warning' | 'danger'
+
+interface BannerProps {
+    severity: BannerSeverity
+    children: ReactNode
+    dismissible?: boolean
+    onDismiss?: () => void
+}
+
+const ICONS: Record<BannerSeverity, string> = {
+    info: 'ℹ️',
+    success: '✅',
+    warning: '⚠️',
+    danger: '🚨',
+}
+
+export default function Banner({ severity, children, dismissible, onDismiss }: BannerProps) {
+    const isUrgent = severity === 'danger' || severity === 'warning'
+
+    return (
+        <div
+            className={`banner banner--${severity}`}
+            role={isUrgent ? 'alert' : 'status'}
+        >
+            <span className="banner__icon" aria-hidden="true">
+                {ICONS[severity]}
+            </span>
+            <div className="banner__content">{children}</div>
+            {dismissible && (
+                <button
+                    type="button"
+                    className="banner__dismiss"
+                    onClick={onDismiss}
+                    aria-label="Dismiss notification"
+                >
+                    ✕
+                </button>
+            )}
+        </div>
+    )
+}

--- a/src/components/Toast.css
+++ b/src/components/Toast.css
@@ -1,0 +1,89 @@
+.toast-container {
+    position: fixed;
+    top: 1rem;
+    right: 1rem;
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    max-width: 22rem;
+    pointer-events: none;
+}
+
+.toast {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.625rem;
+    padding: 0.75rem 1rem;
+    border-left: 4px solid;
+    border-radius: 6px;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    pointer-events: auto;
+    animation: toast-in 0.25s ease-out;
+}
+
+.toast--info {
+    background: #eff6ff;
+    border-color: #3b82f6;
+    color: #1e40af;
+}
+
+.toast--success {
+    background: #f0fdf4;
+    border-color: #22c55e;
+    color: #166534;
+}
+
+.toast--warning {
+    background: #fffbeb;
+    border-color: #f59e0b;
+    color: #92400e;
+}
+
+.toast--danger {
+    background: #fef2f2;
+    border-color: #ef4444;
+    color: #991b1b;
+}
+
+.toast__icon {
+    flex-shrink: 0;
+    font-size: 1rem;
+    line-height: 1;
+    margin-top: 1px;
+}
+
+.toast__message {
+    flex: 1;
+    min-width: 0;
+}
+
+.toast__dismiss {
+    flex-shrink: 0;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1rem;
+    line-height: 1;
+    padding: 0;
+    color: inherit;
+    opacity: 0.6;
+}
+
+.toast__dismiss:hover {
+    opacity: 1;
+}
+
+@keyframes toast-in {
+    from {
+        opacity: 0;
+        transform: translateX(1rem);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateX(0);
+    }
+}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,39 @@
+import type { BannerSeverity } from './Banner'
+import './Toast.css'
+
+const ICONS: Record<BannerSeverity, string> = {
+    info: 'ℹ️',
+    success: '✅',
+    warning: '⚠️',
+    danger: '🚨',
+}
+
+export interface ToastData {
+    id: string
+    severity: BannerSeverity
+    message: string
+}
+
+interface ToastProps {
+    toast: ToastData
+    onDismiss: (id: string) => void
+}
+
+export default function Toast({ toast, onDismiss }: ToastProps) {
+    return (
+        <div className={`toast toast--${toast.severity}`} role="status">
+            <span className="toast__icon" aria-hidden="true">
+                {ICONS[toast.severity]}
+            </span>
+            <span className="toast__message">{toast.message}</span>
+            <button
+                type="button"
+                className="toast__dismiss"
+                onClick={() => onDismiss(toast.id)}
+                aria-label="Dismiss"
+            >
+                ✕
+            </button>
+        </div>
+    )
+}

--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -1,0 +1,59 @@
+import { createContext, useContext, useState, useCallback, useRef, type ReactNode } from 'react'
+import type { BannerSeverity } from './Banner'
+import Toast, { type ToastData } from './Toast'
+import './Toast.css'
+
+const MAX_TOASTS = 3
+
+const TIMEOUTS: Record<BannerSeverity, number> = {
+    info: 5000,
+    success: 5000,
+    warning: 8000,
+    danger: 0,
+}
+
+interface ToastContextValue {
+    addToast: (severity: BannerSeverity, message: string) => void
+    removeToast: (id: string) => void
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null)
+
+export function useToast() {
+    const ctx = useContext(ToastContext)
+    if (!ctx) throw new Error('useToast must be used within ToastProvider')
+    return ctx
+}
+
+export default function ToastProvider({ children }: { children: ReactNode }) {
+    const [toasts, setToasts] = useState<ToastData[]>([])
+    const idCounter = useRef(0)
+
+    const removeToast = useCallback((id: string) => {
+        setToasts(prev => prev.filter(t => t.id !== id))
+    }, [])
+
+    const addToast = useCallback((severity: BannerSeverity, message: string) => {
+        const id = String(++idCounter.current)
+        setToasts(prev => {
+            const next = [...prev, { id, severity, message }]
+            return next.length > MAX_TOASTS ? next.slice(next.length - MAX_TOASTS) : next
+        })
+
+        const timeout = TIMEOUTS[severity]
+        if (timeout > 0) {
+            setTimeout(() => removeToast(id), timeout)
+        }
+    }, [removeToast])
+
+    return (
+        <ToastContext.Provider value={{ addToast, removeToast }}>
+            {children}
+            <div className="toast-container" aria-live="polite" aria-label="Notifications">
+                {toasts.map(t => (
+                    <Toast key={t.id} toast={t} onDismiss={removeToast} />
+                ))}
+            </div>
+        </ToastContext.Provider>
+    )
+}

--- a/src/pages/Bond.tsx
+++ b/src/pages/Bond.tsx
@@ -1,10 +1,22 @@
+import Banner from '../components/Banner'
+import { useToast } from '../components/ToastProvider'
+
 export default function Bond() {
+  const { addToast } = useToast()
+
+  const handleCreate = () => {
+    addToast('success', 'Bond created successfully.')
+  }
+
   return (
     <div>
       <h1 style={{ marginBottom: '0.5rem' }}>Bond USDC</h1>
-      <p style={{ color: '#64748b', marginBottom: '1.5rem' }}>
+      <p id="bond-desc" style={{ color: '#64748b', marginBottom: '1rem' }}>
         Lock USDC into the Credence contract to build your economic reputation.
       </p>
+      <Banner severity="info">
+        Bonds are locked for a minimum of 30 days. Early withdrawal incurs a slash penalty.
+      </Banner>
       <div
         style={{
           maxWidth: '24rem',
@@ -12,16 +24,19 @@ export default function Bond() {
           border: '1px solid #e2e8f0',
           borderRadius: '12px',
           background: '#fff',
+          marginTop: '1rem',
         }}
       >
-        <label style={{ display: 'block', marginBottom: '0.5rem', fontWeight: 500 }}>
+        <label htmlFor="bond-amount" style={{ display: 'block', marginBottom: '0.5rem', fontWeight: 500 }}>
           Amount (USDC)
         </label>
         <input
+          id="bond-amount"
           type="number"
           placeholder="0"
           min="0"
           step="1"
+          aria-describedby="bond-desc"
           style={{
             width: '100%',
             padding: '0.75rem',
@@ -32,11 +47,12 @@ export default function Bond() {
         />
         <button
           type="button"
+          onClick={handleCreate}
           style={{
             marginTop: '1rem',
             width: '100%',
             padding: '0.75rem',
-            background: '#0ea5e9',
+            background: '#0284c7',
             color: '#fff',
             border: 'none',
             borderRadius: '8px',

--- a/src/pages/TrustScore.tsx
+++ b/src/pages/TrustScore.tsx
@@ -1,10 +1,22 @@
+import Banner from '../components/Banner'
+import { useToast } from '../components/ToastProvider'
+
 export default function TrustScore() {
+  const { addToast } = useToast()
+
+  const handleLookup = () => {
+    addToast('success', 'Trust score retrieved.')
+  }
+
   return (
     <div>
       <h1 style={{ marginBottom: '0.5rem' }}>Trust Score</h1>
-      <p style={{ color: '#64748b', marginBottom: '1.5rem' }}>
+      <p id="trust-desc" style={{ color: '#64748b', marginBottom: '1rem' }}>
         Your reputation score is computed from bond amount, duration, and attestations.
       </p>
+      <Banner severity="info">
+        Scores update once per epoch. Recent bond changes may not be reflected immediately.
+      </Banner>
       <div
         style={{
           maxWidth: '24rem',
@@ -12,14 +24,17 @@ export default function TrustScore() {
           border: '1px solid #e2e8f0',
           borderRadius: '12px',
           background: '#fff',
+          marginTop: '1rem',
         }}
       >
-        <label style={{ display: 'block', marginBottom: '0.5rem', fontWeight: 500 }}>
+        <label htmlFor="wallet-address" style={{ display: 'block', marginBottom: '0.5rem', fontWeight: 500 }}>
           Identity / Wallet address
         </label>
         <input
+          id="wallet-address"
           type="text"
           placeholder="G..."
+          aria-describedby="trust-desc"
           style={{
             width: '100%',
             padding: '0.75rem',
@@ -31,10 +46,11 @@ export default function TrustScore() {
         />
         <button
           type="button"
+          onClick={handleLookup}
           style={{
             width: '100%',
             padding: '0.75rem',
-            background: '#0ea5e9',
+            background: '#0284c7',
             color: '#fff',
             border: 'none',
             borderRadius: '8px',


### PR DESCRIPTION

Closes #10

## Summary
Adds a notification design system covering inline banners and ephemeral toasts with four severity levels (`info`, `success`, `warning`, `danger`).

## Root Cause
No notification components existed in the design system. Lifecycle events (bond created, slashed, score updated, governance decisions) had no visual feedback mechanism.

## Changes
- `Banner` component for persistent contextual/global alerts with severity-based ARIA roles (`role="alert"` for `warning`/`danger`, `role="status"` for `info`/`success`)
- `Toast` + `ToastProvider` for ephemeral action confirmations with auto-dismiss (5s `info`/`success`, 8s `warning`, manual-only `danger`) and max-3 stacking
- Example integrations on Bond and Trust Score pages
- `docs/notifications.md` documenting severities, placements, timeouts, stacking, accessibility rules, and event-to-notification mapping

## Testing
- ✅ `npm run build` passes (tsc + vite, 0 errors, 43 modules)
- ✅ Dev server works
