### PR TITLE
feat(uiux): add USDC amount input pattern with presets and max

### DIFF
--- a/docs/uiux/usdc-amount-input.md
+++ b/docs/uiux/usdc-amount-input.md
@@ -1,0 +1,31 @@
+# USDC amount input pattern
+
+This introduces a reusable USDC amount input pattern for `Bond` that improves UX for entering financial amounts with formatting and quick actions. Balance is mocked (UI-only).
+
+## Behavior
+
+- **Currency adornment**: shows `USDC` inside the input as a suffix (visual affordance only).
+- **Thousands formatting**: when the input is not focused, the value is displayed with grouping separators and **2 decimal places** (e.g. `12,345.60`).
+- **Editing**: while focused, the raw value is shown (no commas) to avoid cursor-jumps; invalid characters are stripped.
+- **Normalization**:
+  - On blur, values normalize to 2 decimals (e.g. `12345.6` → `12345.60`).
+  - Presets/Max set normalized values immediately.
+
+## Presets and Max
+
+- Preset chips: `100`, `500`, `1000` (USDC).
+- Presets are disabled when the preset amount is greater than the available balance.
+- **Mock available balance**: `2500.00` USDC.
+- “Max” sets the amount to the mocked available balance.
+
+## Validation (UI-only)
+
+- Error displays only when `amount > balance`.
+- Error is announced via `FormField` using `role="alert"`.
+
+## Visual QA
+
+- Route: `/bond`
+- Viewports: 375×800 and 1280×800
+- Check: adornment, Max, presets, focus-visible ring, error state when amount > 2500.00
+

--- a/src/components/AmountInput.css
+++ b/src/components/AmountInput.css
@@ -1,0 +1,140 @@
+.amountInput {
+  display: grid;
+  gap: var(--credence-space-3);
+}
+
+.amountInput__row {
+  display: flex;
+  align-items: center;
+  gap: var(--credence-space-3);
+}
+
+.amountInput__control {
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: center;
+}
+
+.amountInput__input {
+  width: 100%;
+  padding: var(--credence-space-3) var(--credence-space-12) var(--credence-space-3)
+    var(--credence-space-4);
+  border: 1px solid var(--credence-border-default);
+  border-radius: var(--credence-radius-lg);
+  font-size: var(--credence-font-size-base);
+  background: var(--credence-surface-page);
+  color: var(--credence-text-primary);
+  transition:
+    border-color var(--credence-motion-duration-base) var(--credence-motion-easing-standard),
+    box-shadow var(--credence-motion-duration-base) var(--credence-motion-easing-standard);
+}
+
+.amountInput__input:focus-visible {
+  outline: var(--credence-focus-ring);
+  outline-offset: 2px;
+}
+
+.amountInput[data-invalid='true'] .amountInput__input {
+  border-color: var(--credence-color-danger-border);
+}
+
+.amountInput__adornment {
+  position: absolute;
+  right: var(--credence-space-3);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--credence-space-2);
+  color: var(--credence-text-secondary);
+  font-weight: var(--credence-font-weight-semibold);
+  pointer-events: none;
+}
+
+.amountInput__maxButton {
+  padding: var(--credence-space-2) var(--credence-space-3);
+  border-radius: var(--credence-radius-md);
+  border: 1px solid var(--credence-border-default);
+  background: var(--credence-surface-card);
+  color: var(--credence-text-primary);
+  font-weight: var(--credence-font-weight-semibold);
+  cursor: pointer;
+  transition:
+    background-color var(--credence-motion-duration-base) var(--credence-motion-easing-standard),
+    border-color var(--credence-motion-duration-base) var(--credence-motion-easing-standard),
+    color var(--credence-motion-duration-base) var(--credence-motion-easing-standard);
+}
+
+.amountInput__maxButton:hover:not(:disabled) {
+  background: var(--credence-color-slate-100);
+  border-color: var(--credence-color-slate-400);
+}
+
+[data-theme='dark'] .amountInput__maxButton {
+  background: var(--credence-color-slate-700);
+  border-color: var(--credence-color-slate-600);
+}
+
+[data-theme='dark'] .amountInput__maxButton:hover:not(:disabled) {
+  background: var(--credence-color-slate-600);
+  border-color: var(--credence-color-slate-500);
+}
+
+.amountInput__maxButton:focus-visible {
+  outline: var(--credence-focus-ring);
+  outline-offset: 2px;
+}
+
+.amountInput__maxButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.amountInput__presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--credence-space-2);
+}
+
+.amountInput__chip {
+  padding: var(--credence-space-2) var(--credence-space-3);
+  border-radius: var(--credence-radius-full);
+  border: 1px solid var(--credence-border-default);
+  background: transparent;
+  color: var(--credence-text-primary);
+  font-weight: var(--credence-font-weight-semibold);
+  cursor: pointer;
+  transition:
+    background-color var(--credence-motion-duration-base) var(--credence-motion-easing-standard),
+    border-color var(--credence-motion-duration-base) var(--credence-motion-easing-standard);
+}
+
+.amountInput__chip:hover:not(:disabled) {
+  background: var(--credence-color-slate-100);
+  border-color: var(--credence-color-slate-400);
+}
+
+[data-theme='dark'] .amountInput__chip:hover:not(:disabled) {
+  background: rgba(56, 189, 248, 0.1);
+}
+
+.amountInput__chip:focus-visible {
+  outline: var(--credence-focus-ring);
+  outline-offset: 2px;
+}
+
+.amountInput__chip:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@media (max-width: 480px) {
+  .amountInput__row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .amountInput__maxButton {
+    width: 100%;
+  }
+}
+

--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -1,0 +1,148 @@
+import { useMemo, useState } from 'react'
+import './AmountInput.css'
+
+type NativeInputProps = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  'value' | 'onChange' | 'inputMode'
+>
+
+export interface AmountInputProps extends NativeInputProps {
+  value: string
+  onChange: (value: string) => void
+  balance: number
+  presets?: number[]
+  currencyLabel?: string
+  error?: string
+}
+
+const numberFormatter = new Intl.NumberFormat(undefined, {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+})
+
+function normalizeUSDC(rawValue: string) {
+  const trimmed = rawValue.trim()
+  if (!trimmed) return ''
+
+  const normalized = trimmed.replace(/,/g, '')
+  const numericValue = Number(normalized)
+  if (!Number.isFinite(numericValue)) return ''
+
+  const clamped = Math.max(0, numericValue)
+  return clamped.toFixed(2)
+}
+
+function formatUSDC(rawValue: string) {
+  const trimmed = rawValue.trim()
+  if (!trimmed) return ''
+
+  const normalized = trimmed.replace(/,/g, '')
+  const numericValue = Number(normalized)
+  if (!Number.isFinite(numericValue)) return rawValue
+
+  return numberFormatter.format(numericValue)
+}
+
+function sanitizeUSDCInput(nextValue: string) {
+  const cleaned = nextValue.replace(/[^\d.]/g, '')
+  const [whole = '', fraction = ''] = cleaned.split('.')
+  const trimmedWhole = whole.replace(/^0+(?=\d)/, '')
+  const trimmedFraction = fraction.slice(0, 2)
+
+  if (cleaned.includes('.')) return `${trimmedWhole || '0'}.${trimmedFraction}`
+  return trimmedWhole
+}
+
+export default function AmountInput({
+  value,
+  onChange,
+  balance,
+  presets = [100, 500, 1000],
+  currencyLabel = 'USDC',
+  error,
+  'aria-invalid': ariaInvalid,
+  onBlur,
+  onFocus,
+  ...inputProps
+}: AmountInputProps) {
+  const [isFocused, setIsFocused] = useState(false)
+  const isInvalid = Boolean(error) || ariaInvalid === 'true'
+
+  const displayValue = useMemo(() => {
+    if (isFocused) return value
+    return formatUSDC(value)
+  }, [isFocused, value])
+
+  const handleBlur: React.FocusEventHandler<HTMLInputElement> = (event) => {
+    setIsFocused(false)
+    const normalized = normalizeUSDC(value)
+    if (normalized !== value) onChange(normalized)
+    onBlur?.(event)
+  }
+
+  const handleFocus: React.FocusEventHandler<HTMLInputElement> = (event) => {
+    setIsFocused(true)
+    onFocus?.(event)
+  }
+
+  const handleMax = () => {
+    onChange(balance.toFixed(2))
+  }
+
+  const handlePreset = (preset: number) => {
+    onChange(preset.toFixed(2))
+  }
+
+  const maxDisabled = balance <= 0
+
+  return (
+    <div className="amountInput" data-invalid={isInvalid ? 'true' : 'false'}>
+      <div className="amountInput__row">
+        <div className="amountInput__control">
+          <input
+            {...inputProps}
+            className={['amountInput__input', inputProps.className].filter(Boolean).join(' ')}
+            value={displayValue}
+            inputMode="decimal"
+            autoComplete="off"
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            onChange={(event) => onChange(sanitizeUSDCInput(event.target.value))}
+          />
+          <span className="amountInput__adornment" aria-hidden="true">
+            {currencyLabel}
+          </span>
+        </div>
+
+        <button
+          type="button"
+          className="amountInput__maxButton"
+          onClick={handleMax}
+          disabled={maxDisabled}
+          aria-label={`Set max amount (${currencyLabel})`}
+        >
+          Max
+        </button>
+      </div>
+
+      <div className="amountInput__presets" aria-label="Quick amount presets">
+        {presets.map((preset) => {
+          const disabled = preset > balance
+          return (
+            <button
+              key={preset}
+              type="button"
+              className="amountInput__chip"
+              onClick={() => handlePreset(preset)}
+              disabled={disabled}
+              aria-label={`Set amount to ${preset} ${currencyLabel}`}
+            >
+              {preset}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+

--- a/src/components/forms/FormField.css
+++ b/src/components/forms/FormField.css
@@ -1,0 +1,23 @@
+.form-field {
+  display: grid;
+  gap: var(--credence-space-2);
+}
+
+.form-field label {
+  font-weight: var(--credence-font-weight-semibold);
+  color: var(--credence-text-secondary);
+}
+
+.form-hint {
+  color: var(--credence-text-secondary);
+  font-size: var(--credence-font-size-sm);
+}
+
+.form-error {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--credence-space-2);
+  color: var(--credence-color-danger-text);
+  font-size: var(--credence-font-size-sm);
+}
+

--- a/src/components/forms/FormField.tsx
+++ b/src/components/forms/FormField.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import './FormField.css'
 
 interface FormFieldProps {
   id: string
@@ -11,6 +12,7 @@ interface FormFieldProps {
 export function FormField({ id, label, hint, error, children }: FormFieldProps) {
   const hintId = hint ? `${id}-hint` : undefined
   const errorId = error ? `${id}-error` : undefined
+  const existingDescribedBy = children.props['aria-describedby'] as string | undefined
 
   return (
     <div className="form-field">
@@ -24,7 +26,8 @@ export function FormField({ id, label, hint, error, children }: FormFieldProps) 
 
       {React.cloneElement(children, {
         id,
-        'aria-describedby': [hintId, errorId].filter(Boolean).join(' ') || undefined,
+        'aria-describedby':
+          [existingDescribedBy, hintId, errorId].filter(Boolean).join(' ') || undefined,
         'aria-invalid': error ? 'true' : undefined,
       })}
 

--- a/src/pages/Bond.tsx
+++ b/src/pages/Bond.tsx
@@ -4,9 +4,30 @@ import { useToast } from '../components/ToastProvider'
 import Badge from '../components/Badge'
 import ActionCard from '../components/ActionCard'
 import Button from '../components/Button'
+import AmountInput from '../components/AmountInput'
+import { FormField } from '../components/forms/FormField'
+import { useMemo, useState } from 'react'
 
 export default function Bond() {
   const { addToast } = useToast()
+  const [amount, setAmount] = useState('')
+
+  const mockedBalance = 2500
+
+  const parsedAmount = useMemo(() => {
+    const normalized = amount.replace(/,/g, '').trim()
+    if (!normalized) return 0
+    const numericValue = Number(normalized)
+    return Number.isFinite(numericValue) ? numericValue : 0
+  }, [amount])
+
+  const overBalance = parsedAmount > mockedBalance
+  const balanceLabel = useMemo(() => {
+    return new Intl.NumberFormat(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(mockedBalance)
+  }, [mockedBalance])
 
   const handleCreate = () => {
     addToast('success', 'Bond created successfully.')
@@ -39,35 +60,22 @@ export default function Bond() {
         }}
       >
         <ActionCard title="Create New Bond">
-          <label
-            htmlFor="bond-amount"
-            style={{
-              display: 'block',
-              marginBottom: 'var(--credence-space-2)',
-              fontWeight: 'var(--credence-font-weight-semibold)',
-              color: 'var(--credence-text-secondary)',
-            }}
-          >
-            Amount (USDC)
-          </label>
-          <input
+          <FormField
             id="bond-amount"
-            type="number"
-            placeholder="0"
-            min="0"
-            step="1"
-            aria-describedby="bond-desc"
-            style={{
-              width: '100%',
-              padding: 'var(--credence-space-3) var(--credence-space-4)',
-              border: '1px solid var(--border-default)',
-              borderRadius: 'var(--credence-radius-lg)',
-              fontSize: 'var(--credence-font-size-base)',
-              margin: 0,
-              background: 'var(--bg-page)',
-              color: 'var(--text-primary)',
-            }}
-          />
+            label="Amount (USDC)"
+            hint={`Available: ${balanceLabel} USDC`}
+            error={overBalance ? 'Amount exceeds available balance.' : undefined}
+          >
+            <AmountInput
+              value={amount}
+              onChange={setAmount}
+              balance={mockedBalance}
+              presets={[100, 500, 1000]}
+              placeholder="0.00"
+              aria-describedby="bond-desc"
+              error={overBalance ? 'Amount exceeds available balance.' : undefined}
+            />
+          </FormField>
           <Button
             type="button"
             onClick={handleCreate}


### PR DESCRIPTION

Closes #118

## Summary
The Bond amount field was a bare numeric input with no currency affordance, formatting, balance/max control, or quick presets. This PR adds a reusable USDC AmountInput pattern and integrates it into the Bond flow (UI/UX only; balance mocked).

## What changed
- Added `AmountInput` component with:
  - `USDC` suffix/adornment
  - `Max` button bound to a mocked available balance (`2500.00`)
  - Quick-amount preset chips (`100`, `500`, `1000`) (disabled if preset > balance)
  - Thousands formatting + 2-decimal precision (formats on blur; raw while focused)
  - Focus + error styling using existing `--credence-*` tokens
- Integrated into Bond using `FormField` for label/hint/error + a11y wiring:
  - Hint: `Available: 2,500.00 USDC`
  - Error rule (UI-only): show error only when `amount > balance`
- Docs: `docs/uiux/usdc-amount-input.md` documents presets, formatting, mock balance, and validation behavior.

## Screenshot
Screenshot is attached to this PR:
- Route: `/bond`
- Viewports: 375×800 and 1280×800
- States: default, focus-visible on input/buttons, and error state when amount > 2500.00

Viewport: 375px
<img width="639" height="1368" alt="Screenshot from 2026-06-01 06-18-51" src="https://github.com/user-attachments/assets/5de7513b-2aae-4b92-b367-e99d0fb6b16e" />

Viewport: 1280px
<img width="1026" height="723" alt="Screenshot from 2026-06-01 06-20-35" src="https://github.com/user-attachments/assets/fc047264-7280-4270-bdbd-570dfdc25452" />


## Validation
- `npm run lint`
- `npm run build`

## A11y notes
- Presets and Max are labeled buttons (`type="button"` + `aria-label`).
- Input keeps a programmatic label via `FormField`.
- Errors are announced via `role="alert"` (FormField).