### PR TITLE
Uiux/create bond flow

### DIFF
--- a/src/components/CreateBondFlow.tsx
+++ b/src/components/CreateBondFlow.tsx
@@ -1,0 +1,307 @@
+import React, { useState, useRef, useEffect } from 'react'
+import { FormField } from './forms/FormField'
+import Button from './Button'
+import Banner from './Banner'
+import Disclaimer from './Disclaimer'
+import { useToast } from './ToastProvider'
+
+const calcUnlockDate = (days: number) => {
+  const today = new Date()
+  const unlock = new Date(today.getTime() + days * 24 * 60 * 60 * 1000)
+  return unlock.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
+}
+
+export default function CreateBondFlow() {
+  const { addToast } = useToast()
+  const [step, setStep] = useState(1)
+  const [amount, setAmount] = useState('')
+  const [duration, setDuration] = useState<number | null>(null)
+  const [error, setError] = useState('')
+  const [acknowledged, setAcknowledged] = useState(false)
+
+  const step1Ref = useRef<HTMLHeadingElement>(null)
+  const step2Ref = useRef<HTMLHeadingElement>(null)
+  const step3Ref = useRef<HTMLHeadingElement>(null)
+  const step4Ref = useRef<HTMLHeadingElement>(null)
+
+  useEffect(() => {
+    if (step === 1) step1Ref.current?.focus()
+    else if (step === 2) step2Ref.current?.focus()
+    else if (step === 3) step3Ref.current?.focus()
+    else if (step === 4) step4Ref.current?.focus()
+  }, [step])
+
+  const reset = () => {
+    setStep(1)
+    setAmount('')
+    setDuration(null)
+    setError('')
+    setAcknowledged(false)
+  }
+
+  const handleNext = () => {
+    if (step === 1) {
+      if (!amount || Number(amount) <= 0) {
+        setError('Please enter a valid amount greater than 0.')
+        return
+      }
+    }
+    if (step === 2) {
+      if (!duration) {
+        setError('Please select a lock duration.')
+        return
+      }
+    }
+    setError('')
+    setStep(step + 1)
+  }
+
+  const handleBack = () => {
+    setError('')
+    setStep(step - 1)
+  }
+
+  const handleConfirm = () => {
+    addToast('success', 'Bond created successfully.')
+    reset()
+  }
+
+  const StepIndicator = () => (
+    <div 
+      style={{ display: 'flex', gap: 'var(--credence-space-2)', marginBottom: 'var(--credence-space-4)' }} 
+      aria-label={`Step ${step} of 4`}
+    >
+      {[1, 2, 3, 4].map((i) => (
+        <div
+          key={i}
+          style={{
+            flex: 1,
+            height: '4px',
+            borderRadius: 'var(--credence-radius-full)',
+            background: i <= step ? 'var(--color-primary)' : 'var(--border-default)',
+            transition: 'background 0.2s ease',
+          }}
+        />
+      ))}
+    </div>
+  )
+
+  return (
+    <div style={{ display: 'grid', gap: 'var(--credence-space-6)' }}>
+      <StepIndicator />
+
+      {step === 1 && (
+        <div style={{ display: 'grid', gap: 'var(--credence-space-4)' }}>
+          <h2 ref={step1Ref} tabIndex={-1} style={{ outline: 'none', color: 'var(--text-primary)' }}>
+            Step 1: Enter Bond Amount
+          </h2>
+          <Banner severity="info">
+            Bonds are locked for a minimum of 30 days. Early withdrawal incurs a slash penalty.
+          </Banner>
+          <FormField id="bond-amount" label="Amount (USDC)" error={error}>
+            <input
+              type="number"
+              value={amount}
+              onChange={(e) => {
+                setAmount(e.target.value)
+                if (error) setError('')
+              }}
+              placeholder="0"
+              min="0"
+              step="1"
+              className="focus-visible"
+              style={{
+                width: '100%',
+                padding: 'var(--credence-space-3) var(--credence-space-4)',
+                border: '1px solid var(--border-default)',
+                borderRadius: 'var(--credence-radius-lg)',
+                fontSize: 'var(--credence-font-size-base)',
+                background: 'var(--bg-page)',
+                color: 'var(--text-primary)',
+              }}
+            />
+          </FormField>
+        </div>
+      )}
+
+      {step === 2 && (
+        <div style={{ display: 'grid', gap: 'var(--credence-space-4)' }}>
+          <h2 ref={step2Ref} tabIndex={-1} style={{ outline: 'none', color: 'var(--text-primary)' }}>
+            Step 2: Choose Lock Duration
+          </h2>
+          <p style={{ color: 'var(--text-secondary)' }}>Select how long you want to lock your USDC:</p>
+          
+          {error && (
+            <div role="alert" style={{ color: 'var(--color-danger)', fontWeight: 'var(--credence-font-weight-semibold)' }}>
+              ⚠ {error}
+            </div>
+          )}
+
+          <div style={{ display: 'flex', gap: 'var(--credence-space-3)' }}>
+            {[30, 90, 180].map((d) => (
+              <Button
+                key={d}
+                type="button"
+                onClick={() => {
+                  setDuration(d)
+                  if (error) setError('')
+                }}
+                style={{
+                  flex: 1,
+                  padding: 'var(--credence-space-4)',
+                  background: duration === d ? 'var(--color-primary)' : 'var(--bg-page)',
+                  color: duration === d ? 'var(--bg-page)' : 'var(--text-primary)',
+                  border: '1px solid var(--border-default)',
+                  borderRadius: 'var(--credence-radius-lg)',
+                  fontWeight: 'var(--credence-font-weight-semibold)',
+                  cursor: 'pointer',
+                  transition: 'all 0.2s ease',
+                }}
+              >
+                {d} Days
+              </Button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {step === 3 && (
+        <div style={{ display: 'grid', gap: 'var(--credence-space-4)' }}>
+          <h2 ref={step3Ref} tabIndex={-1} style={{ outline: 'none', color: 'var(--text-primary)' }}>
+            Step 3: Review Terms
+          </h2>
+          <Banner severity="warning">
+            Warning: Early withdrawal prior to lock maturity incurs a slash penalty on principal.
+          </Banner>
+          <div
+            style={{
+              padding: 'var(--credence-space-4)',
+              border: '1px solid var(--border-default)',
+              borderRadius: 'var(--credence-radius-lg)',
+              background: 'var(--bg-page)',
+              display: 'grid',
+              gap: 'var(--credence-space-3)',
+            }}
+          >
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <span style={{ color: 'var(--text-secondary)' }}>Bond Amount:</span>
+              <strong style={{ color: 'var(--text-primary)' }}>{amount} USDC</strong>
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <span style={{ color: 'var(--text-secondary)' }}>Lock Duration:</span>
+              <strong style={{ color: 'var(--text-primary)' }}>{duration} Days</strong>
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <span style={{ color: 'var(--text-secondary)' }}>Estimated Unlock Date:</span>
+              <strong style={{ color: 'var(--text-primary)' }}>{duration ? calcUnlockDate(duration) : ''}</strong>
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+              <span style={{ color: 'var(--text-secondary)' }}>Slash Terms:</span>
+              <strong style={{ color: 'var(--color-danger)' }}>Penalties Apply</strong>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {step === 4 && (
+        <div style={{ display: 'grid', gap: 'var(--credence-space-4)' }}>
+          <h2 ref={step4Ref} tabIndex={-1} style={{ outline: 'none', color: 'var(--text-primary)' }}>
+            Step 4: Confirm Bond
+          </h2>
+          <Disclaimer
+            context="Bonding USDC locks funds in a non-custodial smart contract. Slashing conditions apply."
+            termsHref="#"
+          />
+          <label
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--credence-space-2)',
+              cursor: 'pointer',
+              color: 'var(--text-primary)',
+              marginTop: 'var(--credence-space-2)',
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={acknowledged}
+              onChange={(e) => setAcknowledged(e.target.checked)}
+              style={{ width: '1.2rem', height: '1.2rem', cursor: 'pointer' }}
+            />
+            <span>I explicitly acknowledge the slashing terms and lock conditions.</span>
+          </label>
+        </div>
+      )}
+
+      <div style={{ display: 'flex', gap: 'var(--credence-space-3)', marginTop: 'var(--credence-space-4)' }}>
+        {step > 1 && (
+          <Button
+            type="button"
+            onClick={handleBack}
+            style={{
+              flex: 1,
+              padding: 'var(--credence-space-3)',
+              background: 'transparent',
+              color: 'var(--text-primary)',
+              border: '1px solid var(--border-default)',
+              borderRadius: 'var(--credence-radius-lg)',
+              cursor: 'pointer',
+            }}
+          >
+            Back
+          </Button>
+        )}
+        {step < 4 ? (
+          <Button
+            type="button"
+            onClick={handleNext}
+            style={{
+              flex: 1,
+              padding: 'var(--credence-space-3)',
+              background: 'var(--color-primary)',
+              color: 'var(--bg-page)',
+              border: 'none',
+              borderRadius: 'var(--credence-radius-lg)',
+              fontWeight: 'var(--credence-font-weight-semibold)',
+              cursor: 'pointer',
+            }}
+          >
+            Next
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            onClick={handleConfirm}
+            disabled={!acknowledged}
+            style={{
+              flex: 1,
+              padding: 'var(--credence-space-3)',
+              background: acknowledged ? 'var(--color-primary)' : 'var(--border-default)',
+              color: acknowledged ? 'var(--bg-page)' : 'var(--text-secondary)',
+              border: 'none',
+              borderRadius: 'var(--credence-radius-lg)',
+              fontWeight: 'var(--credence-font-weight-semibold)',
+              cursor: acknowledged ? 'pointer' : 'not-allowed',
+            }}
+          >
+            Confirm & Create Bond
+          </Button>
+        )}
+        <Button
+          type="button"
+          onClick={reset}
+          style={{
+            padding: 'var(--credence-space-3) var(--credence-space-4)',
+            background: 'var(--bg-page)',
+            color: 'var(--color-danger)',
+            border: '1px solid var(--border-default)',
+            borderRadius: 'var(--credence-radius-lg)',
+            cursor: 'pointer',
+          }}
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -24,6 +24,7 @@ export default function ThemeToggle() {
     <button
       onClick={toggleTheme}
       aria-label="Toggle dark mode"
+      className="focus-visible"
       style={{
         padding: '0.5rem',
         borderRadius: '8px',

--- a/src/components/states/EmptyState.tsx
+++ b/src/components/states/EmptyState.tsx
@@ -85,6 +85,7 @@ export default function EmptyState({
       {action && (
         <button
           onClick={action.onClick}
+          className="focus-visible"
           style={{
             padding: 'var(--credence-space-3) var(--credence-space-6)',
             background:

--- a/src/components/states/ErrorState.tsx
+++ b/src/components/states/ErrorState.tsx
@@ -89,6 +89,7 @@ export default function ErrorState({
       {action && (
         <button
           onClick={action.onClick}
+          className="focus-visible"
           style={{
             padding: '0.625rem var(--credence-space-5)',
             background: 'var(--credence-color-danger-action)',

--- a/src/pages/Bond.tsx
+++ b/src/pages/Bond.tsx
@@ -51,23 +51,24 @@ export default function Bond() {
             Amount (USDC)
           </label>
           <input
-            id="bond-amount"
-            type="number"
-            placeholder="0"
-            min="0"
-            step="1"
-            aria-describedby="bond-desc"
-            style={{
-              width: '100%',
-              padding: 'var(--credence-space-3) var(--credence-space-4)',
-              border: '1px solid var(--border-default)',
-              borderRadius: 'var(--credence-radius-lg)',
-              fontSize: 'var(--credence-font-size-base)',
-              margin: 0,
-              background: 'var(--bg-page)',
-              color: 'var(--text-primary)',
-            }}
-          />
+              id="bond-amount"
+              type="number"
+              placeholder="0"
+              min="0"
+              step="1"
+              aria-describedby="bond-desc"
+              className="focus-visible"
+              style={{
+                width: '100%',
+                padding: 'var(--credence-space-3) var(--credence-space-4)',
+                border: '1px solid var(--border-default)',
+                borderRadius: 'var(--credence-radius-lg)',
+                fontSize: 'var(--credence-font-size-base)',
+                margin: 0,
+                background: 'var(--bg-page)',
+                color: 'var(--text-primary)',
+              }}
+            />
           <Button
             type="button"
             onClick={handleCreate}

--- a/src/pages/Bond.tsx
+++ b/src/pages/Bond.tsx
@@ -1,17 +1,10 @@
 import Banner from '../components/Banner'
 import Disclaimer from '../components/Disclaimer'
-import { useToast } from '../components/ToastProvider'
 import Badge from '../components/Badge'
 import ActionCard from '../components/ActionCard'
-import Button from '../components/Button'
+import CreateBondFlow from '../components/CreateBondFlow'
 
 export default function Bond() {
-  const { addToast } = useToast()
-
-  const handleCreate = () => {
-    addToast('success', 'Bond created successfully.')
-  }
-
   const mockBonds = [
     { id: 1, amount: '500 USDC', status: 'active' },
     { id: 2, amount: '1000 USDC', status: 'locked' },
@@ -26,9 +19,6 @@ export default function Bond() {
           Lock USDC into the Credence contract to build your economic reputation.
         </p>
       </div>
-      <Banner severity="info">
-        Bonds are locked for a minimum of 30 days. Early withdrawal incurs a slash penalty.
-      </Banner>
 
       <div
         style={{
@@ -39,52 +29,7 @@ export default function Bond() {
         }}
       >
         <ActionCard title="Create New Bond">
-          <label
-            htmlFor="bond-amount"
-            style={{
-              display: 'block',
-              marginBottom: 'var(--credence-space-2)',
-              fontWeight: 'var(--credence-font-weight-semibold)',
-              color: 'var(--credence-text-secondary)',
-            }}
-          >
-            Amount (USDC)
-          </label>
-          <input
-              id="bond-amount"
-              type="number"
-              placeholder="0"
-              min="0"
-              step="1"
-              aria-describedby="bond-desc"
-              className="focus-visible"
-              style={{
-                width: '100%',
-                padding: 'var(--credence-space-3) var(--credence-space-4)',
-                border: '1px solid var(--border-default)',
-                borderRadius: 'var(--credence-radius-lg)',
-                fontSize: 'var(--credence-font-size-base)',
-                margin: 0,
-                background: 'var(--bg-page)',
-                color: 'var(--text-primary)',
-              }}
-            />
-          <Button
-            type="button"
-            onClick={handleCreate}
-            style={{
-              width: '100%',
-              padding: 'var(--credence-space-3) var(--credence-space-4)',
-              background: 'var(--color-primary)',
-              color: 'var(--bg-page)',
-              border: 'none',
-              borderRadius: 'var(--credence-radius-lg)',
-              fontWeight: 'var(--credence-font-weight-semibold)',
-              cursor: 'pointer',
-            }}
-          >
-            Create bond
-          </Button>
+          <CreateBondFlow />
         </ActionCard>
 
         <ActionCard title="Active Bonds">
@@ -109,11 +54,7 @@ export default function Bond() {
           </ul>
         </ActionCard>
       </div>
-
-      <Disclaimer
-        context="Bonding USDC locks funds in a non-custodial smart contract. Slashing conditions apply."
-        termsHref="#"
-      />
     </div>
   )
 }
+

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -13,6 +13,7 @@ export default function Home() {
         <Link
           to="/bond"
           role="button"
+          className="focus-visible"
           style={{
             padding: '0.75rem 1.25rem',
             background: 'var(--color-primary)',
@@ -27,6 +28,7 @@ export default function Home() {
         <Link
           to="/trust"
           role="button"
+          className="focus-visible"
           style={{
             padding: '0.75rem 1.25rem',
             background: 'var(--border-default)',

--- a/src/pages/TrustScore.tsx
+++ b/src/pages/TrustScore.tsx
@@ -62,7 +62,7 @@ export default function TrustScore() {
             Identity / Wallet address
           </label>
           <input
-            id="wallet-address"
+            id="wallet-address" className="focus-visible"
             type="text"
             placeholder="G..."
             aria-describedby="trust-desc"


### PR DESCRIPTION
This pr closes #101 
Summary
Implemented a guided, multi-step UI/UX flow for creating a USDC bond.

 Changes
- **New component** `CreateBondFlow`:
  - Step 1 – Amount input (validated, using `FormField`).
  - Step 2 – Lock duration selection (30 d / 90 d / 180 d button presets).
  - Step 3 – Review screen showing amount, duration, unlock date, and slash warning (`Banner`).
  - Step 4 – Final confirmation with mandatory disclaimer acknowledgement (`Disclaimer` + checkbox).
  - Accessible step indicator, focus management, error alerts (`role="alert"`), and responsive layout (375 px - 1280 px).

- **`Bond.tsx`** simplified to import and render `CreateBondFlow`.

QA
- ✅ Manual inspection at 375 px and 1280 px confirms proper layout.
- ✅ All steps include proper headings (`h2`/`h3`) and a11y alerts.