### PR TITLE
docs(config): add env example and proxy documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Credence Frontend runtime link configuration
+# Copy this file to .env for local overrides. These are public Vite variables,
+# so use placeholder or canonical public URLs only. Do not place secrets here.
+
+# Primary link override variables used by src/config/links.ts.
+VITE_DOCS_URL=https://docs.example.com/credence
+VITE_TERMS_URL=https://credence.example.com/legal/terms
+VITE_PRIVACY_URL=https://credence.example.com/legal/privacy
+
+# Legacy aliases kept for backward compatibility. The *_URL variables above
+# take precedence when both forms are set.
+VITE_DOCS=
+VITE_TERMS=
+VITE_PRIVACY=

--- a/README.md
+++ b/README.md
@@ -25,6 +25,28 @@ npm run dev
 
 App runs at [http://localhost:5173](http://localhost:5173). API requests to `/api` are proxied to the backend (default `http://localhost:3000`).
 
+## Configuration
+
+Copy `.env.example` to `.env` when you need local link overrides:
+
+```bash
+cp .env.example .env
+```
+
+The footer and legal links are resolved in `src/config/links.ts`. Use placeholder or canonical public URLs only; do not add secrets to Vite env files because `VITE_*` values are exposed to the browser build.
+
+| Variable | Legacy alias | Default fallback | Purpose |
+|----------|--------------|------------------|---------|
+| `VITE_DOCS_URL` | `VITE_DOCS` | `/docs` | Documentation link used in the footer. |
+| `VITE_TERMS_URL` | `VITE_TERMS` | `/legal/terms` | Terms of Service link used in the footer. |
+| `VITE_PRIVACY_URL` | `VITE_PRIVACY` | `/legal/privacy` | Privacy Policy link used in the footer. |
+
+Precedence is `VITE_*_URL` first, then the legacy `VITE_*` alias, then the default fallback path. For example, `VITE_DOCS_URL` wins over `VITE_DOCS`; if neither is set, the app uses `/docs`.
+
+The Vite dev server also proxies local API requests. Requests from the frontend to `/api` are forwarded to `http://localhost:3000` by `vite.config.ts`, so run the backend on port `3000` when testing API-backed flows locally.
+
+The link variable intent and legal handoff notes are also tracked in `docs/footer-link-manifest.md`.
+
 ## Scripts
 
 | Command   | Description          |


### PR DESCRIPTION
## Summary
- add a placeholder-only `.env.example` covering the docs, terms, and privacy link vars plus legacy aliases
- document Vite link env precedence, default fallbacks, and the local `/api` proxy target in `README.md`
- point contributors to `docs/footer-link-manifest.md` for the link handoff notes

## Validation
- `npm run build`

Closes #194