### PR TITLE
docs: add contributor and component references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,161 @@
+# Contributing to Credence Frontend
+
+Thanks for helping improve Credence Frontend. This guide covers the local workflow,
+branch conventions, quality gates, and pull request expectations for UI and
+component-library contributions.
+
+## Project Shape
+
+Credence Frontend is a Vite + React + TypeScript app. Shared UI primitives live in
+`src/components/`, design guidance lives in `docs/`, and global tokens are
+defined in `src/index.css` and documented in `docs/DESIGN_TOKENS.md`.
+
+Useful directories:
+
+- `src/components/` - shared UI components, forms, controls, navigation, and states.
+- `src/pages/` - route-level page implementations.
+- `src/hooks/` - reusable React hooks.
+- `src/context/` - shared app context.
+- `docs/` - design, motion, accessibility, and implementation references.
+
+## Local Setup
+
+Use a recent Node.js LTS release. Install dependencies once:
+
+```bash
+npm install
+```
+
+Start the Vite dev server:
+
+```bash
+npm run dev
+```
+
+Build the production bundle:
+
+```bash
+npm run build
+```
+
+Run linting:
+
+```bash
+npm run lint
+```
+
+Run tests:
+
+```bash
+npm run test
+```
+
+Run tests in watch mode:
+
+```bash
+npm run test:watch
+```
+
+Run coverage:
+
+```bash
+npm run test:coverage
+```
+
+Check formatting without rewriting files:
+
+```bash
+npm run format:check
+```
+
+Apply formatting:
+
+```bash
+npm run format
+```
+
+## Branch Naming
+
+Use short branch names that describe the outcome:
+
+- `docs/component-reference`
+- `fix/address-input-validation`
+- `test/focus-trap-regression`
+- `ui/mobile-nav-states`
+
+Avoid unrelated changes in the same branch. Keep documentation, behavior fixes,
+and visual refactors separate unless the issue asks for them together.
+
+## Pull Request Workflow
+
+1. Fork the repository.
+2. Create a topic branch from `main`.
+3. Make the smallest cohesive change that satisfies the issue.
+4. Run the relevant checks listed below.
+5. Open a pull request using `.github/pull_request_template.md` when present.
+
+For documentation-only changes, run at least:
+
+```bash
+npm run format:check
+```
+
+For component or hook changes, run:
+
+```bash
+npm run lint
+npm run test
+npm run build
+```
+
+Include any command that could not be run in the PR body with the reason.
+
+## Component Guidelines
+
+Prefer existing primitives before adding new ones. Check `docs/components.md` for
+the current component catalog and expected props.
+
+When updating or adding a shared component:
+
+- Export prop types when they are useful to consumers.
+- Add TSDoc for public prop fields, especially variants and callbacks.
+- Use `@/...` imports for app modules when a path would otherwise become deeply nested.
+- Use `Button`, `FormField`, `Badge`, and state components before introducing one-off UI.
+- Keep accessible names, roles, keyboard behavior, and focus return behavior explicit.
+- Prefer design tokens from `docs/DESIGN_TOKENS.md` over raw colors, spacing, and radii.
+- Add or update tests for validation, keyboard flow, and visible user-facing states.
+
+## Design Token Usage
+
+Use the `--credence-*` token family for color, spacing, radius, typography, and
+motion. Tokens keep pages consistent across light/dark themes and reduce drift
+from the Figma specs.
+
+Common token categories:
+
+- `--credence-color-*` for semantic colors and tier colors.
+- `--credence-space-*` for layout spacing.
+- `--credence-radius-*` for border radius.
+- `--credence-font-*` and `--credence-line-height-*` for typography.
+- `--credence-motion-*` for transitions and skeleton loading.
+
+Before adding a token, check `docs/DESIGN_TOKENS.md` and nearby component CSS.
+
+## Accessibility Expectations
+
+All component changes should preserve keyboard and assistive technology support:
+
+- Interactive controls need an accessible name.
+- Dialogs must trap focus, close with Escape when appropriate, and restore focus.
+- Status and error content should use semantic roles such as `status` or `alert`.
+- Form controls should connect labels, hints, and errors with ARIA relationships.
+- Visual-only icons should use `aria-hidden="true"`.
+
+## PR Checklist
+
+- Scope matches the linked issue.
+- Component props and usage are documented when public.
+- Design tokens are used instead of one-off visual values.
+- Accessibility behavior is preserved or improved.
+- Relevant tests and checks were run, or skipped checks are explained.
+- Screenshots are included when the change affects UI appearance.

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,0 +1,333 @@
+# Component Reference
+
+This reference documents the shared Credence Frontend component library. Use it
+when composing pages, adding variants, or reviewing whether a new UI element
+should be built from existing primitives.
+
+## Import Conventions
+
+Prefer direct component imports from `src/components` or its subfolders:
+
+```tsx
+import Button from '@/components/Button'
+import Badge from '@/components/Badge'
+import { FormField } from '@/components/forms/FormField'
+```
+
+Use the `@` alias for app source imports. Keep relative imports for files that
+live next to each other when that reads more clearly.
+
+## Core Components
+
+### `Button`
+
+Path: `src/components/Button.tsx`
+
+Use `Button` for primary commands, secondary actions, ghost actions, and
+destructive confirmations.
+
+Props:
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `variant` | `'primary' | 'secondary' | 'ghost' | 'danger'` | `'primary'` | Controls visual emphasis. |
+| `isLoading` | `boolean` | `false` | Shows a spinner, sets `aria-busy`, and disables interaction. |
+| `fullWidth` | `boolean` | `false` | Expands the button to its container width. |
+| `children` | `ReactNode` | required | Visible button label or inline content. |
+
+Example:
+
+```tsx
+<Button variant="primary" onClick={handleSave}>
+  Save changes
+</Button>
+```
+
+### `Badge`
+
+Path: `src/components/Badge.tsx`
+
+Use `Badge` for tier and status labels. Unknown variants intentionally fall back
+to the `unknown` style so callers do not silently render unstyled text.
+
+Props:
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `variant` | `BadgeVariant | string` | required | Known variants: `bronze`, `silver`, `gold`, `platinum`, `active`, `locked`, `slashed`, `grace-period`, `unknown`. |
+| `label` | `string` | variant label | Overrides the default display label. |
+| `className` | `string` | `''` | Appends custom classes. |
+
+Example:
+
+```tsx
+<Badge variant="gold" />
+<Badge variant="grace-period" label="Grace" />
+```
+
+### `Banner`
+
+Path: `src/components/Banner.tsx`
+
+Use `Banner` for contextual information, warnings, success feedback, and critical
+messages. Warning and critical banners use `role="alert"`; info and success use
+`role="status"`.
+
+Props:
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `severity` | `'info' | 'success' | 'warning' | 'critical'` | required | Controls icon, tone, and live-region role. |
+| `children` | `ReactNode` | required | Message body. |
+| `title` | `string` | undefined | Optional bold heading. |
+| `dismissible` | `boolean` | false | Shows a close button and enables Escape dismissal on that button. |
+| `onDismiss` | `() => void` | undefined | Called when the banner is dismissed. |
+| `action` | `{ label; href?; onClick? }` | undefined | Inline CTA rendered as a link or button. |
+| `returnFocusRef` | `RefObject<HTMLElement>` | `document.body` | Focus target after dismissal. |
+
+Example:
+
+```tsx
+<Banner severity="warning" title="Review required" dismissible onDismiss={hideBanner}>
+  Your bond details changed. Confirm before continuing.
+</Banner>
+```
+
+### `ConfirmDialog`
+
+Path: `src/components/ConfirmDialog.tsx`
+
+Use `ConfirmDialog` for destructive bond withdrawal flows that require the user
+to type `CONFIRM`. It uses a focus trap, blocks body scroll while open, and
+returns focus through `useFocusTrap`.
+
+Props:
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `open` | `boolean` | required | Controls portal rendering. |
+| `title` | `string` | required | Dialog heading. |
+| `subtitle` | `string` | undefined | Optional explanatory text. |
+| `breakdown` | `ConfirmDialogPenaltyBreakdown` | required | Bond amount, penalty, percent, and resulting balance. |
+| `onConfirm` | `() => void` | required | Called only after the typed phrase matches. |
+| `onCancel` | `() => void` | required | Called on cancel, backdrop click, or Escape. |
+| `returnFocusRef` | `RefObject<HTMLElement | null>` | undefined | Focus target after close. |
+| `confirmLabel` | `string` | `'Withdraw bond'` | Destructive action label. |
+
+Example:
+
+```tsx
+<ConfirmDialog
+  open={isOpen}
+  title="Withdraw bond?"
+  breakdown={breakdown}
+  onCancel={close}
+  onConfirm={withdraw}
+/>
+```
+
+## Form and Input Components
+
+### `FormField`
+
+Path: `src/components/forms/FormField.tsx`
+
+Use `FormField` to connect a label, hint, and error message to a single form
+control. It clones the child element and injects `id`, `aria-describedby`, and
+`aria-invalid`.
+
+Props:
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `id` | `string` | required | Shared by the label and child control. |
+| `label` | `string` | required | Visible field label. |
+| `hint` | `string` | undefined | Optional helper text. |
+| `error` | `string` | undefined | Optional error text rendered with `role="alert"`. |
+| `children` | `ReactElement` | required | A single input-like element. |
+
+### `AddressInput`
+
+Path: `src/components/AddressInput.tsx`
+
+Use `AddressInput` for Stellar public key entry. It validates 56-character
+addresses beginning with `G`, exposes validation changes, supports clipboard
+paste, and echoes a truncated valid address.
+
+Props:
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `id` | `string` | required | Input id passed into `FormField`. |
+| `label` | `string` | `'Stellar Address'` | Field label. |
+| `value` | `string` | required | Controlled address value. |
+| `onChange` | `(value: string) => void` | required | Called with raw address text. |
+| `onValidationChange` | `(isValid: boolean) => void` | undefined | Called whenever validity changes. |
+| `disabled` | `boolean` | `false` | Disables input and paste button. |
+| `className` | `string` | `''` | Wrapper class. |
+
+Utility:
+
+- `truncateAddress(address)` returns the first 12 and last 8 characters with an
+  ellipsis for long addresses.
+
+### `AmountInput`
+
+Path: `src/components/AmountInput.tsx`
+
+Use `AmountInput` for USDC-style decimal amounts. It sanitizes numeric input,
+normalizes to two decimals on blur, formats display when unfocused, and supports
+quick presets plus a max button.
+
+Props:
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `value` | `string` | required | Controlled decimal string. |
+| `onChange` | `(value: string) => void` | required | Receives sanitized or normalized value. |
+| `balance` | `number` | required | Maximum value used by the Max button and preset disabled state. |
+| `presets` | `number[]` | `[100, 500, 1000]` | Quick amount chips. |
+| `currencyLabel` | `string` | `'USDC'` | Visible adornment and accessible labels. |
+| `error` | `string` | undefined | Marks the wrapper invalid. |
+
+Example:
+
+```tsx
+<AmountInput value={amount} onChange={setAmount} balance={availableBalance} />
+```
+
+## Trust Components
+
+### `TrustGauge`
+
+Path: `src/components/TrustGauge.tsx`
+
+Use `TrustGauge` to display a 0-1000 trust score across Bronze, Silver, Gold,
+and Platinum tiers. It renders an accessible progressbar plus a tier legend.
+
+Props:
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `score` | `number` | required | Current score. Values above 1000 visually clamp at 100%. |
+| `tier` | `'bronze' | 'silver' | 'gold' | 'platinum'` | required | Current tier used for labels and next-tier text. |
+| `className` | `string` | `''` | Wrapper class. |
+| `id` | `string` | `'trust-gauge'` | Wrapper id. |
+
+Related export:
+
+- `TIER_CONFIG` contains tier thresholds, colors, and labels.
+
+### `TierLadder`
+
+Path: `src/components/TierLadder.tsx`
+
+Use `TierLadder` for an expandable explanation of trust tiers, thresholds, and
+benefits. Thresholds align with `docs/tier-thresholds.md`.
+
+Props:
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `className` | `string` | `''` | Section class. |
+| `defaultOpen` | `boolean` | `false` | Initial expanded state. |
+
+Related exports:
+
+- `TIER_LADDER` is the ordered list of tier definitions.
+- `TierDefinition` describes each tier's id, label, score range, and benefits.
+
+## State Components
+
+### `EmptyState`
+
+Path: `src/components/states/EmptyState.tsx`
+
+Use `EmptyState` when a view has no content yet and the user needs a next step.
+
+Props:
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `icon` | `ReactNode` | undefined | Custom icon node. |
+| `title` | `string` | required | Heading. |
+| `description` | `string` | required | Supporting copy. |
+| `action` | `{ label; onClick; variant? }` | undefined | Optional CTA button. |
+| `illustration` | `'bond' | 'trust' | 'dispute' | 'attestation' | 'activity'` | undefined | Token-backed preset illustration. |
+
+### `ErrorState`
+
+Path: `src/components/states/ErrorState.tsx`
+
+Use `ErrorState` for recoverable errors. Preset types provide default title,
+message, and icon copy.
+
+Props:
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `type` | `'network' | 'backend' | 'validation' | 'generic'` | `'generic'` | Selects default copy. |
+| `title` | `string` | preset title | Overrides default title. |
+| `message` | `string` | preset message | Overrides default message. |
+| `action` | `{ label; onClick }` | undefined | Optional recovery button. |
+| `icon` | `ReactNode` | preset icon | Overrides default icon. |
+
+### `LoadingSkeleton`
+
+Path: `src/components/states/LoadingSkeleton.tsx`
+
+Use `LoadingSkeleton` for loading placeholders. It supports text, card, form,
+table, dashboard, and fallback block shapes.
+
+Props:
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `variant` | `'text' | 'card' | 'form' | 'table' | 'dashboard'` | `'text'` | Skeleton layout. |
+| `rows` | `number` | `3` | Number of repeated rows/cards. |
+| `width` | `string` | `'100%'` | CSS width. |
+| `height` | `string` | undefined | Fallback block height. |
+
+## Control Components
+
+### `Select`
+
+Path: `src/components/controls/Select.tsx`
+
+Use `Select` for simple native select controls where the caller owns the value.
+
+Props:
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `id` | `string` | undefined | Native select id. |
+| `value` | `string` | required | Controlled selected value. |
+| `onChange` | `(value: string) => void` | required | Called with the selected option value. |
+| `options` | `{ value: string; label: string }[]` | required | Option list. |
+| `ariaLabel` | `string` | undefined | Accessible label when no visible label exists. |
+
+### `Toggle`
+
+Path: `src/components/controls/Toggle.tsx`
+
+Use `Toggle` for binary settings. It renders a button with `role="switch"` and
+`aria-checked`.
+
+Props:
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `id` | `string` | undefined | Button id. |
+| `checked` | `boolean` | required | Current switch state. |
+| `onChange` | `(next: boolean) => void` | required | Called with the next state. |
+| `ariaLabel` | `string` | undefined | Accessible label when surrounding text is not enough. |
+
+## Review Checklist
+
+Before adding or changing a shared component:
+
+- Can an existing component or variant solve the need?
+- Are public props exported and documented with TSDoc when useful?
+- Does the component use design tokens instead of one-off visual values?
+- Are labels, roles, focus behavior, and error states accessible?
+- Are behavior tests or usage examples updated for new variants?

--- a/src/components/AddressInput.tsx
+++ b/src/components/AddressInput.tsx
@@ -2,13 +2,20 @@ import React, { useState, useRef } from 'react'
 import { FormField } from './forms/FormField'
 import './AddressInput.css'
 
-interface AddressInputProps {
+export interface AddressInputProps {
+  /** Input id forwarded to FormField for label and description wiring. */
   id: string
+  /** Visible field label. Defaults to `Stellar Address`. */
   label?: string
+  /** Controlled Stellar public key value. */
   value: string
+  /** Called with the raw address text whenever the user edits or pastes. */
   onChange: (value: string) => void
+  /** Receives the current 56-character Stellar public key validation state. */
   onValidationChange?: (isValid: boolean) => void
+  /** Disables both the text input and paste button. */
   disabled?: boolean
+  /** Additional class names appended to the wrapper. */
   className?: string
 }
 

--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -7,11 +7,17 @@ type NativeInputProps = Omit<
 >
 
 export interface AmountInputProps extends NativeInputProps {
+  /** Controlled decimal amount string. */
   value: string
+  /** Called with sanitized input while editing and normalized input on blur. */
   onChange: (value: string) => void
+  /** Available balance used by the Max button and preset disabled states. */
   balance: number
+  /** Quick-select amounts rendered below the input. */
   presets?: number[]
+  /** Currency label shown as the input adornment and in button labels. */
   currencyLabel?: string
+  /** Optional validation message that marks the amount control invalid. */
   error?: string
 }
 

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -11,9 +11,12 @@ export type BadgeVariant =
   | 'grace-period'
   | 'unknown'
 
-interface BadgeProps {
+export interface BadgeProps {
+  /** Tier or status variant. Unknown strings normalize to the `unknown` style. */
   variant: BadgeVariant | string
+  /** Optional display label override. Defaults to the known variant label. */
   label?: string
+  /** Additional class names appended to the badge root. */
   className?: string
 }
 


### PR DESCRIPTION
## Summary

- add a root `CONTRIBUTING.md` covering setup, scripts, branch naming, PR workflow, component conventions, token usage, and accessibility expectations
- add `docs/components.md` as a Storybook-style component reference for the shared component library
- document props, variants, usage guidance, and review expectations for core components, forms, trust components, states, and controls
- add TSDoc to exported prop interfaces for Badge, AddressInput, and AmountInput

## Validation

- Not run locally: this is a static documentation change prepared from public repository source, and no untrusted repository commands were executed.
- Reviewed source files through GitHub read-only access to keep the documentation aligned with current props and exports.

Closes #157.