### PR TITLE
feat:enhance toast accessibility by splitting live regions for polite and assertive announcements

### DIFF
--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -127,7 +127,10 @@ const triggerRef = useRef<HTMLButtonElement>(null)
 
 - Banners use `role="alert"` for `warning`/`critical` and `role="status"` for `info`/`success`
 - `aria-label` on the banner root announces severity to screen readers
-- Toast container uses `aria-live="polite"` so screen readers announce new toasts
+- Toast container splits toasts across two sibling live regions to avoid double-announcing:
+  - `aria-live="polite"` (labelled "Notifications") for `info`, `success`, and `warning` — announced when the screen reader is idle
+  - `aria-live="assertive"` (labelled "Error notifications") for `danger` — interrupts and announces immediately, matching the sticky, must-acknowledge nature of error feedback
+- Individual toast elements use `role="alert"` for `danger` and `role="status"` for all other severities
 - Dismiss buttons have `aria-label` text
 - Icons are marked `aria-hidden="true"` (decorative)
 - Dismiss buttons are keyboard-focusable and respond to Enter/Space

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -80,7 +80,7 @@ interface ToastProps {
 
 export default function Toast({ toast, onDismiss }: ToastProps) {
   return (
-    <div className={`toast toast--${toast.severity}`} role="status">
+    <div className={`toast toast--${toast.severity}`} role={toast.severity === 'danger' ? 'alert' : 'status'}>
       <div className="toast__icon-container" aria-hidden="true">
         {ICONS[toast.severity]}
       </div>

--- a/src/components/ToastProvider.test.tsx
+++ b/src/components/ToastProvider.test.tsx
@@ -27,6 +27,8 @@ function ToastTrigger({ severity = 'info' as const, message = 'hello' } = {}) {
   return (
     <>
       <button onClick={() => addToast(severity, message)}>add toast</button>
+      <button onClick={() => addToast('danger', 'error message')}>add danger toast</button>
+      <button onClick={() => addToast('info', 'info message')}>add info toast</button>
       <button onClick={removeAllToasts}>remove all</button>
     </>
   )
@@ -99,5 +101,66 @@ describe('ToastProvider wiring with SettingsProvider', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
     expect(() => render(<ToastTrigger />)).toThrow('useToast must be used within ToastProvider')
     spy.mockRestore()
+  })
+})
+
+describe('aria-live region split', () => {
+  it('renders danger toast inside the assertive region', async () => {
+    const user = userEvent.setup()
+    renderWithProviders({ toastsEnabled: true })
+    await user.click(screen.getByRole('button', { name: 'add danger toast' }))
+    const assertiveRegion = screen.getByRole('region', { name: 'Error notifications' })
+    expect(assertiveRegion).toContainElement(screen.getByText('error message'))
+  })
+
+  it('danger toast uses role="alert"', async () => {
+    const user = userEvent.setup()
+    renderWithProviders({ toastsEnabled: true })
+    await user.click(screen.getByRole('button', { name: 'add danger toast' }))
+    expect(screen.getByRole('alert')).toHaveTextContent('error message')
+  })
+
+  it('renders info toast inside the polite region', async () => {
+    const user = userEvent.setup()
+    renderWithProviders({ toastsEnabled: true })
+    await user.click(screen.getByRole('button', { name: 'add info toast' }))
+    const politeRegion = screen.getByRole('region', { name: 'Notifications' })
+    expect(politeRegion).toContainElement(screen.getByText('info message'))
+  })
+
+  it('info toast uses role="status"', async () => {
+    const user = userEvent.setup()
+    renderWithProviders({ toastsEnabled: true })
+    await user.click(screen.getByRole('button', { name: 'add info toast' }))
+    expect(screen.getByRole('status')).toHaveTextContent('info message')
+  })
+
+  it('mixed stack: danger goes to assertive, info stays polite', async () => {
+    const user = userEvent.setup()
+    renderWithProviders({ toastsEnabled: true, autoDismiss: 'off' })
+    await user.click(screen.getByRole('button', { name: 'add danger toast' }))
+    await user.click(screen.getByRole('button', { name: 'add info toast' }))
+    const assertiveRegion = screen.getByRole('region', { name: 'Error notifications' })
+    const politeRegion = screen.getByRole('region', { name: 'Notifications' })
+    expect(assertiveRegion).toContainElement(screen.getByText('error message'))
+    expect(politeRegion).toContainElement(screen.getByText('info message'))
+  })
+
+  it('danger toast is NOT inside the polite region', async () => {
+    const user = userEvent.setup()
+    renderWithProviders({ toastsEnabled: true })
+    await user.click(screen.getByRole('button', { name: 'add danger toast' }))
+    const politeRegion = screen.getByRole('region', { name: 'Notifications' })
+    expect(politeRegion).not.toContainElement(screen.getByText('error message'))
+  })
+
+  it('dismiss-all clears toasts from both regions', async () => {
+    const user = userEvent.setup()
+    renderWithProviders({ toastsEnabled: true, autoDismiss: 'off' })
+    await user.click(screen.getByRole('button', { name: 'add danger toast' }))
+    await user.click(screen.getByRole('button', { name: 'add info toast' }))
+    await user.click(screen.getByRole('button', { name: 'Dismiss All' }))
+    expect(screen.queryByText('error message')).not.toBeInTheDocument()
+    expect(screen.queryByText('info message')).not.toBeInTheDocument()
   })
 })

--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -69,18 +69,31 @@ export default function ToastProvider({ children }: { children: ReactNode }) {
     [removeToast, toastsEnabled, autoDismiss]
   )
 
+  /** Toasts split by politeness: danger → assertive; all others → polite. */
+  const politeToasts = toasts.filter((t: ToastData) => t.severity !== 'danger')
+  const assertiveToasts = toasts.filter((t: ToastData) => t.severity === 'danger')
+
   return (
     <ToastContext.Provider value={{ addToast, removeToast, removeAllToasts }}>
       {children}
-      <div className="toast-container" aria-live="polite" aria-label="Notifications">
+      <div className="toast-container">
         {toasts.length > 1 && (
           <button type="button" className="toast-dismiss-all" onClick={removeAllToasts}>
             Dismiss All
           </button>
         )}
-        {toasts.map((t: ToastData) => (
-          <Toast key={t.id} toast={t} onDismiss={removeToast} />
-        ))}
+        {/* Polite region: info, success, warning — announced when the screen reader is idle */}
+        <div role="region" aria-live="polite" aria-label="Notifications">
+          {politeToasts.map((t: ToastData) => (
+            <Toast key={t.id} toast={t} onDismiss={removeToast} />
+          ))}
+        </div>
+        {/* Assertive region: danger — interrupts and announces immediately */}
+        <div role="region" aria-live="assertive" aria-label="Error notifications">
+          {assertiveToasts.map((t: ToastData) => (
+            <Toast key={t.id} toast={t} onDismiss={removeToast} />
+          ))}
+        </div>
       </div>
     </ToastContext.Provider>
   )


### PR DESCRIPTION

Closes #181

Here's a summary of every change and the reasoning behind each decision.
                                                                                
  What changed and why                                                          
                                                                                
  `Toast.tsx`                                                                   
                                                                                
  role={toast.severity === 'danger' ? 'alert' : 'status'}                       
                                                                                
  role="alert" implicitly carries aria-live="assertive" + aria-atomic="true" per
  the ARIA spec. Pairing it with the assertive container region reinforces the  
  intent and avoids any ambiguity for screen readers that inspect individual    
  element roles.                                                                
                                                                                
  ──────────────────────────────────────────────────────────────────────────────
                                                                                
  `ToastProvider.tsx` — the core fix                                            
                                                                                
  /** Toasts split by politeness: danger → assertive; all others → polite. */   
  const politeToasts = toasts.filter((t) => t.severity !== 'danger')            
  const assertiveToasts = toasts.filter((t) => t.severity === 'danger')         
                                                                                
  <div className="toast-container">                                             
    {toasts.length > 1 && <button ...>Dismiss All</button>}                     
                                                                                
    {/* info / success / warning */}                                            
    <div role="region" aria-live="polite" aria-label="Notifications">           
      {politeToasts.map(...)}                                                   
    </div>                                                                      
                                                                                
    {/* danger */}                                                              
    <div role="region" aria-live="assertive" aria-label="Error notifications">  
      {assertiveToasts.map(...)}                                                
    </div>                                                                      
  </div>                                                                        
                                                                                
  Two key design decisions:                                                     
                                                                                
  - Sibling containers, not nested — the original single aria-live="polite"     
  wrapper is gone. Nesting an assertive region inside a polite one would cause  
  the polite region to re-announce whatever the assertive one just said,        
  producing double-announcements.                                               
  - `role="region"` on each — makes them proper landmarks, which is what lets   
  the tests query them by getByRole('region', { name: '...' }). It's also a     
  bonus for AT navigation.                                                      
  - Dismiss All lives above both regions in the .toast-container wrapper,       
  outside any live region, so clicking it doesn't trigger an announcement.      
                                                                                
  ──────────────────────────────────────────────────────────────────────────────
                                                                                
  `ToastProvider.test.tsx` — 6 new cases in describe('aria-live region split',  
  ...)                                                                          
                                                                                
  ┌───────────────────────────────────────┬────────────────────────┐            
  │ Test                                  │ What it verifies       │            
  ├───────────────────────────────────────┼────────────────────────┤            
  │ danger in assertive region            │ DOM containment check  │            
  │ danger uses `role="alert"`            │ ARIA role              │            
  │ info in polite region                 │ DOM containment check  │            
  │ info uses `role="status"`             │ ARIA role              │            
  │ mixed stack: correct routing for both │ Region isolation       │            
  │ danger NOT in polite region           │ No cross-contamination │            
  │ dismiss-all clears both regions       │ State management       │            
  └───────────────────────────────────────┴────────────────────────┘            
                                                                                
  ──────────────────────────────────────────────────────────────────────────────
                                                                                
  `docs/notifications.md` — accessibility section updated to describe the       
  two-region model and the danger → assertive mapping.  