### PR TITLE
Migrate TrustScore inline styles to token CSS

### DIFF
--- a/docs/uiux/inline-style-migration.md
+++ b/docs/uiux/inline-style-migration.md
@@ -2,21 +2,23 @@
 
 This change migrates `style={{...}}` blocks in Home, TrustScore, and Layout to CSS classes that reference canonical `--credence-*` tokens (defined in `src/index.css`), to improve maintainability and enable pseudo-class states like `:hover` and `:focus-visible`.
 
+TrustScore now uses token-backed classes for the responsive grid, cards, lookup action spacing, and activity rows instead of page-level inline style objects.
+
 ## Legacy alias → canonical token mapping
 
-| Legacy alias used previously | Canonical token(s) in `src/index.css` |
-| --- | --- |
-| `--bg-page` | `--credence-surface-page` |
-| `--bg-card` | `--credence-surface-card` |
-| `--text-primary` | `--credence-text-primary` |
-| `--text-secondary` | `--credence-text-secondary` |
-| `--border-default` | `--credence-border-default` |
-| `--color-primary` | `--credence-color-primary` |
-| `--color-primary-hover` / `--primary-hover` | `--credence-color-primary-strong` |
-| `--space-6` | `--credence-space-6` |
-| `--container-padding` | `--credence-container-padding` |
-| `--container-max` | `--credence-container-max` |
-| `--slate-900` | `--credence-color-slate-900` (light), `--credence-color-slate-50` (dark override) |
+| Legacy alias used previously                | Canonical token(s) in `src/index.css`                                             |
+| ------------------------------------------- | --------------------------------------------------------------------------------- |
+| `--bg-page`                                 | `--credence-surface-page`                                                         |
+| `--bg-card`                                 | `--credence-surface-card`                                                         |
+| `--text-primary`                            | `--credence-text-primary`                                                         |
+| `--text-secondary`                          | `--credence-text-secondary`                                                       |
+| `--border-default`                          | `--credence-border-default`                                                       |
+| `--color-primary`                           | `--credence-color-primary`                                                        |
+| `--color-primary-hover` / `--primary-hover` | `--credence-color-primary-strong`                                                 |
+| `--space-6`                                 | `--credence-space-6`                                                              |
+| `--container-padding`                       | `--credence-container-padding`                                                    |
+| `--container-max`                           | `--credence-container-max`                                                        |
+| `--slate-900`                               | `--credence-color-slate-900` (light), `--credence-color-slate-50` (dark override) |
 
 ## Screenshot
 
@@ -24,4 +26,3 @@ This change migrates `style={{...}}` blocks in Home, TrustScore, and Layout to C
 - Viewport: 1280×800
 - State: focus-visible on “Look up score”
 - File: `docs/uiux/inline-style-migration/trustscore-1280-focus-visible.png` (add your captured screenshot here)
-

--- a/src/pages/TrustScore.css
+++ b/src/pages/TrustScore.css
@@ -37,6 +37,10 @@
   margin-bottom: var(--credence-space-4);
 }
 
+.trustScore__lookupButton {
+  margin-top: var(--credence-space-4);
+}
+
 .trustScore__label {
   display: block;
   margin-bottom: var(--credence-space-2);
@@ -80,4 +84,3 @@
   font-size: var(--credence-font-size-xs);
   color: var(--credence-text-secondary);
 }
-

--- a/src/pages/TrustScore.tsx
+++ b/src/pages/TrustScore.tsx
@@ -70,11 +70,11 @@ export default function TrustScore() {
             />
           ) : (
             <ul className="trustScore__activityList">
-              {activity.map((item) => (
+              {activity.map((item, index) => (
                 <li
                   key={item.id}
                   className={`trustScore__activityRow ${
-                    item.id === activity.length ? 'trustScore__activityRow--last' : ''
+                    index === activity.length - 1 ? 'trustScore__activityRow--last' : ''
                   }`}
                 >
                   <div>

--- a/src/pages/TrustScore.tsx
+++ b/src/pages/TrustScore.tsx
@@ -17,8 +17,12 @@ export default function TrustScore() {
     addToast('success', 'Trust score retrieved.')
   }
 
-  const activity: Array<{ id: number; action: string; date: string; status: 'active' | 'slashed' }> =
-    []
+  const activity: Array<{
+    id: number
+    action: string
+    date: string
+    status: 'active' | 'slashed'
+  }> = []
 
   return (
     <div>
@@ -34,24 +38,9 @@ export default function TrustScore() {
         Scores update once per epoch. Recent bond changes may not be reflected immediately.
       </Banner>
 
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
-          gap: '2rem',
-          marginTop: '2rem',
-        }}
-      >
-        <div
-          style={{
-            padding: '1.5rem',
-            border: '1px solid var(--border-default)',
-            borderRadius: '12px',
-            background: 'var(--bg-card)',
-            color: 'var(--text-primary)',
-          }}
-        >
-          <h2 style={{ fontSize: '1.25rem', marginBottom: '1rem' }}>Lookup Identity</h2>
+      <div className="trustScore__grid">
+        <div className="trustScore__card">
+          <h2 className="trustScore__cardTitle">Lookup Identity</h2>
           <AddressInput
             id="wallet-address"
             label="Stellar Address"
@@ -65,22 +54,14 @@ export default function TrustScore() {
             variant="primary"
             fullWidth
             disabled={!isAddressValid}
-            style={{ marginTop: '1rem' }}
+            className="trustScore__lookupButton"
           >
             Look up score
           </Button>
         </div>
 
-        <div
-          style={{
-            padding: '1.5rem',
-            border: '1px solid var(--border-default)',
-            borderRadius: '12px',
-            background: 'var(--bg-card)',
-            color: 'var(--text-primary)',
-          }}
-        >
-          <h2 style={{ fontSize: '1.25rem', marginBottom: '1rem' }}>Recent Activity</h2>
+        <div className="trustScore__card">
+          <h2 className="trustScore__cardTitle">Recent Activity</h2>
           {activity.length === 0 ? (
             <EmptyState
               illustration="activity"
@@ -88,24 +69,17 @@ export default function TrustScore() {
               description="New trust score events will appear here once bonds, attestations, or score updates occur."
             />
           ) : (
-            <ul style={{ listStyle: 'none', padding: 0 }}>
+            <ul className="trustScore__activityList">
               {activity.map((item) => (
                 <li
                   key={item.id}
-                  style={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                    padding: '0.75rem 0',
-                    borderBottom:
-                      item.id === activity.length ? 'none' : '1px solid var(--border-default)',
-                  }}
+                  className={`trustScore__activityRow ${
+                    item.id === activity.length ? 'trustScore__activityRow--last' : ''
+                  }`}
                 >
                   <div>
-                    <div style={{ fontWeight: 500 }}>{item.action}</div>
-                    <div style={{ fontSize: '0.75rem', color: 'var(--text-secondary)' }}>
-                      {item.date}
-                    </div>
+                    <div className="trustScore__activityAction">{item.action}</div>
+                    <div className="trustScore__activityDate">{item.date}</div>
                   </div>
                   <Badge variant={item.status} />
                 </li>


### PR DESCRIPTION
## Summary
- replace the TrustScore grid, card, heading, button spacing, and activity-row inline styles with token-backed CSS classes
- preserve the current DOM structure, responsive auto-fit grid, and empty-state behavior
- update the inline-style migration note for the TrustScore page scope

Closes #186

## Validation
- git diff --check
- npm exec --package=prettier@3.2.5 -- prettier --check src/pages/TrustScore.tsx src/pages/TrustScore.css docs/uiux/inline-style-migration.md
- rg -n "style=|var\(--bg-card\)|var\(--text-secondary\)|var\(--border-default\)|gridTemplateColumns" src/pages/TrustScore.tsx src/pages/TrustScore.css