### PR TITLE
feat(api): add typed fetch client layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ VITE_DOCS_URL=https://docs.example.com/credence
 VITE_TERMS_URL=https://credence.example.com/legal/terms
 VITE_PRIVACY_URL=https://credence.example.com/legal/privacy
 
+# API requests use /api by default in the browser. During local development,
+# Vite proxies /api to this backend origin.
+VITE_API_BASE_URL=http://localhost:3000
+
 # Legacy aliases kept for backward compatibility. The *_URL variables above
 # take precedence when both forms are set.
 VITE_DOCS=

--- a/README.md
+++ b/README.md
@@ -35,26 +35,29 @@ cp .env.example .env
 
 The footer and legal links are resolved in `src/config/links.ts`. Use placeholder or canonical public URLs only; do not add secrets to Vite env files because `VITE_*` values are exposed to the browser build.
 
-| Variable | Legacy alias | Default fallback | Purpose |
-|----------|--------------|------------------|---------|
-| `VITE_DOCS_URL` | `VITE_DOCS` | `/docs` | Documentation link used in the footer. |
-| `VITE_TERMS_URL` | `VITE_TERMS` | `/legal/terms` | Terms of Service link used in the footer. |
-| `VITE_PRIVACY_URL` | `VITE_PRIVACY` | `/legal/privacy` | Privacy Policy link used in the footer. |
+| Variable            | Legacy alias   | Default fallback                                                  | Purpose                                                                     |
+| ------------------- | -------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `VITE_DOCS_URL`     | `VITE_DOCS`    | `/docs`                                                           | Documentation link used in the footer.                                      |
+| `VITE_TERMS_URL`    | `VITE_TERMS`   | `/legal/terms`                                                    | Terms of Service link used in the footer.                                   |
+| `VITE_PRIVACY_URL`  | `VITE_PRIVACY` | `/legal/privacy`                                                  | Privacy Policy link used in the footer.                                     |
+| `VITE_API_BASE_URL` | -              | `/api` in the browser, `http://localhost:3000` for the Vite proxy | Backend origin for local `/api` proxying or a direct API base URL override. |
 
 Precedence is `VITE_*_URL` first, then the legacy `VITE_*` alias, then the default fallback path. For example, `VITE_DOCS_URL` wins over `VITE_DOCS`; if neither is set, the app uses `/docs`.
 
-The Vite dev server also proxies local API requests. Requests from the frontend to `/api` are forwarded to `http://localhost:3000` by `vite.config.ts`, so run the backend on port `3000` when testing API-backed flows locally.
+The Vite dev server also proxies local API requests. Requests from the frontend to `/api` are forwarded to `VITE_API_BASE_URL` by `vite.config.ts`, defaulting to `http://localhost:3000`, so run the backend on port `3000` when testing API-backed flows locally.
+
+Shared API helpers live in `src/api/`. Use `apiFetch<T>()` for JSON requests so pages and hooks get consistent `/api` prefixing, typed `ApiError` failures, and `AbortSignal` cancellation support without coupling the client to React.
 
 The link variable intent and legal handoff notes are also tracked in `docs/footer-link-manifest.md`.
 
 ## Scripts
 
-| Command   | Description          |
-|----------|----------------------|
-| `npm run dev`    | Start Vite dev server |
-| `npm run build`  | TypeScript + production build |
-| `npm run preview`| Preview production build |
-| `npm run lint`   | Run ESLint |
+| Command           | Description                   |
+| ----------------- | ----------------------------- |
+| `npm run dev`     | Start Vite dev server         |
+| `npm run build`   | TypeScript + production build |
+| `npm run preview` | Preview production build      |
+| `npm run lint`    | Run ESLint                    |
 
 ## Tech
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,10 +3,6 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { SettingsProvider } from './context/SettingsContext'
 import ToastProvider from './components/ToastProvider'
 import Layout from './components/Layout'
-import { Suspense, lazy } from 'react';
-import { Routes, Route } from 'react-router-dom';
-import Layout from './components/Layout';
-import RouteLoader from './components/RouteLoader';
 
 const Home = lazy(() => import('./pages/Home'))
 const Bond = lazy(() => import('./pages/Bond'))

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ApiError, apiFetch } from './client'
+
+const fetchMock = vi.fn<typeof fetch>()
+
+function jsonResponse(payload: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(payload), {
+    headers: { 'Content-Type': 'application/json', ...init.headers },
+    ...init,
+  })
+}
+
+afterEach(() => {
+  fetchMock.mockReset()
+  vi.unstubAllGlobals()
+})
+
+describe('apiFetch', () => {
+  it('prefixes /api, sends JSON headers, and parses JSON responses', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ score: 720 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await apiFetch<{ score: number }>('/trust-score/GABC', {
+      method: 'POST',
+      body: { network: 'testnet' },
+    })
+
+    expect(result).toEqual({ score: 720 })
+    expect(fetchMock).toHaveBeenCalledWith('/api/trust-score/GABC', {
+      method: 'POST',
+      headers: expect.any(Headers),
+      body: JSON.stringify({ network: 'testnet' }),
+    })
+
+    const headers = fetchMock.mock.calls[0][1]?.headers as Headers
+    expect(headers.get('Accept')).toBe('application/json')
+    expect(headers.get('Content-Type')).toBe('application/json')
+  })
+
+  it('throws ApiError with status, message, and payload for non-2xx JSON responses', async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ message: 'Bond not found', code: 'not_found' }, { status: 404 })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(apiFetch('/bonds/missing')).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 404,
+      message: 'Bond not found',
+      payload: { message: 'Bond not found', code: 'not_found' },
+    } satisfies Partial<ApiError>)
+  })
+
+  it('uses text response bodies as ApiError messages when JSON is not returned', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('temporarily unavailable', { status: 503 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(apiFetch('/health')).rejects.toMatchObject({
+      status: 503,
+      message: 'temporarily unavailable',
+      payload: 'temporarily unavailable',
+    })
+  })
+
+  it('returns undefined for 204 responses', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(apiFetch<void>('/bonds/123', { method: 'DELETE' })).resolves.toBeUndefined()
+  })
+
+  it('passes AbortSignal through to fetch so callers can cancel requests', async () => {
+    const controller = new AbortController()
+    fetchMock.mockResolvedValueOnce(jsonResponse({ items: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await apiFetch('/bonds', { signal: controller.signal })
+
+    expect(fetchMock.mock.calls[0][1]?.signal).toBe(controller.signal)
+  })
+
+  it('preserves AbortError rejections from fetch', async () => {
+    const abortError = new DOMException('The operation was aborted.', 'AbortError')
+    fetchMock.mockRejectedValueOnce(abortError)
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(apiFetch('/bonds')).rejects.toBe(abortError)
+  })
+
+  it('wraps network failures in ApiError with status 0', async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(apiFetch('/bonds')).rejects.toMatchObject({
+      name: 'ApiError',
+      status: 0,
+      message: 'Failed to fetch',
+    } satisfies Partial<ApiError>)
+  })
+
+  it('normalizes paths without a leading slash', async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ items: [] }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await apiFetch('bonds')
+
+    expect(fetchMock.mock.calls[0][0]).toBe('/api/bonds')
+  })
+
+  it('falls back to a status-based message when an error response has no body', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 500 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(apiFetch('/bonds')).rejects.toMatchObject({
+      status: 500,
+      message: 'Request failed with status 500',
+      payload: undefined,
+    })
+  })
+})

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,115 @@
+export interface ApiFetchOptions extends Omit<RequestInit, 'body'> {
+  body?: BodyInit | Record<string, unknown> | unknown[] | null
+}
+
+export class ApiError extends Error {
+  readonly status: number
+  readonly payload: unknown
+
+  constructor(status: number, message: string, payload?: unknown) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+    this.payload = payload
+  }
+}
+
+const env = (import.meta as ImportMeta & { env?: Record<string, string | undefined> }).env
+
+export const API_BASE_URL = normalizeBaseUrl(env?.VITE_API_BASE_URL || '/api')
+
+function normalizeBaseUrl(value: string): string {
+  const trimmed = value.trim()
+  if (!trimmed || trimmed === '/') {
+    return ''
+  }
+  return trimmed.replace(/\/+$/, '')
+}
+
+function buildUrl(path: string): string {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${API_BASE_URL}${normalizedPath}`
+}
+
+function isJsonBody(body: ApiFetchOptions['body']): body is Record<string, unknown> | unknown[] {
+  const isReadableStream = typeof ReadableStream !== 'undefined' && body instanceof ReadableStream
+
+  return (
+    Boolean(body) &&
+    typeof body === 'object' &&
+    !(body instanceof FormData) &&
+    !(body instanceof Blob) &&
+    !(body instanceof ArrayBuffer) &&
+    !ArrayBuffer.isView(body) &&
+    !(body instanceof URLSearchParams) &&
+    !isReadableStream
+  )
+}
+
+function buildHeaders(headers: HeadersInit | undefined, hasJsonBody: boolean): Headers {
+  const nextHeaders = new Headers(headers)
+  if (!nextHeaders.has('Accept')) {
+    nextHeaders.set('Accept', 'application/json')
+  }
+  if (hasJsonBody && !nextHeaders.has('Content-Type')) {
+    nextHeaders.set('Content-Type', 'application/json')
+  }
+  return nextHeaders
+}
+
+async function parseResponse(response: Response): Promise<unknown> {
+  if (response.status === 204) {
+    return undefined
+  }
+
+  const contentType = response.headers.get('content-type') || ''
+  if (contentType.includes('application/json')) {
+    return response.json()
+  }
+
+  const text = await response.text()
+  return text || undefined
+}
+
+function errorMessage(status: number, payload: unknown): string {
+  if (
+    payload &&
+    typeof payload === 'object' &&
+    'message' in payload &&
+    typeof payload.message === 'string'
+  ) {
+    return payload.message
+  }
+  if (typeof payload === 'string' && payload.trim()) {
+    return payload
+  }
+  return `Request failed with status ${status}`
+}
+
+export async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): Promise<T> {
+  const { body, headers, ...init } = options
+  const hasJsonBody = isJsonBody(body)
+
+  let response: Response
+  try {
+    response = await fetch(buildUrl(path), {
+      ...init,
+      headers: buildHeaders(headers, hasJsonBody),
+      body: hasJsonBody ? JSON.stringify(body) : body,
+    })
+  } catch (error) {
+    if (error && typeof error === 'object' && 'name' in error && error.name === 'AbortError') {
+      throw error
+    }
+    const message = error instanceof Error ? error.message : 'Network request failed'
+    throw new ApiError(0, message, error)
+  }
+
+  const payload = await parseResponse(response)
+
+  if (!response.ok) {
+    throw new ApiError(response.status, errorMessage(response.status, payload), payload)
+  }
+
+  return payload as T
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,2 @@
+export * from './client'
+export * from './types'

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,0 +1,31 @@
+export type BondStatus = 'active' | 'pending' | 'settled' | 'slashed' | 'cancelled'
+
+export type TrustTier = 'bronze' | 'silver' | 'gold' | 'platinum'
+
+export interface TrustScore {
+  address: string
+  score: number
+  tier: TrustTier
+  attestations: number
+  updatedAt: string
+}
+
+export interface Bond {
+  id: string
+  borrower: string
+  lender?: string
+  amount: string
+  asset: string
+  status: BondStatus
+  createdAt: string
+  maturesAt?: string
+}
+
+export interface ApiListResponse<T> {
+  items: T[]
+  nextCursor?: string
+}
+
+export interface ApiMessageResponse {
+  message: string
+}

--- a/src/components/AmountInput.test.ts
+++ b/src/components/AmountInput.test.ts
@@ -24,14 +24,14 @@ describe('sanitizeUSDCInput', () => {
   it('keeps leading zero before a decimal point', () => {
     expect(sanitizeUSDCInput('0.5')).toBe('0.5')
   })
+})
 
 // Export for manual testing in browser console
 if (typeof window !== 'undefined') {
-  (window as Window & { testAmountInput?: unknown }).testAmountInput = {
+  ;(window as Window & { testAmountInput?: unknown }).testAmountInput = {
     sanitizeUSDCInput,
     formatUSDC,
     normalizeUSDC,
-    runTests,
   }
   console.log('Test functions available as window.testAmountInput')
 }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -20,7 +20,6 @@ export default function Settings() {
     setAutoDismiss,
     saveSettings,
     cancelSettings,
-    hasUnsavedChanges,
   } = useSettings()
   const { addToast } = useToast()
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,8 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
+const apiProxyTarget = process.env.VITE_API_BASE_URL || 'http://localhost:3000'
+
 export default defineConfig({
   plugins: [react()],
   resolve: {
@@ -11,7 +13,7 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      '/api': { target: 'http://localhost:3000', changeOrigin: true },
+      '/api': { target: apiProxyTarget, changeOrigin: true },
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- add a framework-agnostic `src/api` layer with `apiFetch<T>`, `ApiError`, JSON body/header handling, AbortSignal passthrough, and network-error wrapping
- add shared Credence domain response types plus a barrel export for future hooks/pages
- wire `VITE_API_BASE_URL` into the Vite `/api` proxy and document the env/proxy/client usage
- fix two existing main-branch build blockers: duplicate imports in `App.tsx` and the malformed legacy `AmountInput.test.ts` syntax; remove an unused `Settings.tsx` binding

Closes #146

## Verification
- `npm.cmd run test -- src/api/client.test.ts` - 9 tests passed
- `vitest run src/api/client.test.ts --coverage.enabled true --coverage.include src/api/client.ts --coverage.reporter text` - client branch coverage 95.34%
- `npm.cmd run build` - passed
- `npm.cmd run lint` - passed
- `git diff --check` - passed

## Notes
- No live backend is required; tests mock native `fetch`.
- Full `npm.cmd run test` currently has unrelated SettingsContext localStorage persistence failures on `origin/main`; the new API client test file passes independently.