### PR TITLE
feat(wallet): gate bond and trust actions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,9 @@
 import { lazy, Suspense } from 'react'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { SettingsProvider } from './context/SettingsContext'
+import { WalletProvider } from './context/WalletContext'
 import ToastProvider from './components/ToastProvider'
 import Layout from './components/Layout'
-import { Suspense, lazy } from 'react';
-import { Routes, Route } from 'react-router-dom';
-import Layout from './components/Layout';
-import RouteLoader from './components/RouteLoader';
 
 const Home = lazy(() => import('./pages/Home'))
 const Bond = lazy(() => import('./pages/Bond'))
@@ -23,20 +20,22 @@ function App() {
   return (
     <BrowserRouter>
       <SettingsProvider>
-        <ToastProvider>
-          <Suspense fallback={<div>Loading...</div>}>
-            <Routes>
-              <Route path="/" element={<Layout />}>
-                <Route index element={<Home />} />
-                <Route path="bond" element={<Bond />} />
-                <Route path="trust" element={<TrustScore />} />
-                <Route path="settings" element={<Settings />} />
-                <Route path="test-amount-input" element={<AmountInputTestPage />} />
-                <Route path="*" element={<NotFound />} />
-              </Route>
-            </Routes>
-          </Suspense>
-        </ToastProvider>
+        <WalletProvider>
+          <ToastProvider>
+            <Suspense fallback={<div>Loading...</div>}>
+              <Routes>
+                <Route path="/" element={<Layout />}>
+                  <Route index element={<Home />} />
+                  <Route path="bond" element={<Bond />} />
+                  <Route path="trust" element={<TrustScore />} />
+                  <Route path="settings" element={<Settings />} />
+                  <Route path="test-amount-input" element={<AmountInputTestPage />} />
+                  <Route path="*" element={<NotFound />} />
+                </Route>
+              </Routes>
+            </Suspense>
+          </ToastProvider>
+        </WalletProvider>
       </SettingsProvider>
     </BrowserRouter>
   )

--- a/src/components/AmountInput.test.ts
+++ b/src/components/AmountInput.test.ts
@@ -1,37 +1,48 @@
-import { describe, it, expect } from 'vitest'
-import { sanitizeUSDCInput, formatUSDC, normalizeUSDC } from './AmountInput'
+import { describe, expect, it } from 'vitest'
+import { formatUSDC, normalizeUSDC, sanitizeUSDCInput } from './AmountInput'
 
-describe('sanitizeUSDCInput', () => {
-  it('passes through a valid decimal string', () => {
-    expect(sanitizeUSDCInput('123.45')).toBe('123.45')
+describe('AmountInput formatting helpers', () => {
+  describe('sanitizeUSDCInput', () => {
+    it('passes through a valid decimal string', () => {
+      expect(sanitizeUSDCInput('123.45')).toBe('123.45')
+    })
+
+    it('strips non-numeric, non-dot characters', () => {
+      expect(sanitizeUSDCInput('abc123')).toBe('123')
+      expect(sanitizeUSDCInput('$100.00')).toBe('100.00')
+      expect(sanitizeUSDCInput('1,000.50')).toBe('1000.50')
+    })
+
+    it('truncates fractions to two decimal places', () => {
+      expect(sanitizeUSDCInput('12.345')).toBe('12.34')
+    })
+
+    it('normalizes leading zeroes while preserving decimal input', () => {
+      expect(sanitizeUSDCInput('00123')).toBe('123')
+      expect(sanitizeUSDCInput('00')).toBe('0')
+      expect(sanitizeUSDCInput('0.5')).toBe('0.5')
+    })
   })
 
-  it('strips non-numeric, non-dot characters', () => {
-    expect(sanitizeUSDCInput('abc123')).toBe('123')
-    expect(sanitizeUSDCInput('$100.00')).toBe('100.00')
-    expect(sanitizeUSDCInput('1,000.50')).toBe('1000.50')
+  describe('normalizeUSDC', () => {
+    it('returns fixed two-decimal values for finite amounts', () => {
+      expect(normalizeUSDC('100')).toBe('100.00')
+      expect(normalizeUSDC('1,234.5')).toBe('1234.50')
+    })
+
+    it('drops invalid or empty values', () => {
+      expect(normalizeUSDC('')).toBe('')
+      expect(normalizeUSDC('not a number')).toBe('')
+    })
   })
 
-  it('truncates fraction to 2 decimal places', () => {
-    expect(sanitizeUSDCInput('12.345')).toBe('12.34')
-  })
+  describe('formatUSDC', () => {
+    it('formats display values with grouping and two decimals', () => {
+      expect(formatUSDC('1234.5')).toBe('1,234.50')
+    })
 
-  it('removes leading zeros from whole part', () => {
-    expect(sanitizeUSDCInput('00123')).toBe('123')
-    expect(sanitizeUSDCInput('00')).toBe('0')
+    it('returns invalid text unchanged for manual correction', () => {
+      expect(formatUSDC('abc')).toBe('abc')
+    })
   })
-
-  it('keeps leading zero before a decimal point', () => {
-    expect(sanitizeUSDCInput('0.5')).toBe('0.5')
-  })
-
-// Export for manual testing in browser console
-if (typeof window !== 'undefined') {
-  (window as Window & { testAmountInput?: unknown }).testAmountInput = {
-    sanitizeUSDCInput,
-    formatUSDC,
-    normalizeUSDC,
-    runTests,
-  }
-  console.log('Test functions available as window.testAmountInput')
-}
+})

--- a/src/context/WalletContext.test.tsx
+++ b/src/context/WalletContext.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { WalletProvider, useWallet } from './WalletContext'
+
+function WalletConsumer() {
+  const wallet = useWallet()
+
+  return (
+    <div>
+      <span data-testid="connected">{String(wallet.connected)}</span>
+      <span data-testid="address">{wallet.address ?? 'none'}</span>
+      <button type="button" onClick={wallet.connect}>
+        connect
+      </button>
+      <button type="button" onClick={wallet.disconnect}>
+        disconnect
+      </button>
+    </div>
+  )
+}
+
+describe('WalletProvider', () => {
+  it('connects and disconnects the placeholder wallet state', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <WalletProvider>
+        <WalletConsumer />
+      </WalletProvider>
+    )
+
+    expect(screen.getByTestId('connected')).toHaveTextContent('false')
+    expect(screen.getByTestId('address')).toHaveTextContent('none')
+
+    await user.click(screen.getByRole('button', { name: 'connect' }))
+
+    expect(screen.getByTestId('connected')).toHaveTextContent('true')
+    expect(screen.getByTestId('address').textContent).toMatch(/^G[A-Z0-9]{55}$/)
+
+    await user.click(screen.getByRole('button', { name: 'disconnect' }))
+
+    expect(screen.getByTestId('connected')).toHaveTextContent('false')
+    expect(screen.getByTestId('address')).toHaveTextContent('none')
+  })
+})

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -1,0 +1,39 @@
+import { createContext, useContext, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+
+const DEMO_WALLET_ADDRESS = 'GDEMO000000000000000000000000000000000000000000000000000'
+
+export interface WalletState {
+  connected: boolean
+  address: string | null
+  connect: () => void
+  disconnect: () => void
+}
+
+const WalletContext = createContext<WalletState | undefined>(undefined)
+
+export function WalletProvider({ children }: { children: ReactNode }) {
+  const [address, setAddress] = useState<string | null>(null)
+
+  const value = useMemo<WalletState>(
+    () => ({
+      connected: Boolean(address),
+      address,
+      connect: () => setAddress(DEMO_WALLET_ADDRESS),
+      disconnect: () => setAddress(null),
+    }),
+    [address]
+  )
+
+  return <WalletContext.Provider value={value}>{children}</WalletContext.Provider>
+}
+
+export function useWallet() {
+  const wallet = useContext(WalletContext)
+
+  if (!wallet) {
+    throw new Error('useWallet must be used within WalletProvider')
+  }
+
+  return wallet
+}

--- a/src/pages/Bond.test.tsx
+++ b/src/pages/Bond.test.tsx
@@ -4,6 +4,9 @@ import { vi, describe, it, expect, beforeEach } from 'vitest'
 import Bond from './Bond'
 
 const mockAddToast = vi.fn()
+const mockConnect = vi.fn()
+
+let mockConnected = true
 
 vi.mock('../components/ToastProvider', () => ({
   useToast: () => ({
@@ -11,9 +14,20 @@ vi.mock('../components/ToastProvider', () => ({
   }),
 }))
 
+vi.mock('../context/WalletContext', () => ({
+  useWallet: () => ({
+    connected: mockConnected,
+    address: mockConnected ? 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' : null,
+    connect: mockConnect,
+    disconnect: vi.fn(),
+  }),
+}))
+
 describe('Bond Page', () => {
   beforeEach(() => {
     mockAddToast.mockClear()
+    mockConnect.mockClear()
+    mockConnected = true
     // Mock scrollIntoView since it's not implemented in JSDOM
     window.HTMLElement.prototype.scrollIntoView = vi.fn()
   })
@@ -115,5 +129,33 @@ describe('Bond Page', () => {
 
     await user.click(actionBtn)
     expect(document.activeElement).toBe(input)
+  })
+
+  it('shows wallet gating and connects instead of creating a bond while disconnected', async () => {
+    const user = userEvent.setup()
+    mockConnected = false
+    render(<Bond />)
+
+    expect(screen.getByText(/Create bond and withdraw actions require a connected Stellar wallet/i)).toBeInTheDocument()
+
+    const input = screen.getByPlaceholderText('0.00')
+    await user.type(input, '500')
+
+    await user.click(screen.getByRole('button', { name: /^Connect wallet to continue$/i }))
+
+    expect(mockConnect).toHaveBeenCalledTimes(1)
+    expect(mockAddToast).not.toHaveBeenCalled()
+  })
+
+  it('restores the create bond action while connected', async () => {
+    const user = userEvent.setup()
+    render(<Bond />)
+
+    const input = screen.getByPlaceholderText('0.00')
+    await user.type(input, '250')
+    await user.click(screen.getByRole('button', { name: /^Create bond$/i }))
+
+    expect(mockConnect).not.toHaveBeenCalled()
+    expect(mockAddToast).toHaveBeenCalledWith('success', 'Bond of 250 USDC created successfully.')
   })
 })

--- a/src/pages/Bond.tsx
+++ b/src/pages/Bond.tsx
@@ -9,6 +9,7 @@ import ConfirmDialog, { type ConfirmDialogPenaltyBreakdown } from '../components
 import EmptyState from '../components/states/EmptyState'
 import { FormField } from '../components/forms/FormField'
 import AmountInput from '../components/AmountInput'
+import { useWallet } from '../context/WalletContext'
 
 type BondStatus = 'active' | 'locked' | 'grace-period'
 
@@ -52,6 +53,7 @@ function computeWithdrawBreakdown(bond: MockBond): ConfirmDialogPenaltyBreakdown
 
 export default function Bond() {
   const { addToast } = useToast()
+  const { connected, connect } = useWallet()
   const [withdrawTarget, setWithdrawTarget] = useState<MockBond | null>(null)
   const withdrawTriggerRef = useRef<HTMLElement | null>(null)
 
@@ -76,6 +78,11 @@ export default function Bond() {
    * otherwise sets an inline validation error.
    */
   const handleCreate = () => {
+    if (!connected) {
+      connect()
+      return
+    }
+
     const parsed = parseFloat(amount)
     if (isNaN(parsed) || parsed <= 0) {
       setError('Please enter a valid amount greater than 0.')
@@ -102,9 +109,14 @@ export default function Bond() {
   )
 
   const requestWithdraw = useCallback((bond: MockBond, event: React.MouseEvent<HTMLButtonElement>) => {
+    if (!connected) {
+      connect()
+      return
+    }
+
     withdrawTriggerRef.current = event.currentTarget
     setWithdrawTarget(bond)
-  }, [])
+  }, [connected, connect])
 
   const cancelWithdraw = useCallback(() => {
     setWithdrawTarget(null)
@@ -147,6 +159,16 @@ export default function Bond() {
         Bonds are locked for a minimum of 30 days. Early withdrawal incurs a slash penalty.
       </Banner>
 
+      {!connected && (
+        <Banner
+          severity="warning"
+          title="Connect wallet required"
+          action={{ label: 'Connect wallet', onClick: connect }}
+        >
+          Create bond and withdraw actions require a connected Stellar wallet.
+        </Banner>
+      )}
+
       {slashBannerBreakdown && slashExposureBond && (
         <Banner severity="warning" title="Slash exposure on early withdrawal">
           Withdrawing {formatUsdc(slashExposureBond.amountUsdc)} while{' '}
@@ -183,12 +205,12 @@ export default function Bond() {
           </FormField>
           <Button
             type="button"
-            onClick={handleCreate}
-            disabled={!amount || overBalance}
+            onClick={connected ? handleCreate : connect}
+            disabled={connected ? !amount || overBalance : false}
             fullWidth
             style={{ marginTop: 'var(--credence-space-4)' }}
           >
-            Create bond
+            {connected ? 'Create bond' : 'Connect wallet to continue'}
           </Button>
         </ActionCard>
 
@@ -232,10 +254,12 @@ export default function Bond() {
                   <Button
                     type="button"
                     variant={getPenaltyRate(bond.status) > 0 ? 'danger' : 'secondary'}
-                    onClick={(event) => requestWithdraw(bond, event)}
-                    aria-haspopup="dialog"
+                    onClick={
+                      connected ? (event) => requestWithdraw(bond, event) : () => connect()
+                    }
+                    aria-haspopup={connected ? 'dialog' : undefined}
                   >
-                    Withdraw
+                    {connected ? 'Withdraw' : 'Connect wallet to withdraw'}
                   </Button>
                 </li>
               ))}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -20,7 +20,6 @@ export default function Settings() {
     setAutoDismiss,
     saveSettings,
     cancelSettings,
-    hasUnsavedChanges,
   } = useSettings()
   const { addToast } = useToast()
 

--- a/src/pages/TrustScore.test.tsx
+++ b/src/pages/TrustScore.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import TrustScore from './TrustScore'
+
+const connectedAddress = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+const mockAddToast = vi.fn()
+const mockConnect = vi.fn()
+
+let mockConnected = true
+
+vi.mock('../components/ToastProvider', () => ({
+  useToast: () => ({
+    addToast: mockAddToast,
+  }),
+}))
+
+vi.mock('../context/WalletContext', () => ({
+  useWallet: () => ({
+    connected: mockConnected,
+    address: mockConnected ? connectedAddress : null,
+    connect: mockConnect,
+    disconnect: vi.fn(),
+  }),
+}))
+
+describe('TrustScore Page', () => {
+  beforeEach(() => {
+    mockAddToast.mockClear()
+    mockConnect.mockClear()
+    mockConnected = true
+  })
+
+  it('connects the wallet instead of looking up a score while disconnected', async () => {
+    const user = userEvent.setup()
+    mockConnected = false
+
+    render(<TrustScore />)
+
+    expect(screen.getByText(/Connect a wallet to look up your own trust score/i)).toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: /^Connect wallet to continue$/i }))
+
+    expect(mockConnect).toHaveBeenCalledTimes(1)
+    expect(mockAddToast).not.toHaveBeenCalled()
+  })
+
+  it('fills the connected wallet and looks up the score while connected', async () => {
+    const user = userEvent.setup()
+
+    render(<TrustScore />)
+
+    await user.click(screen.getByRole('button', { name: /^Use connected wallet$/i }))
+
+    const lookupButton = screen.getByRole('button', { name: /^Look up score$/i })
+    await waitFor(() => expect(lookupButton).toBeEnabled())
+    await user.click(lookupButton)
+
+    expect(screen.getByRole('textbox', { name: /Stellar Address/i })).toHaveValue(connectedAddress)
+    expect(mockConnect).not.toHaveBeenCalled()
+    expect(mockAddToast).toHaveBeenCalledWith('success', 'Trust score retrieved.')
+  })
+})

--- a/src/pages/TrustScore.tsx
+++ b/src/pages/TrustScore.tsx
@@ -7,14 +7,26 @@ import Button from '../components/Button'
 import AddressInput from '../components/AddressInput'
 import TierLadder from '../components/TierLadder'
 import { EmptyState } from '../components/states'
+import { useWallet } from '../context/WalletContext'
 
 export default function TrustScore() {
   const { addToast } = useToast()
+  const { connected, address: walletAddress, connect } = useWallet()
   const [address, setAddress] = useState('')
   const [isAddressValid, setIsAddressValid] = useState(false)
 
   const handleLookup = () => {
+    if (!connected) {
+      connect()
+      return
+    }
+
     addToast('success', 'Trust score retrieved.')
+  }
+
+  const useConnectedAddress = () => {
+    if (!walletAddress) return
+    setAddress(walletAddress)
   }
 
   const activity: Array<{ id: number; action: string; date: string; status: 'active' | 'slashed' }> =
@@ -33,6 +45,17 @@ export default function TrustScore() {
       <Banner severity="info">
         Scores update once per epoch. Recent bond changes may not be reflected immediately.
       </Banner>
+
+      {!connected && (
+        <Banner
+          severity="warning"
+          title="Connect wallet required"
+          action={{ label: 'Connect wallet', onClick: connect }}
+        >
+          Connect a wallet to look up your own trust score. You can still type another Stellar
+          address for review.
+        </Banner>
+      )}
 
       <div
         style={{
@@ -59,15 +82,26 @@ export default function TrustScore() {
             onChange={setAddress}
             onValidationChange={setIsAddressValid}
           />
+          {connected && walletAddress && (
+            <Button
+              type="button"
+              onClick={useConnectedAddress}
+              variant="secondary"
+              fullWidth
+              style={{ marginTop: '1rem' }}
+            >
+              Use connected wallet
+            </Button>
+          )}
           <Button
             type="button"
-            onClick={handleLookup}
+            onClick={connected ? handleLookup : connect}
             variant="primary"
             fullWidth
-            disabled={!isAddressValid}
+            disabled={connected ? !isAddressValid : false}
             style={{ marginTop: '1rem' }}
           >
-            Look up score
+            {connected ? 'Look up score' : 'Connect wallet to continue'}
           </Button>
         </div>
 


### PR DESCRIPTION
## Summary
- adds a minimal `WalletProvider` / `useWallet` surface so wallet-bound UI can consume connected state before the real wallet integration lands
- gates Bond create/withdraw actions behind connected state with a Banner + connect CTA instead of firing success toasts while disconnected
- gates Trust Score lookup behind connected state while keeping manual address entry available, plus a connected-wallet autofill affordance
- includes focused connected/disconnected tests for Bond, TrustScore, and WalletContext

Closes #145

## Verification
- `npm.cmd run test -- src/context/WalletContext.test.tsx src/pages/Bond.test.tsx src/pages/TrustScore.test.tsx src/components/AmountInput.test.ts` passed 31 tests
- `vitest.cmd run src/context/WalletContext.test.tsx src/pages/Bond.test.tsx src/pages/TrustScore.test.tsx --coverage.enabled true --coverage.include src/context/WalletContext.tsx --coverage.include src/pages/Bond.tsx --coverage.include src/pages/TrustScore.tsx --coverage.reporter text` passed; WalletContext 91.3% statements / 83.33% branch, TrustScore 79.83% statements / 80% branch
- `npm.cmd run lint` passed
- `npm.cmd run build` passed
- `git diff --check` passed

## Notes
- The new wallet context is intentionally a thin placeholder because the repository does not yet include a real `useWallet` / Freighter integration. It keeps the UI contract explicit and can be swapped under the same hook later.
- Baseline cleanup included removing duplicate imports in `src/App.tsx`, repairing the malformed legacy `src/components/AmountInput.test.ts`, and removing one unused `Settings.tsx` binding so lint/build can run cleanly.
- Full `npm.cmd run test` still has the existing `SettingsContext.test.tsx` persistence expectation failures: those tests expect setter calls to write localStorage immediately, while the current provider behavior persists only via `saveSettings()`.