### PR TITLE
test(badge): cover variant normalization, fallback, and label override

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3080,6 +3080,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",

--- a/src/components/Badge.test.tsx
+++ b/src/components/Badge.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen } from '@testing-library/react'
+import Badge from './Badge'
+
+// Mock the CSS import so Vitest doesn't choke on it
+vi.mock('./Badge.css', () => ({}))
+
+const KNOWN_VARIANTS = [
+  { variant: 'bronze', label: 'Bronze' },
+  { variant: 'silver', label: 'Silver' },
+  { variant: 'gold', label: 'Gold' },
+  { variant: 'platinum', label: 'Platinum' },
+  { variant: 'active', label: 'Active' },
+  { variant: 'locked', label: 'Locked' },
+  { variant: 'slashed', label: 'Slashed' },
+  { variant: 'grace-period', label: 'Grace Period' },
+  { variant: 'unknown', label: 'Unknown' },
+] as const
+
+describe('Badge', () => {
+  describe('known variants', () => {
+    it.each(KNOWN_VARIANTS)(
+      '$variant renders badge--$variant class and default label "$label"',
+      ({ variant, label }) => {
+        render(<Badge variant={variant} />)
+        const el = screen.getByText(label)
+        expect(el).toHaveClass('badge', `badge--${variant}`)
+      },
+    )
+  })
+
+  describe('case-insensitive normalization', () => {
+    it('uppercased Gold → badge--gold class and label "Gold"', () => {
+      render(<Badge variant="GOLD" />)
+      const el = screen.getByText('Gold')
+      expect(el).toHaveClass('badge--gold')
+    })
+
+    it('mixed-case Grace-Period → badge--grace-period', () => {
+      render(<Badge variant="Grace-Period" />)
+      const el = screen.getByText('Grace Period')
+      expect(el).toHaveClass('badge--grace-period')
+    })
+  })
+
+  describe('unknown fallback', () => {
+    it('unrecognized string → badge--unknown class and label "Unknown"', () => {
+      render(<Badge variant="foobar" />)
+      const el = screen.getByText('Unknown')
+      expect(el).toHaveClass('badge--unknown')
+      expect(el).not.toHaveClass('badge--foobar')
+    })
+
+    it('empty string → badge--unknown', () => {
+      render(<Badge variant="" />)
+      const el = screen.getByText('Unknown')
+      expect(el).toHaveClass('badge--unknown')
+    })
+
+    it('whitespace-only string → badge--unknown', () => {
+      render(<Badge variant="   " />)
+      const el = screen.getByText('Unknown')
+      expect(el).toHaveClass('badge--unknown')
+    })
+  })
+
+  describe('explicit label override', () => {
+    it('overrides default label for a known variant', () => {
+      render(<Badge variant="gold" label="Custom Gold" />)
+      expect(screen.getByText('Custom Gold')).toHaveClass('badge--gold')
+      expect(screen.queryByText('Gold')).toBeNull()
+    })
+
+    it('overrides label even for an unknown variant', () => {
+      render(<Badge variant="foobar" label="My Label" />)
+      expect(screen.getByText('My Label')).toHaveClass('badge--unknown')
+    })
+  })
+
+  describe('className passthrough', () => {
+    it('appends extra className to the badge element', () => {
+      render(<Badge variant="active" className="extra-class" />)
+      expect(screen.getByText('Active')).toHaveClass('badge', 'badge--active', 'extra-class')
+    })
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -58,9 +58,12 @@ export default defineConfig({
     },
     coverage: {
       provider: 'v8',
-      include: ['src/components/AddressInput.tsx'],
+      include: ['src/components/AddressInput.tsx', 'src/components/Badge.tsx'],
       reporter: ['text', 'lcov'],
-      thresholds: { lines: 90, branches: 90 },
+      thresholds: {
+        'src/components/AddressInput.tsx': { lines: 90, branches: 90 },
+        'src/components/Badge.tsx': { branches: 95 },
+      },
     },
   },
 })


### PR DESCRIPTION
closes #176 

# test(badge): cover variant normalization, fallback, and label override

## Summary

Adds a test suite for `src/components/Badge.tsx` — the single source of truth for
tier and status labels across the Bond, TrustScore, and TierLadder views.

Badge accepts a `variant: BadgeVariant | string` prop, meaning call-sites that cast
`bond.status as BadgeVariant` can pass an unexpected runtime value. The `'unknown'`
fallback is the safety net that prevents a broken CSS class or empty label from
reaching the UI. This PR verifies that safety net and all surrounding logic.

---

## Changes

- **`src/components/Badge.test.tsx`** — new file, 17 tests
- **`vite.config.ts`** — added `Badge.tsx` to the coverage `include` list with a
  `≥ 95% branches` threshold

No production code was changed.

---

## Test coverage

| Group | Cases |
|---|---|
| Known variants | `bronze`, `silver`, `gold`, `platinum`, `active`, `locked`, `slashed`, `grace-period`, `unknown` each render the correct `badge--<variant>` class and default label |
| Case normalization | `'GOLD'` → `badge--gold` / "Gold"; `'Grace-Period'` → `badge--grace-period` / "Grace Period" |
| Unknown fallback | `'foobar'`, `''` (empty string), `'   '` (whitespace-only) all resolve to `badge--unknown` and label "Unknown" |
| Label override | Explicit `label` prop overrides the default for both known and unknown variants |
| className passthrough | Extra class is appended alongside `badge` and `badge--<variant>` |

All 17 tests pass. Badge variants were cross-referenced against
`docs/badge-contrast-audit.md` to ensure full variant coverage.

---

## Acceptance criteria

| Requirement | Status |
|---|---|
| Coverage of `Badge.tsx` ≥ 95% branches | ✅ |
| Unknown fallback explicitly asserted | ✅ |
| `npm run test` green (Badge suite) | ✅ 17/17 |
| `eslint src/components/Badge.test.tsx` clean | ✅ 0 errors |
| No production code modified | ✅ |

---

## How to verify

```bash
npx vitest run src/components/Badge.test.tsx
```
