### PR TITLE
Refactor/activity timeline props

### DIFF
--- a/docs/ACTIVITY_SURFACE_CONCEPT.md
+++ b/docs/ACTIVITY_SURFACE_CONCEPT.md
@@ -116,4 +116,34 @@ Presentational reference component:
 - [src/components/ActivityTimeline.tsx](src/components/ActivityTimeline.tsx)
 - [src/components/ActivityTimeline.css](src/components/ActivityTimeline.css)
 
-This component is static by design and intended as a concept surface for future data binding.
+### Props
+
+| Prop    | Type             | Default        | Description                                       |
+|---------|------------------|----------------|---------------------------------------------------|
+| `items` | `ActivityItem[]` | Sample 3 items | Timeline events to render. Pass `[]` for no data. |
+
+### Usage
+
+```tsx
+import ActivityTimeline, { ActivityItem } from '../components/ActivityTimeline'
+
+// Concept demo — no props needed (shows 3 sample events)
+<ActivityTimeline />
+
+// Data-driven (empty state when no events)
+<ActivityTimeline items={[]} />
+
+// Data-driven with real events
+<ActivityTimeline items={myEvents} />
+```
+
+### Empty state
+
+When `items` is an empty array the timeline rail is hidden and `EmptyState` (with
+`illustration="activity"`) is rendered in its place, consistent with the pattern used
+across the app.
+
+### Exported types
+
+`ActivityItem` and `ActivityTone` are exported so consumers can type their own data without
+duplicating the interface.

--- a/docs/TRUST_GAUGE_QUICK_REFERENCE.md
+++ b/docs/TRUST_GAUGE_QUICK_REFERENCE.md
@@ -107,6 +107,31 @@ export default function TrustScore() {
 
 ---
 
+## Test Coverage
+
+Tests live in **[src/components/TrustGauge.test.tsx](../src/components/TrustGauge.test.tsx)** (Vitest + RTL).
+
+| Area | What is covered |
+| ---- | --------------- |
+| `pointsToNextTier` | Mid-tier values, exact thresholds (250/500/750), platinum always returns 0, scores above the next threshold clamp to 0, negative scores handled defensively, tier mismatch clamping |
+| `getProgressPercentage` | Score 0 → 0%, tier boundaries (25/50/75/100%), cap at 100% for scores ≥ 1000, documents negative-score behavior (no lower clamp) |
+| ARIA progressbar | `aria-valuenow`, `aria-valuemin=0`, `aria-valuemax=1000`, `aria-label` per tier |
+| Maxed caption | Appears only when `tier=platinum` and `score >= 1000`; absent at score=750 platinum |
+| Tier badge | `data-tier` attribute matches each tier; label text from `TIER_CONFIG` |
+| Score display | Numeric value and `/ 1000` label rendered |
+| Tier legend | All four range strings (Bronze: 0–250 … Platinum: 750–1000) |
+| Props | Default `id`, custom `id`, merged `className` |
+| Heading | Visible `<h3>` with "Trust Score Gauge" |
+
+Coverage target: ≥ 90% lines and branches on `src/components/TrustGauge.tsx` (enforced in `vite.config.ts` thresholds).
+
+```bash
+npm run test              # run all tests (TrustGauge: 43 tests)
+npm run test:coverage     # print coverage report with per-file thresholds
+```
+
+---
+
 ## Build & Lint Status
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -3080,6 +3080,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",

--- a/src/components/ActivityTimeline.test.tsx
+++ b/src/components/ActivityTimeline.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ActivityTimeline, { ActivityItem } from './ActivityTimeline'
+
+const makeItem = (overrides: Partial<ActivityItem> = {}): ActivityItem => ({
+  id: 'test-1',
+  timestamp: 'Jun 20, 10:00 UTC',
+  title: 'Test event',
+  description: 'A test event description.',
+  actor: 'Test Actor',
+  statusLabel: 'Done',
+  tone: 'info',
+  meta: 'meta-value',
+  ...overrides,
+})
+
+describe('ActivityTimeline', () => {
+  describe('default (no props)', () => {
+    it('renders the section with the correct aria-label', () => {
+      render(<ActivityTimeline />)
+      expect(screen.getByRole('region', { name: /activity and attestations/i })).toBeInTheDocument()
+    })
+
+    it('renders the eyebrow and title', () => {
+      render(<ActivityTimeline />)
+      expect(screen.getByText('Activity Surface Concept')).toBeInTheDocument()
+      expect(screen.getByRole('heading', { name: 'Attestation timeline' })).toBeInTheDocument()
+    })
+
+    it('shows "3 recent events" summary for the sample data', () => {
+      render(<ActivityTimeline />)
+      expect(screen.getByText('3 recent events')).toBeInTheDocument()
+    })
+
+    it('renders the sample timeline list', () => {
+      render(<ActivityTimeline />)
+      expect(screen.getByRole('list', { name: /recent timeline events/i })).toBeInTheDocument()
+      expect(screen.getAllByRole('listitem')).toHaveLength(3)
+    })
+
+    it('renders all three sample event titles', () => {
+      render(<ActivityTimeline />)
+      expect(screen.getByText('Attestation submitted')).toBeInTheDocument()
+      expect(screen.getByText('Proof mismatch detected')).toBeInTheDocument()
+      expect(screen.getByText('Credential refreshed')).toBeInTheDocument()
+    })
+  })
+
+  describe('empty items', () => {
+    it('renders the EmptyState heading when items is an empty array', () => {
+      render(<ActivityTimeline items={[]} />)
+      expect(screen.getByRole('heading', { name: /no activity yet/i })).toBeInTheDocument()
+    })
+
+    it('renders the EmptyState description', () => {
+      render(<ActivityTimeline items={[]} />)
+      expect(
+        screen.getByText(/attestations and events will appear here/i)
+      ).toBeInTheDocument()
+    })
+
+    it('does not render the timeline list', () => {
+      render(<ActivityTimeline items={[]} />)
+      expect(screen.queryByRole('list', { name: /recent timeline events/i })).toBeNull()
+    })
+
+    it('does not render the summary count', () => {
+      render(<ActivityTimeline items={[]} />)
+      expect(screen.queryByText(/recent event/i)).toBeNull()
+    })
+
+    it('still renders the section heading', () => {
+      render(<ActivityTimeline items={[]} />)
+      expect(screen.getByRole('heading', { name: 'Attestation timeline' })).toBeInTheDocument()
+    })
+  })
+
+  describe('single item', () => {
+    it('shows "1 recent event" (singular)', () => {
+      render(<ActivityTimeline items={[makeItem()]} />)
+      expect(screen.getByText('1 recent event')).toBeInTheDocument()
+    })
+
+    it('does not show plural "events" label', () => {
+      render(<ActivityTimeline items={[makeItem()]} />)
+      expect(screen.queryByText(/\d+ recent events/)).toBeNull()
+    })
+
+    it('renders exactly one list item', () => {
+      render(<ActivityTimeline items={[makeItem()]} />)
+      expect(screen.getAllByRole('listitem')).toHaveLength(1)
+    })
+  })
+
+  describe('multiple items', () => {
+    const items: ActivityItem[] = [
+      makeItem({ id: 'a', title: 'Alpha' }),
+      makeItem({ id: 'b', title: 'Beta' }),
+      makeItem({ id: 'c', title: 'Gamma' }),
+      makeItem({ id: 'd', title: 'Delta' }),
+      makeItem({ id: 'e', title: 'Epsilon' }),
+    ]
+
+    it('shows correct plural count', () => {
+      render(<ActivityTimeline items={items} />)
+      expect(screen.getByText('5 recent events')).toBeInTheDocument()
+    })
+
+    it('renders the correct number of list items', () => {
+      render(<ActivityTimeline items={items} />)
+      expect(screen.getAllByRole('listitem')).toHaveLength(5)
+    })
+  })
+
+  describe('tone classes', () => {
+    it.each(['success', 'warning', 'info'] as const)(
+      'applies tone class "%s" to node and status pill',
+      (tone) => {
+        const { container } = render(
+          <ActivityTimeline items={[makeItem({ tone, id: `tone-${tone}` })]} />
+        )
+        expect(container.querySelector(`.activity-row__node--${tone}`)).not.toBeNull()
+        expect(container.querySelector(`.activity-row__status--${tone}`)).not.toBeNull()
+      }
+    )
+  })
+
+  describe('a11y semantics', () => {
+    it('renders timestamps as <time> elements', () => {
+      const { container } = render(<ActivityTimeline items={[makeItem()]} />)
+      expect(container.querySelector('time')).not.toBeNull()
+      expect(container.querySelector('time')?.textContent).toBe('Jun 20, 10:00 UTC')
+    })
+
+    it('renders the rail as aria-hidden', () => {
+      const { container } = render(<ActivityTimeline items={[makeItem()]} />)
+      expect(container.querySelector('.activity-row__rail')).toHaveAttribute('aria-hidden', 'true')
+    })
+
+    it('renders actor prefixed with "By"', () => {
+      render(<ActivityTimeline items={[makeItem({ actor: 'Node 99' })]} />)
+      expect(screen.getByText('By Node 99')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/ActivityTimeline.tsx
+++ b/src/components/ActivityTimeline.tsx
@@ -1,8 +1,9 @@
 import './ActivityTimeline.css'
+import EmptyState from './states/EmptyState'
 
-type ActivityTone = 'success' | 'warning' | 'info'
+export type ActivityTone = 'success' | 'warning' | 'info'
 
-interface ActivityItem {
+export interface ActivityItem {
   id: string
   timestamp: string
   title: string
@@ -13,7 +14,7 @@ interface ActivityItem {
   meta: string
 }
 
-const ACTIVITY_ITEMS: ActivityItem[] = [
+const SAMPLE_ITEMS: ActivityItem[] = [
   {
     id: 'evt-001',
     timestamp: 'Apr 28, 14:22 UTC',
@@ -46,7 +47,18 @@ const ACTIVITY_ITEMS: ActivityItem[] = [
   },
 ]
 
-export default function ActivityTimeline() {
+interface ActivityTimelineProps {
+  /**
+   * Timeline events to render. Defaults to the concept sample data when omitted,
+   * preserving backwards-compatible behaviour for the demo surface.
+   */
+  items?: ActivityItem[]
+}
+
+export default function ActivityTimeline({ items = SAMPLE_ITEMS }: ActivityTimelineProps) {
+  const count = items.length
+  const summary = count === 1 ? '1 recent event' : `${count} recent events`
+
   return (
     <section className="activity-surface" aria-label="Activity and attestations">
       <header className="activity-surface__header">
@@ -54,34 +66,42 @@ export default function ActivityTimeline() {
           <p className="activity-surface__eyebrow">Activity Surface Concept</p>
           <h2 className="activity-surface__title">Attestation timeline</h2>
         </div>
-        <p className="activity-surface__summary">3 recent events</p>
+        {count > 0 && <p className="activity-surface__summary">{summary}</p>}
       </header>
 
-      <ul className="activity-timeline" aria-label="Recent timeline events">
-        {ACTIVITY_ITEMS.map((item) => (
-          <li className="activity-row" key={item.id}>
-            <div className="activity-row__rail" aria-hidden="true">
-              <span className={`activity-row__node activity-row__node--${item.tone}`} />
-              <span className="activity-row__line" />
-            </div>
-
-            <time className="activity-row__time">{item.timestamp}</time>
-
-            <div className="activity-row__content">
-              <div className="activity-row__title-wrap">
-                <p className="activity-row__title">{item.title}</p>
-                <span className={`activity-row__status activity-row__status--${item.tone}`}>
-                  {item.statusLabel}
-                </span>
+      {count === 0 ? (
+        <EmptyState
+          illustration="activity"
+          title="No activity yet"
+          description="Attestations and events will appear here once activity begins."
+        />
+      ) : (
+        <ul className="activity-timeline" aria-label="Recent timeline events">
+          {items.map((item) => (
+            <li className="activity-row" key={item.id}>
+              <div className="activity-row__rail" aria-hidden="true">
+                <span className={`activity-row__node activity-row__node--${item.tone}`} />
+                <span className="activity-row__line" />
               </div>
-              <p className="activity-row__description">{item.description}</p>
-              <p className="activity-row__actor">By {item.actor}</p>
-            </div>
 
-            <p className="activity-row__meta">{item.meta}</p>
-          </li>
-        ))}
-      </ul>
+              <time className="activity-row__time">{item.timestamp}</time>
+
+              <div className="activity-row__content">
+                <div className="activity-row__title-wrap">
+                  <p className="activity-row__title">{item.title}</p>
+                  <span className={`activity-row__status activity-row__status--${item.tone}`}>
+                    {item.statusLabel}
+                  </span>
+                </div>
+                <p className="activity-row__description">{item.description}</p>
+                <p className="activity-row__actor">By {item.actor}</p>
+              </div>
+
+              <p className="activity-row__meta">{item.meta}</p>
+            </li>
+          ))}
+        </ul>
+      )}
     </section>
   )
 }

--- a/src/components/TrustGauge.test.tsx
+++ b/src/components/TrustGauge.test.tsx
@@ -44,6 +44,16 @@ describe('pointsToNextTier', () => {
   it('never returns negative (score above tier threshold)', () => {
     expect(pointsToNextTier(300, 'bronze')).toBe(0)
   })
+
+  it('handles negative score defensively (treats as below-zero offset)', () => {
+    // score is below zero: points = TIER_CONFIG.silver.min - (-50) = 300
+    expect(pointsToNextTier(-50, 'bronze')).toBe(300)
+  })
+
+  it('handles tier mismatch where score already exceeds next-tier threshold', () => {
+    // score=600 with tier='bronze': silver.min(250) - 600 < 0, clamped to 0
+    expect(pointsToNextTier(600, 'bronze')).toBe(0)
+  })
 })
 
 // --- getProgressPercentage ---
@@ -79,6 +89,11 @@ describe('getProgressPercentage', () => {
 
   it('returns 49.9 for score=499', () => {
     expect(getProgressPercentage(499)).toBeCloseTo(49.9)
+  })
+
+  it('returns a negative value for negative score (no lower clamp)', () => {
+    // getProgressPercentage only clamps at 100; callers must supply score >= 0
+    expect(getProgressPercentage(-100)).toBeCloseTo(-10)
   })
 })
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,11 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./src/test-setup.ts'],
     exclude: ['**/node_modules/**', '**/AmountInput.test.ts'],
+    server: {
+      deps: {
+        inline: ['@exodus/bytes'],
+      },
+    },
     coverage: {
       provider: 'v8',
       include: [
@@ -45,22 +50,6 @@ export default defineConfig({
         'src/components/ToastProvider.tsx': { lines: 80, branches: 80 },
         'src/components/TrustGauge.tsx': { lines: 90, branches: 90 },
       },
-    },
-  },
-  test: {
-    environment: 'jsdom',
-    globals: true,
-    setupFiles: ['./src/test-setup.ts'],
-    server: {
-      deps: {
-        inline: ['@exodus/bytes'],
-      },
-    },
-    coverage: {
-      provider: 'v8',
-      include: ['src/components/AddressInput.tsx'],
-      reporter: ['text', 'lcov'],
-      thresholds: { lines: 90, branches: 90 },
     },
   },
 })


### PR DESCRIPTION
closes #189 

items prop — ActivityTimeline now accepts items?: ActivityItem[]. Omitting the prop renders the existing 3-item concept sample, so all current usages remain unchanged.
Exported types — ActivityItem and ActivityTone are now exported so consumers (Trust Score page, future Attestations route) can type their own event data without duplicating the interface.
Dynamic count — summary label is derived from items.length with correct pluralisation ("1 recent event" / "N recent events").
Empty state — when items is [], the timeline list is replaced by EmptyState illustration="activity", consistent with the pattern already used on the Trust Score page.
Docs updated — docs/ACTIVITY_SURFACE_CONCEPT.md now documents the prop API, exports, and usage examples.
Test plan
ActivityTimeline with no props still renders the 3 concept items and "3 recent events"
ActivityTimeline items={[]} renders the EmptyState heading, no list, no count
ActivityTimeline items={[oneItem]} renders "1 recent event" (singular)
ActivityTimeline items={fiveItems} renders "5 recent events"
All three tone classes (success / warning / info) apply to node and status pill
time elements and aria-hidden rail preserved
21 tests, all passing (npx vitest run src/components/ActivityTimeline.test.tsx)