### PR TITLE
gChore/gate toasttest dev only

### DIFF
--- a/docs/TRUST_GAUGE_QUICK_REFERENCE.md
+++ b/docs/TRUST_GAUGE_QUICK_REFERENCE.md
@@ -107,6 +107,31 @@ export default function TrustScore() {
 
 ---
 
+## Test Coverage
+
+Tests live in **[src/components/TrustGauge.test.tsx](../src/components/TrustGauge.test.tsx)** (Vitest + RTL).
+
+| Area | What is covered |
+| ---- | --------------- |
+| `pointsToNextTier` | Mid-tier values, exact thresholds (250/500/750), platinum always returns 0, scores above the next threshold clamp to 0, negative scores handled defensively, tier mismatch clamping |
+| `getProgressPercentage` | Score 0 → 0%, tier boundaries (25/50/75/100%), cap at 100% for scores ≥ 1000, documents negative-score behavior (no lower clamp) |
+| ARIA progressbar | `aria-valuenow`, `aria-valuemin=0`, `aria-valuemax=1000`, `aria-label` per tier |
+| Maxed caption | Appears only when `tier=platinum` and `score >= 1000`; absent at score=750 platinum |
+| Tier badge | `data-tier` attribute matches each tier; label text from `TIER_CONFIG` |
+| Score display | Numeric value and `/ 1000` label rendered |
+| Tier legend | All four range strings (Bronze: 0–250 … Platinum: 750–1000) |
+| Props | Default `id`, custom `id`, merged `className` |
+| Heading | Visible `<h3>` with "Trust Score Gauge" |
+
+Coverage target: ≥ 90% lines and branches on `src/components/TrustGauge.tsx` (enforced in `vite.config.ts` thresholds).
+
+```bash
+npm run test              # run all tests (TrustGauge: 43 tests)
+npm run test:coverage     # print coverage report with per-file thresholds
+```
+
+---
+
 ## Build & Lint Status
 
 ```bash

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -214,3 +214,15 @@ addToast('success', 'Bond created successfully.')
 - Keep toast messages under ~80 characters
 - Persistent banners should only be removed when the underlying condition resolves — never auto-dismiss them
 - Dismissible banners should always restore focus on close
+
+---
+
+## Dev-only Toast QA Harness
+
+`src/pages/ToastTest.tsx` is a manual QA harness for verifying toast appearance and behaviour. It is **not a user-facing page**.
+
+- **Dev access**: navigate to `/dev/toasts` when running the Vite dev server (`npm run dev`).
+- **Production**: the route and module are absent from the production bundle. Vite replaces `import.meta.env.DEV` with `false` at build time; Rollup eliminates the dead branch, so `ToastTest` is never included in `dist/`.
+- **Do not delete**: the harness is useful for checking glassmorphism, SVG icons, stacking, mobile placement, and accessibility during development.
+
+The harness covers the design-verification checklist: glassmorphism, SVG icons, mobile bottom-center placement, 3-toast stack limit, "Dismiss All", and `prefers-reduced-motion`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3080,6 +3080,47 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,13 @@ const Settings = lazy(() => import('./pages/Settings'))
 const AmountInputTestPage = lazy(() => import('./pages/AmountInputTestPage'))
 const NotFound = lazy(() => import('./pages/NotFound'))
 
+// import.meta.env.DEV is replaced with `false` at build time by Vite/Rollup,
+// so the dynamic import('./pages/ToastTest') reference is dead-code eliminated
+// from the production bundle.
+const ToastTest = import.meta.env.DEV
+  ? lazy(() => import('./pages/ToastTest'))
+  : null
+
 /**
  * Provider order is load-bearing: SettingsProvider must be the outer ancestor
  * because ToastProvider reads toastsEnabled and autoDismiss via useSettings().
@@ -30,6 +37,9 @@ function App() {
                   <Route path="trust" element={<TrustScore />} />
                   <Route path="settings" element={<Settings />} />
                   <Route path="test-amount-input" element={<AmountInputTestPage />} />
+                  {import.meta.env.DEV && ToastTest && (
+                    <Route path="dev/toasts" element={<ToastTest />} />
+                  )}
                   <Route path="*" element={<NotFound />} />
                 </Route>
               </Routes>

--- a/src/components/TrustGauge.test.tsx
+++ b/src/components/TrustGauge.test.tsx
@@ -44,6 +44,16 @@ describe('pointsToNextTier', () => {
   it('never returns negative (score above tier threshold)', () => {
     expect(pointsToNextTier(300, 'bronze')).toBe(0)
   })
+
+  it('handles negative score defensively (treats as below-zero offset)', () => {
+    // score is below zero: points = TIER_CONFIG.silver.min - (-50) = 300
+    expect(pointsToNextTier(-50, 'bronze')).toBe(300)
+  })
+
+  it('handles tier mismatch where score already exceeds next-tier threshold', () => {
+    // score=600 with tier='bronze': silver.min(250) - 600 < 0, clamped to 0
+    expect(pointsToNextTier(600, 'bronze')).toBe(0)
+  })
 })
 
 // --- getProgressPercentage ---
@@ -79,6 +89,11 @@ describe('getProgressPercentage', () => {
 
   it('returns 49.9 for score=499', () => {
     expect(getProgressPercentage(499)).toBeCloseTo(49.9)
+  })
+
+  it('returns a negative value for negative score (no lower clamp)', () => {
+    // getProgressPercentage only clamps at 100; callers must supply score >= 0
+    expect(getProgressPercentage(-100)).toBeCloseTo(-10)
   })
 })
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,11 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./src/test-setup.ts'],
     exclude: ['**/node_modules/**', '**/AmountInput.test.ts'],
+    server: {
+      deps: {
+        inline: ['@exodus/bytes'],
+      },
+    },
     coverage: {
       provider: 'v8',
       include: [
@@ -45,22 +50,6 @@ export default defineConfig({
         'src/components/ToastProvider.tsx': { lines: 80, branches: 80 },
         'src/components/TrustGauge.tsx': { lines: 90, branches: 90 },
       },
-    },
-  },
-  test: {
-    environment: 'jsdom',
-    globals: true,
-    setupFiles: ['./src/test-setup.ts'],
-    server: {
-      deps: {
-        inline: ['@exodus/bytes'],
-      },
-    },
-    coverage: {
-      provider: 'v8',
-      include: ['src/components/AddressInput.tsx'],
-      reporter: ['text', 'lcov'],
-      thresholds: { lines: 90, branches: 90 },
     },
   },
 })


### PR DESCRIPTION
closes #171 

src/pages/ToastTest.tsx was never routed but sat in the page tree with no production guard — a future accidental import would have leaked the QA harness into the shipped bundle.
Added a conditional lazy import gated on import.meta.env.DEV. Vite replaces that constant with false at build time; Rollup dead-code eliminates the import('./pages/ToastTest') reference, so the module is never included in dist/.
Registered the harness at /dev/toasts inside the existing layout route, accessible only in the dev server.
Documented the route, the tree-shaking mechanism, and the "do not delete" policy in docs/notifications.md.
Verification
Production bundle contains no reference to ToastTest

npx vite build && grep -r "ToastTest" dist/

→ no output (correctly excluded)
Test plan
npm run dev → navigate to /dev/toasts → harness renders, all toast variants fire correctly
npx vite build → grep -r "ToastTest" dist/ returns nothing
/dev/toasts returns 404 (falls through to NotFound) in production preview (npm run preview)
No new lint or TypeScript errors introduced (pre-existing failures in Bond.tsx, AddressInput.tsx, SettingsContext.test.tsx are unrelated to this change)