### PR TITLE
Feat/app error boundary

### DIFF
--- a/docs/UI_STATES_GUIDE.md
+++ b/docs/UI_STATES_GUIDE.md
@@ -433,6 +433,63 @@ Before shipping, validate:
 
 ---
 
+---
+
+## Error Boundary Strategy
+
+### Architecture
+
+Two boundaries protect the app from white-screen crashes:
+
+| Layer | Component | Location | Catches |
+|---|---|---|---|
+| Root (outermost) | `ErrorBoundary` | `main.tsx` wrapping `<App />` | Provider bootstrap errors |
+| Route tree | `ErrorBoundary` | `App.tsx` wrapping `<Suspense>` | Lazy-chunk failures, route render errors |
+| Router-level | `RouteErrorPage` | `errorElement` on root `<Route>` | Loader errors (data-router) |
+
+### Class ErrorBoundary (`src/components/ErrorBoundary.tsx`)
+
+```tsx
+import ErrorBoundary from './components/ErrorBoundary'
+
+// Default fallback (ErrorState + retry + home link)
+<ErrorBoundary>
+  <SomeSubtree />
+</ErrorBoundary>
+
+// Custom fallback via render prop
+<ErrorBoundary fallback={(error, reset) => (
+  <div>
+    <p>{error.message}</p>
+    <button onClick={reset}>Retry</button>
+  </div>
+)}>
+  <SomeSubtree />
+</ErrorBoundary>
+```
+
+**Retry behaviour:** clicking "Try again" calls `setState({ hasError: false, error: null })`.
+React re-renders the children without a hard reload. If they throw again the boundary
+catches once more.
+
+**Telemetry hook:** `componentDidCatch` currently logs to `console.error`. Replace the
+`console.error` call with your error monitoring SDK (Sentry, Datadog, etc.) before shipping.
+
+### RouteErrorPage (`src/pages/RouteErrorPage.tsx`)
+
+Registered as `errorElement` on the root route. In the current `BrowserRouter` setup this
+serves as forward-compatible scaffolding; it becomes fully active if the app is migrated to
+`createBrowserRouter`. Handles 404 (route miss) and generic router errors with the same
+`ErrorState` visual.
+
+### Accessibility
+
+- The fallback renders an `<h3>` heading from `ErrorState` — screen readers announce the error.
+- A `<a href="/">Go to home page</a>` link ensures keyboard-only users have a navigation escape hatch even if JavaScript is broken.
+- The retry `<button>` is `focus-visible` styled via the shared class.
+
+---
+
 ## Future Enhancements
 
 - Custom illustrations for each empty state

--- a/docs/uiux/inline-style-migration.md
+++ b/docs/uiux/inline-style-migration.md
@@ -18,6 +18,24 @@ This change migrates `style={{...}}` blocks in Home, TrustScore, and Layout to C
 | `--container-max` | `--credence-container-max` |
 | `--slate-900` | `--credence-color-slate-900` (light), `--credence-color-slate-50` (dark override) |
 
+## TrustScore.tsx migration (refactor/trustscore-token-css)
+
+All inline `style={{}}` blocks removed from `src/pages/TrustScore.tsx`. Every value
+now resolves through a `--credence-*` token in `TrustScore.css`.
+
+| Inline style removed | CSS class applied | Token(s) used |
+|---|---|---|
+| Grid `display/gridTemplateColumns/gap/marginTop` | `.trustScore__grid` | `--credence-space-8` |
+| Card `padding/border/borderRadius/background/color` | `.trustScore__card` | `--credence-space-6`, `--credence-border-default`, `--credence-radius-xl`, `--credence-surface-card`, `--credence-text-primary` |
+| `h2` `fontSize/marginBottom` | `.trustScore__cardTitle` | `--credence-font-size-xl`, `--credence-space-4` |
+| Button `marginTop: '1rem'` | `.trustScore__buttonRow` | `--credence-space-4` |
+| `ul` `listStyle/padding` | `.trustScore__activityList` | — |
+| `li` `display/justifyContent/padding/borderBottom` | `.trustScore__activityRow` / `--last` | `--credence-space-3`, `--credence-border-default` |
+| Action `div` `fontWeight: 500` | `.trustScore__activityAction` | `--credence-font-weight-semibold` |
+| Date `div` `fontSize/color` | `.trustScore__activityDate` | `--credence-font-size-xs`, `--credence-text-secondary` |
+
+Legacy aliases (`--bg-card`, `--border-default`, `--text-primary`, `--text-secondary`) replaced with canonical `--credence-*` equivalents per the mapping table above.
+
 ## Screenshot
 
 - Route: `/trust`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import { SettingsProvider } from './context/SettingsContext'
 import { WalletProvider } from './context/WalletContext'
 import ToastProvider from './components/ToastProvider'
 import Layout from './components/Layout'
+import ErrorBoundary from './components/ErrorBoundary'
+import RouteErrorPage from './pages/RouteErrorPage'
 
 const Home = lazy(() => import('./pages/Home'))
 const Dashboard = lazy(() => import('./pages/Dashboard'))
@@ -30,22 +32,24 @@ function App() {
       <SettingsProvider>
         <WalletProvider>
           <ToastProvider>
-            <Suspense fallback={<div>Loading...</div>}>
-              <Routes>
-                <Route path="/" element={<Layout />}>
-                  <Route index element={<Home />} />
-                  <Route path="dashboard" element={<Dashboard />} />
-                  <Route path="bond" element={<Bond />} />
-                  <Route path="trust" element={<TrustScore />} />
-                  <Route path="settings" element={<Settings />} />
-                  <Route path="test-amount-input" element={<AmountInputTestPage />} />
-                  {import.meta.env.DEV && ToastTest && (
-                    <Route path="dev/toasts" element={<ToastTest />} />
-                  )}
-                  <Route path="*" element={<NotFound />} />
-                </Route>
-              </Routes>
-            </Suspense>
+            <ErrorBoundary>
+              <Suspense fallback={<div>Loading...</div>}>
+                <Routes>
+                  <Route path="/" element={<Layout />} errorElement={<RouteErrorPage />}>
+                    <Route index element={<Home />} />
+                    <Route path="dashboard" element={<Dashboard />} />
+                    <Route path="bond" element={<Bond />} />
+                    <Route path="trust" element={<TrustScore />} />
+                    <Route path="settings" element={<Settings />} />
+                    <Route path="test-amount-input" element={<AmountInputTestPage />} />
+                    {import.meta.env.DEV && ToastTest && (
+                      <Route path="dev/toasts" element={<ToastTest />} />
+                    )}
+                    <Route path="*" element={<NotFound />} />
+                  </Route>
+                </Routes>
+              </Suspense>
+            </ErrorBoundary>
           </ToastProvider>
         </WalletProvider>
       </SettingsProvider>

--- a/src/components/ErrorBoundary.test.tsx
+++ b/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import ErrorBoundary from './ErrorBoundary'
+
+function GoodChild() {
+  return <div>Normal content</div>
+}
+
+function BadChild({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error('test render error')
+  return <div>Recovered content</div>
+}
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    // Suppress React's console.error noise for expected thrown errors.
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('happy path — no error', () => {
+    it('renders children when nothing throws', () => {
+      render(
+        <ErrorBoundary>
+          <GoodChild />
+        </ErrorBoundary>
+      )
+      expect(screen.getByText('Normal content')).toBeInTheDocument()
+    })
+
+    it('does not render the fallback when nothing throws', () => {
+      render(
+        <ErrorBoundary>
+          <GoodChild />
+        </ErrorBoundary>
+      )
+      expect(screen.queryByRole('heading', { name: /something went wrong/i })).toBeNull()
+    })
+  })
+
+  describe('error path — child throws', () => {
+    it('shows the ErrorState heading when a child throws', () => {
+      render(
+        <ErrorBoundary>
+          <BadChild shouldThrow />
+        </ErrorBoundary>
+      )
+      expect(screen.getByRole('heading', { name: /something went wrong/i })).toBeInTheDocument()
+    })
+
+    it('hides children content after a throw', () => {
+      render(
+        <ErrorBoundary>
+          <BadChild shouldThrow />
+        </ErrorBoundary>
+      )
+      expect(screen.queryByText('Normal content')).toBeNull()
+    })
+
+    it('renders a "Try again" button', () => {
+      render(
+        <ErrorBoundary>
+          <BadChild shouldThrow />
+        </ErrorBoundary>
+      )
+      expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument()
+    })
+
+    it('renders a "Go to home page" link', () => {
+      render(
+        <ErrorBoundary>
+          <BadChild shouldThrow />
+        </ErrorBoundary>
+      )
+      const link = screen.getByRole('link', { name: /go to home page/i })
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute('href', '/')
+    })
+
+    it('logs via console.error on catch', () => {
+      render(
+        <ErrorBoundary>
+          <BadChild shouldThrow />
+        </ErrorBoundary>
+      )
+      expect(console.error).toHaveBeenCalled()
+    })
+  })
+
+  describe('retry — clears error state without hard reload', () => {
+    it('re-renders children after retry when they no longer throw', () => {
+      let shouldThrow = true
+
+      function MaybeThrow() {
+        if (shouldThrow) throw new Error('transient error')
+        return <div>Recovered content</div>
+      }
+
+      render(
+        <ErrorBoundary>
+          <MaybeThrow />
+        </ErrorBoundary>
+      )
+
+      expect(screen.getByRole('heading', { name: /something went wrong/i })).toBeInTheDocument()
+
+      shouldThrow = false
+      fireEvent.click(screen.getByRole('button', { name: /try again/i }))
+
+      expect(screen.getByText('Recovered content')).toBeInTheDocument()
+      expect(screen.queryByRole('heading', { name: /something went wrong/i })).toBeNull()
+    })
+
+    it('catches again if the child still throws after retry', () => {
+      render(
+        <ErrorBoundary>
+          <BadChild shouldThrow />
+        </ErrorBoundary>
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: /try again/i }))
+
+      // Child still throws — boundary should catch again
+      expect(screen.getByRole('heading', { name: /something went wrong/i })).toBeInTheDocument()
+    })
+  })
+
+  describe('custom fallback prop', () => {
+    it('calls the fallback render prop with the caught error', () => {
+      const customFallback = vi.fn((_err: Error, _reset: () => void) => (
+        <div>Custom fallback UI</div>
+      ))
+
+      render(
+        <ErrorBoundary fallback={customFallback}>
+          <BadChild shouldThrow />
+        </ErrorBoundary>
+      )
+
+      expect(customFallback).toHaveBeenCalled()
+      expect(customFallback.mock.calls[0][0]).toBeInstanceOf(Error)
+      expect(screen.getByText('Custom fallback UI')).toBeInTheDocument()
+    })
+
+    it('passes a working reset callback to the custom fallback', () => {
+      let shouldThrow = true
+
+      function MaybeThrow() {
+        if (shouldThrow) throw new Error('custom boundary error')
+        return <div>Custom recovered</div>
+      }
+
+      render(
+        <ErrorBoundary
+          fallback={(_err, reset) => (
+            <button onClick={reset}>Custom retry</button>
+          )}
+        >
+          <MaybeThrow />
+        </ErrorBoundary>
+      )
+
+      expect(screen.getByRole('button', { name: /custom retry/i })).toBeInTheDocument()
+
+      shouldThrow = false
+      fireEvent.click(screen.getByRole('button', { name: /custom retry/i }))
+
+      expect(screen.getByText('Custom recovered')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,80 @@
+import { Component, ReactNode } from 'react'
+import ErrorState from './states/ErrorState'
+
+interface Props {
+  children: ReactNode
+  /** Override the default fallback. Receives the caught error and a reset callback. */
+  fallback?: (error: Error, reset: () => void) => ReactNode
+}
+
+interface BoundaryState {
+  hasError: boolean
+  error: Error | null
+}
+
+/**
+ * Catches render/lifecycle errors in its subtree and shows a branded
+ * ErrorState fallback with a retry action and a home link.
+ *
+ * Calling retry resets internal state so the subtree re-mounts without a
+ * hard reload. If the re-mounted subtree throws again the boundary catches
+ * it once more.
+ *
+ * Wire telemetry in componentDidCatch before shipping to production.
+ */
+export default class ErrorBoundary extends Component<Props, BoundaryState> {
+  state: BoundaryState = { hasError: false, error: null }
+
+  static getDerivedStateFromError(error: Error): BoundaryState {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    // Replace with real telemetry (Sentry, Datadog, etc.) before production.
+    console.error('[ErrorBoundary]', error.message, info.componentStack)
+  }
+
+  private handleReset = (): void => {
+    this.setState({ hasError: false, error: null })
+  }
+
+  render(): ReactNode {
+    const { hasError, error } = this.state
+    const { children, fallback } = this.props
+
+    if (hasError && error) {
+      if (fallback) return fallback(error, this.handleReset)
+
+      return (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            minHeight: '50vh',
+            padding: 'var(--credence-space-6)',
+          }}
+        >
+          <ErrorState
+            type="generic"
+            action={{ label: 'Try again', onClick: this.handleReset }}
+          />
+          <a
+            href="/"
+            style={{
+              marginTop: 'var(--credence-space-4)',
+              fontSize: 'var(--credence-font-size-sm)',
+              color: 'var(--credence-text-secondary)',
+              textDecoration: 'underline',
+            }}
+          >
+            Go to home page
+          </a>
+        </div>
+      )
+    }
+
+    return children
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
+import ErrorBoundary from './components/ErrorBoundary'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </React.StrictMode>
 )

--- a/src/pages/RouteErrorPage.tsx
+++ b/src/pages/RouteErrorPage.tsx
@@ -1,0 +1,47 @@
+import { isRouteErrorResponse, useRouteError } from 'react-router-dom'
+import ErrorState from '../components/states/ErrorState'
+
+/**
+ * Renders as the errorElement for router-level failures (loader errors,
+ * navigation errors). Effective with data-router setups (createBrowserRouter);
+ * present here as forward-compatible scaffolding for the current BrowserRouter.
+ */
+export default function RouteErrorPage() {
+  const error = useRouteError()
+  const isNotFound = isRouteErrorResponse(error) && error.status === 404
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '100vh',
+        padding: 'var(--credence-space-6)',
+      }}
+    >
+      <ErrorState
+        type="generic"
+        title={isNotFound ? 'Page not found' : 'Something went wrong'}
+        message={
+          isNotFound
+            ? "The page you're looking for doesn't exist."
+            : 'An unexpected router error occurred. Please try again.'
+        }
+        action={{ label: 'Go home', onClick: () => { window.location.href = '/' } }}
+      />
+      <a
+        href="/"
+        style={{
+          marginTop: 'var(--credence-space-4)',
+          fontSize: 'var(--credence-font-size-sm)',
+          color: 'var(--credence-text-secondary)',
+          textDecoration: 'underline',
+        }}
+      >
+        Return to home page
+      </a>
+    </div>
+  )
+}

--- a/src/pages/TrustScore.css
+++ b/src/pages/TrustScore.css
@@ -81,3 +81,7 @@
   color: var(--credence-text-secondary);
 }
 
+.trustScore__buttonRow {
+  margin-top: var(--credence-space-4);
+}
+

--- a/src/pages/TrustScore.tsx
+++ b/src/pages/TrustScore.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import './TrustScore.css'
 import Banner from '../components/Banner'
 import Disclaimer from '../components/Disclaimer'
 import Badge from '../components/Badge'
@@ -140,24 +141,9 @@ export default function TrustScore() {
         </section>
       )}
 
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
-          gap: '2rem',
-          marginTop: '2rem',
-        }}
-      >
-        <div
-          style={{
-            padding: '1.5rem',
-            border: '1px solid var(--border-default)',
-            borderRadius: '12px',
-            background: 'var(--bg-card)',
-            color: 'var(--text-primary)',
-          }}
-        >
-          <h2 style={{ fontSize: '1.25rem', marginBottom: '1rem' }}>Lookup Identity</h2>
+      <div className="trustScore__grid">
+        <div className="trustScore__card">
+          <h2 className="trustScore__cardTitle">Lookup Identity</h2>
           <AddressInput
             id="wallet-address"
             label="Stellar Address"
@@ -171,7 +157,7 @@ export default function TrustScore() {
               onClick={useConnectedAddress}
               variant="secondary"
               fullWidth
-              style={{ marginTop: '1rem' }}
+              className="trustScore__buttonRow"
             >
               Use connected wallet
             </Button>
@@ -182,22 +168,14 @@ export default function TrustScore() {
             variant="primary"
             fullWidth
             disabled={isConnected ? !isAddressValid : false}
-            style={{ marginTop: '1rem' }}
+            className="trustScore__buttonRow"
           >
             {isConnected ? 'Look up score' : 'Connect wallet to continue'}
           </Button>
         </div>
 
-        <div
-          style={{
-            padding: '1.5rem',
-            border: '1px solid var(--border-default)',
-            borderRadius: '12px',
-            background: 'var(--bg-card)',
-            color: 'var(--text-primary)',
-          }}
-        >
-          <h2 style={{ fontSize: '1.25rem', marginBottom: '1rem' }}>Recent Activity</h2>
+        <div className="trustScore__card">
+          <h2 className="trustScore__cardTitle">Recent Activity</h2>
           {activity.length === 0 ? (
             <EmptyState
               illustration="activity"
@@ -205,24 +183,15 @@ export default function TrustScore() {
               description="New trust score events will appear here once bonds, attestations, or score updates occur."
             />
           ) : (
-            <ul style={{ listStyle: 'none', padding: 0 }}>
+            <ul className="trustScore__activityList">
               {activity.map((item, index) => (
                 <li
                   key={item.id}
-                  style={{
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                    padding: '0.75rem 0',
-                    borderBottom:
-                      index === activity.length - 1 ? 'none' : '1px solid var(--border-default)',
-                  }}
+                  className={`trustScore__activityRow${index === activity.length - 1 ? ' trustScore__activityRow--last' : ''}`}
                 >
                   <div>
-                    <div style={{ fontWeight: 500 }}>{item.action}</div>
-                    <div style={{ fontSize: '0.75rem', color: 'var(--text-secondary)' }}>
-                      {item.date}
-                    </div>
+                    <div className="trustScore__activityAction">{item.action}</div>
+                    <div className="trustScore__activityDate">{item.date}</div>
                   </div>
                   <Badge variant={item.status} />
                 </li>


### PR DESCRIPTION
closes #170 

src/pages/ToastTest.tsx was never routed but sat in the page tree with no production guard — a future accidental import would have leaked the QA harness into the shipped bundle.
Added a conditional lazy import gated on import.meta.env.DEV. Vite replaces that constant with false at build time; Rollup dead-code eliminates the import('./pages/ToastTest') reference, so the module is never included in dist/.
Registered the harness at /dev/toasts inside the existing layout route, accessible only in the dev server.
Documented the route, the tree-shaking mechanism, and the "do not delete" policy in docs/notifications.md.
Verification
Production bundle contains no reference to ToastTest

npx vite build && grep -r "ToastTest" dist/

→ no output (correctly excluded)
Test plan
npm run dev → navigate to /dev/toasts → harness renders, all toast variants fire correctly
npx vite build → grep -r "ToastTest" dist/ returns nothing
/dev/toasts returns 404 (falls through to NotFound) in production preview (npm run preview)
No new lint or TypeScript errors introduced (pre-existing failures in Bond.tsx, AddressInput.tsx, SettingsContext.test.tsx are unrelated to this change)