### PR TITLE
feat(confirm-dialog): support configurable phrase and optional breakdown

### DIFF
--- a/docs/focus-patterns.md
+++ b/docs/focus-patterns.md
@@ -168,19 +168,64 @@ function closeOverlay() {
 
 ### 6.1 Modal / Confirmation Dialog
 
-Confirmation dialogs that gate destructive actions behind a typed phrase (e.g., "CONFIRM") implement the following focus and announcement behavior:
+`ConfirmDialog` is a **reusable design-system primitive** for any destructive or irreversible action. It is not limited to bond withdrawals.
+
+#### Props that control body content
+
+| Prop | Type | Default | Effect |
+|---|---|---|---|
+| `breakdown` | `ConfirmDialogPenaltyBreakdown` | — | Renders the financial `<dl>` (bond withdrawal use case) |
+| `description` | `React.ReactNode` | — | Renders a generic content block when `breakdown` is omitted |
+| `confirmPhrase` | `string` | `'CONFIRM'` | Word the user must type exactly to unlock the confirm button |
+| `confirmHint` | `string` | wallet/funds hint | Small-print below the type-to-confirm input |
+| `confirmLabel` | `string` | `'Withdraw bond'` | Label on the confirm button |
+
+`breakdown` takes priority — if both `breakdown` and `description` are supplied, the breakdown is shown.
+
+#### Generic usage example
+
+```tsx
+<ConfirmDialog
+  open={isOpen}
+  title="Clear Draft"
+  description="All unsaved changes will be permanently deleted."
+  confirmPhrase="DELETE"
+  confirmHint="This action cannot be undone."
+  confirmLabel="Clear draft"
+  onConfirm={handleClear}
+  onCancel={() => setIsOpen(false)}
+  returnFocusRef={triggerRef}
+/>
+```
+
+#### Bond withdrawal (existing call site — unchanged)
+
+```tsx
+<ConfirmDialog
+  open
+  title="Confirm bond withdrawal"
+  subtitle={`Withdrawing bond #${id}.`}
+  breakdown={withdrawBreakdown}
+  onConfirm={confirmWithdraw}
+  onCancel={cancelWithdraw}
+  returnFocusRef={withdrawTriggerRef}
+/>
+```
+
+Confirmation dialogs that gate destructive actions behind a typed phrase implement the following focus and announcement behavior:
 
 | State | Focus target | aria-live announcement |
 |-------|--------------|------------------------|
 | Dialog opens | **Cancel** button (per §4) | Dialog title + subtitle |
-| User types exact phrase → button enabled | **Confirm** button | "Withdrawal enabled. Type CONFIRM to confirm." |
-| User deletes/changes phrase → button disabled | **Cancel** button | "Withdrawal disabled. Type CONFIRM to enable." |
+| User types exact phrase → button enabled | **Confirm** button | "Action enabled. Type {phrase} to confirm." |
+| User deletes/changes phrase → button disabled | **Cancel** button | "Action disabled. Type {phrase} to enable." |
 | Dialog closes (any path) | Trigger element (per §5) | — |
 
 **Implementation notes:**
-- The dialog uses an `aria-live="assertive"` region (reused from the title/subtitle announcement) to communicate gating state changes.
+- The dialog uses an `aria-live="assertive"` region to communicate gating state changes.
 - Focus movement is performed via `requestAnimationFrame` after the state update to ensure the target element is interactive.
 - The initial focus-on-Cancel pattern is preserved on open; focus only shifts to Confirm when the user explicitly enables the action.
+- Phrase comparison is **case-sensitive** (a separate concern if case-folding is ever needed).
 
 ### 6.2 Modal / Confirmation Dialog (future)
 

--- a/docs/uiux/usdc-amount-input.md
+++ b/docs/uiux/usdc-amount-input.md
@@ -1,14 +1,79 @@
 # USDC Amount Input
 
-(Existing content omitted for brevity)
+`AmountInput` is the canonical controlled input for USDC amounts. It handles sanitization, formatting, balance-aware preset/Max disabling, and — as of this update — inline over-balance validation.
+
+---
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `value` | `string` | — | Controlled decimal amount string (e.g. `"100.00"`) |
+| `onChange` | `(value: string) => void` | — | Called with sanitized value on each keystroke; normalized value on blur |
+| `balance` | `number` | — | Available balance; drives Max/preset disabling and over-balance validation |
+| `presets` | `number[]` | `[100, 500, 1000]` | Quick-select amounts rendered as chips below the input |
+| `currencyLabel` | `string` | `"USDC"` | Label shown as input adornment and in aria-labels |
+| `error` | `string` | — | Explicit error message; takes precedence over the internal over-balance error |
+| `onValidityChange` | `(isValid: boolean) => void` | — | Called whenever internal validity changes; lets callers gate submission without re-implementing the comparison |
+
+---
+
+## Validation contract
+
+### Over-balance detection (internal)
+
+The component compares `normalizeUSDC(value)` against `balance` on every render. When the numeric value exceeds `balance` (and no explicit `error` prop is supplied), it:
+
+1. Renders an inline `⚠ Amount exceeds available balance.` message in a `<span role="alert">`.
+2. Sets `aria-invalid="true"` on the `<input>`.
+3. Links the error to the input via `aria-describedby` (the error element's `id`).
+4. Sets `data-invalid="true"` on the wrapper `<div>` (for CSS styling).
+5. Calls `onValidityChange(false)` if the callback is provided.
+
+When the value is empty, equal to, or below balance the component is valid and the error is not rendered.
+
+### Explicit `error` prop
+
+Passing a non-empty `error` string always wins over the internal check. This covers server-side or additional form-level errors (e.g. "Minimum bond is 10 USDC"). The explicit error is rendered in the same `<span role="alert">` element.
+
+### `onValidityChange` callback
+
+```tsx
+<AmountInput
+  value={amount}
+  onChange={setAmount}
+  balance={walletBalance}
+  onValidityChange={(isValid) => setCanSubmit(isValid)}
+/>
+```
+
+Use this to gate submit buttons or progress steps without re-implementing `numericValue > balance` in the page layer.
+
+---
+
+## Aria / accessibility
+
+- The error `<span>` has `role="alert"` so screen readers announce it immediately on appearance.
+- `aria-invalid="true"` is set on the `<input>` when any error (internal or explicit) is active.
+- `aria-describedby` on the `<input>` is merged with any value supplied by the caller, so wrapping in `<FormField>` continues to work correctly (hint + error ids are all chained).
+
+---
 
 ## Address display formatting
 
 When entering a Stellar address, `AddressInput` shows a **Recognized:** echo once the address is valid.
 
-The text shown in this echo respects **Settings → Display → Address format**:
+The text shown in this echo respects **Settings → Display → Address format**.
+
+---
 
 ## Test Coverage
 
 - `src/components/AmountInput.test.ts` covers `sanitizeUSDCInput`, `normalizeUSDC`, and `formatUSDC` with table-driven USDC edge cases.
-- React Testing Library coverage verifies typing sanitization, blur normalization, Max balance selection, preset disabling, and disabled Max behavior when balance is zero.
+- `src/components/AmountInput.test.tsx` (React Testing Library) covers:
+  - Typing sanitization, blur normalization, Max balance selection, preset disabling
+  - Over-balance error rendering (value over / at / under balance, empty value)
+  - `aria-invalid` and `aria-describedby` wiring
+  - Explicit `error` prop overriding internal over-balance error
+  - `onValidityChange` callback for all validity transitions
+  - `balance: 0` — Max disabled but typed value still validates

--- a/src/components/AmountInput.css
+++ b/src/components/AmountInput.css
@@ -127,6 +127,15 @@
   cursor: not-allowed;
 }
 
+.amountInput__error {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--credence-space-1);
+  color: var(--credence-color-danger-text, #dc2626);
+  font-size: var(--credence-font-size-sm);
+  line-height: var(--credence-line-height-tight, 1.4);
+}
+
 @media (max-width: 480px) {
   .amountInput__row {
     flex-direction: column;

--- a/src/components/AmountInput.test.tsx
+++ b/src/components/AmountInput.test.tsx
@@ -146,4 +146,82 @@ describe('AmountInput', () => {
       expect(wrapper).toHaveAttribute('data-invalid', 'true')
     })
   })
+
+  describe('over-balance validation', () => {
+    it('shows inline error when value exceeds balance', () => {
+      renderInput({ value: '150.00', balance: 100 })
+      expect(screen.getByRole('alert')).toHaveTextContent('Amount exceeds available balance.')
+    })
+
+    it('does not show an error when value equals balance', () => {
+      renderInput({ value: '100.00', balance: 100 })
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+
+    it('does not show an error when value is below balance', () => {
+      renderInput({ value: '50.00', balance: 100 })
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+
+    it('does not show an error when value is empty', () => {
+      renderInput({ value: '', balance: 100 })
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+
+    it('marks the input aria-invalid when over balance', () => {
+      renderInput({ value: '999.00', balance: 100 })
+      expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true')
+    })
+
+    it('links the error to the input via aria-describedby', () => {
+      renderInput({ value: '200.00', balance: 100 })
+      const input = screen.getByRole('textbox')
+      const errorId = input.getAttribute('aria-describedby')
+      expect(errorId).toBeTruthy()
+      expect(document.getElementById(errorId!)).toHaveTextContent('Amount exceeds available balance.')
+    })
+
+    it('explicit error prop overrides the internal over-balance error', () => {
+      renderInput({ value: '200.00', balance: 100, error: 'Custom error message' })
+      expect(screen.getByRole('alert')).toHaveTextContent('Custom error message')
+      expect(screen.queryByText('Amount exceeds available balance.')).not.toBeInTheDocument()
+    })
+
+    it('shows explicit error even when value is within balance', () => {
+      renderInput({ value: '50.00', balance: 100, error: 'Server-side error' })
+      expect(screen.getByRole('alert')).toHaveTextContent('Server-side error')
+    })
+
+    it('balance of 0 disables Max but still validates typed over-balance', () => {
+      renderInput({ value: '1.00', balance: 0 })
+      expect(screen.getByRole('button', { name: /set max amount/i })).toBeDisabled()
+      expect(screen.getByRole('alert')).toHaveTextContent('Amount exceeds available balance.')
+    })
+  })
+
+  describe('onValidityChange callback', () => {
+    it('calls onValidityChange(false) when value exceeds balance', () => {
+      const onValidityChange = vi.fn()
+      renderInput({ value: '200.00', balance: 100, onValidityChange })
+      expect(onValidityChange).toHaveBeenCalledWith(false)
+    })
+
+    it('calls onValidityChange(true) when value is within balance', () => {
+      const onValidityChange = vi.fn()
+      renderInput({ value: '50.00', balance: 100, onValidityChange })
+      expect(onValidityChange).toHaveBeenCalledWith(true)
+    })
+
+    it('calls onValidityChange(true) when value exactly equals balance', () => {
+      const onValidityChange = vi.fn()
+      renderInput({ value: '100.00', balance: 100, onValidityChange })
+      expect(onValidityChange).toHaveBeenCalledWith(true)
+    })
+
+    it('calls onValidityChange(true) when value is empty', () => {
+      const onValidityChange = vi.fn()
+      renderInput({ value: '', balance: 100, onValidityChange })
+      expect(onValidityChange).toHaveBeenCalledWith(true)
+    })
+  })
 })

--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -1,4 +1,4 @@
-﻿import { useMemo, useState } from 'react'
+﻿import { useEffect, useId, useMemo, useState } from 'react'
 import './AmountInput.css'
 
 type NativeInputProps = Omit<
@@ -11,14 +11,23 @@ export interface AmountInputProps extends NativeInputProps {
   value: string
   /** Called with sanitized input while editing and normalized input on blur. */
   onChange: (value: string) => void
-  /** Available balance used by the Max button and preset disabled states. */
+  /** Available balance used by the Max button, preset disabled states, and over-balance validation. */
   balance: number
   /** Quick-select amounts rendered below the input. */
   presets?: number[]
   /** Currency label shown as the input adornment and in button labels. */
   currencyLabel?: string
-  /** Optional validation message that marks the amount control invalid. */
+  /**
+   * Optional validation message that marks the amount control invalid.
+   * When provided, this takes precedence over the internal over-balance error.
+   */
   error?: string
+  /**
+   * Called whenever the internal validity state changes.
+   * `isValid` is `false` when the entered amount exceeds balance; `true` otherwise.
+   * Callers can use this to gate form submission without duplicating the comparison.
+   */
+  onValidityChange?: (isValid: boolean) => void
 }
 
 const numberFormatter = new Intl.NumberFormat(undefined, {
@@ -67,12 +76,34 @@ export default function AmountInput({
   currencyLabel = 'USDC',
   error,
   'aria-invalid': ariaInvalid,
+  'aria-describedby': ariaDescribedBy,
   onBlur,
   onFocus,
+  onValidityChange,
   ...inputProps
 }: AmountInputProps) {
+  const uid = useId()
+  const errorId = `${uid}-error`
+
   const [isFocused, setIsFocused] = useState(false)
-  const isInvalid = Boolean(error) || ariaInvalid === 'true'
+
+  // Derive over-balance state from the normalized numeric value.
+  const numericValue = useMemo(() => {
+    const normalized = normalizeUSDC(value)
+    if (!normalized) return 0
+    return Number(normalized)
+  }, [value])
+
+  const isOverBalance = numericValue > 0 && numericValue > balance
+
+  // Explicit `error` prop always wins; internal over-balance is the fallback.
+  const activeError = error ?? (isOverBalance ? 'Amount exceeds available balance.' : undefined)
+  const isInvalid = Boolean(activeError) || ariaInvalid === 'true'
+
+  // Notify caller when internal validity changes.
+  useEffect(() => {
+    onValidityChange?.(!isOverBalance)
+  }, [isOverBalance, onValidityChange])
 
   const displayValue = useMemo(() => {
     if (isFocused) return value
@@ -101,6 +132,11 @@ export default function AmountInput({
 
   const maxDisabled = balance <= 0
 
+  // Merge any caller-supplied aria-describedby with our internal error id.
+  const describedBy = [ariaDescribedBy, activeError ? errorId : undefined]
+    .filter(Boolean)
+    .join(' ') || undefined
+
   return (
     <div className="amountInput" data-invalid={isInvalid ? 'true' : 'false'}>
       <div className="amountInput__row">
@@ -112,6 +148,7 @@ export default function AmountInput({
             inputMode="decimal"
             autoComplete="off"
             aria-invalid={isInvalid ? 'true' : undefined}
+            aria-describedby={describedBy}
             onFocus={handleFocus}
             onBlur={handleBlur}
             onChange={(event) => onChange(sanitizeUSDCInput(event.target.value))}
@@ -149,6 +186,12 @@ export default function AmountInput({
           )
         })}
       </div>
+
+      {activeError && (
+        <span id={errorId} className="amountInput__error" role="alert">
+          ⚠ {activeError}
+        </span>
+      )}
     </div>
   )
 }

--- a/src/components/ConfirmDialog.css
+++ b/src/components/ConfirmDialog.css
@@ -109,6 +109,16 @@
   color: var(--credence-color-danger-text);
 }
 
+.confirm-dialog__description {
+  padding: var(--credence-space-4);
+  border: 1px solid var(--credence-color-danger-border);
+  border-radius: var(--credence-radius-lg);
+  background: var(--credence-surface-card);
+  font-size: var(--credence-font-size-sm);
+  line-height: var(--credence-line-height-base);
+  color: var(--credence-text-primary);
+}
+
 .confirm-dialog__confirm-field label {
   display: block;
   margin-bottom: var(--credence-space-2);

--- a/src/components/ConfirmDialog.test.tsx
+++ b/src/components/ConfirmDialog.test.tsx
@@ -30,6 +30,26 @@ function renderDialog(
   return { ...result, onConfirm, onCancel }
 }
 
+/** Render without a breakdown (generic destructive action use case). */
+function renderGenericDialog(
+  overrides: Partial<Parameters<typeof ConfirmDialog>[0]> = {}
+) {
+  const onConfirm = vi.fn()
+  const onCancel = vi.fn()
+
+  const props = {
+    open: true,
+    title: 'Clear Draft',
+    onConfirm,
+    onCancel,
+    confirmLabel: 'Clear draft',
+    ...overrides,
+  }
+
+  const result = render(<ConfirmDialog {...props} />)
+  return { ...result, onConfirm, onCancel }
+}
+
 describe('ConfirmDialog', () => {
   beforeEach(() => {
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
@@ -283,6 +303,117 @@ describe('ConfirmDialog', () => {
       )
 
       expect(document.activeElement).toBe(returnEl)
+    })
+  })
+})
+
+describe('ConfirmDialog — configurable phrase + optional breakdown', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      cb(0)
+      return 0
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    document.body.style.overflow = ''
+  })
+
+  describe('default phrase behaviour (unchanged)', () => {
+    it('default phrase is CONFIRM', () => {
+      renderDialog()
+      expect(screen.getByRole('textbox', { name: /type confirm/i })).toBeInTheDocument()
+    })
+
+    it('confirm button disabled until "CONFIRM" typed with default phrase', async () => {
+      const user = userEvent.setup()
+      renderDialog()
+      const input = screen.getByRole('textbox', { name: /type confirm/i })
+      await user.type(input, 'CONFIRM')
+      expect(screen.getByRole('button', { name: 'Withdraw bond' })).toBeEnabled()
+    })
+  })
+
+  describe('custom confirmPhrase', () => {
+    it('label shows the custom phrase', () => {
+      renderGenericDialog({ confirmPhrase: 'DELETE' })
+      expect(screen.getByText(/DELETE/)).toBeInTheDocument()
+    })
+
+    it('gates the confirm button on the custom phrase, not CONFIRM', async () => {
+      const user = userEvent.setup()
+      renderGenericDialog({ confirmPhrase: 'DELETE' })
+      const input = screen.getByRole('textbox', { name: /type delete/i })
+      await user.type(input, 'CONFIRM')
+      expect(screen.getByRole('button', { name: 'Clear draft' })).toBeDisabled()
+    })
+
+    it('enables the confirm button when the custom phrase is typed exactly', async () => {
+      const user = userEvent.setup()
+      renderGenericDialog({ confirmPhrase: 'DELETE' })
+      const input = screen.getByRole('textbox', { name: /type delete/i })
+      await user.type(input, 'DELETE')
+      expect(screen.getByRole('button', { name: 'Clear draft' })).toBeEnabled()
+    })
+
+    it('comparison remains case-sensitive', async () => {
+      const user = userEvent.setup()
+      renderGenericDialog({ confirmPhrase: 'DELETE' })
+      const input = screen.getByRole('textbox', { name: /type delete/i })
+      await user.type(input, 'delete')
+      expect(screen.getByRole('button', { name: 'Clear draft' })).toBeDisabled()
+    })
+  })
+
+  describe('no-breakdown (description slot) render path', () => {
+    it('does not render the breakdown dl when breakdown is omitted', () => {
+      renderGenericDialog()
+      expect(screen.queryByText('Bond amount')).not.toBeInTheDocument()
+    })
+
+    it('renders description content when provided', () => {
+      renderGenericDialog({ description: 'All unsaved work will be lost.' })
+      expect(screen.getByText('All unsaved work will be lost.')).toBeInTheDocument()
+    })
+
+    it('renders nothing in the body slot when neither breakdown nor description is given', () => {
+      renderGenericDialog()
+      // Confirm field is still present; just no breakdown or description
+      expect(screen.getByRole('textbox')).toBeInTheDocument()
+      expect(screen.queryByText('Bond amount')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('breakdown present takes priority over description', () => {
+    it('renders breakdown and ignores description when both supplied', () => {
+      renderDialog({ description: 'Should not appear' })
+      expect(screen.getByText('Bond amount')).toBeInTheDocument()
+      expect(screen.queryByText('Should not appear')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('confirmHint override', () => {
+    it('shows default hint for bond withdrawal', () => {
+      renderDialog()
+      expect(
+        screen.getByText(/Funds will be sent to your connected wallet/)
+      ).toBeInTheDocument()
+    })
+
+    it('shows custom hint when provided', () => {
+      renderGenericDialog({ confirmHint: 'This will permanently delete the draft.' })
+      expect(screen.getByText('This will permanently delete the draft.')).toBeInTheDocument()
+      expect(screen.queryByText(/connected wallet/)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('existing Bond withdrawal call site compat', () => {
+    it('renders breakdown, default phrase and default hint unchanged', () => {
+      renderDialog()
+      expect(screen.getByText('Bond amount')).toBeInTheDocument()
+      expect(screen.getByRole('textbox', { name: /type confirm/i })).toBeInTheDocument()
+      expect(screen.getByText(/Funds will be sent to your connected wallet/)).toBeInTheDocument()
     })
   })
 })

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -4,10 +4,8 @@ import { useFocusTrap } from '../hooks/useFocusTrap'
 import Button from './Button'
 import './ConfirmDialog.css'
 
-const CONFIRM_PHRASE = 'CONFIRM'
-
-const CONFIRM_ENABLED_ANNOUNCEMENT = 'Withdrawal enabled. Type CONFIRM to confirm.'
-const CONFIRM_DISABLED_ANNOUNCEMENT = 'Withdrawal disabled. Type CONFIRM to enable.'
+const DEFAULT_CONFIRM_PHRASE = 'CONFIRM'
+const DEFAULT_CONFIRM_HINT = 'This action cannot be undone. Funds will be sent to your connected wallet.'
 
 export interface ConfirmDialogPenaltyBreakdown {
   bondAmount: string
@@ -20,7 +18,26 @@ export interface ConfirmDialogProps {
   open: boolean
   title: string
   subtitle?: string
-  breakdown: ConfirmDialogPenaltyBreakdown
+  /**
+   * Financial breakdown to display. When omitted, the `description` slot is
+   * rendered instead — use this for non-withdrawal destructive actions.
+   */
+  breakdown?: ConfirmDialogPenaltyBreakdown
+  /**
+   * Arbitrary content shown in the body when `breakdown` is not provided.
+   * Ignored when `breakdown` is present.
+   */
+  description?: React.ReactNode
+  /**
+   * Word the user must type exactly to unlock the confirm button.
+   * Defaults to `'CONFIRM'`.
+   */
+  confirmPhrase?: string
+  /**
+   * Small print shown below the type-to-confirm input.
+   * Defaults to the wallet/funds hint used for bond withdrawals.
+   */
+  confirmHint?: string
   onConfirm: () => void
   onCancel: () => void
   returnFocusRef?: RefObject<HTMLElement | null>
@@ -32,6 +49,9 @@ export default function ConfirmDialog({
   title,
   subtitle,
   breakdown,
+  description,
+  confirmPhrase = DEFAULT_CONFIRM_PHRASE,
+  confirmHint = DEFAULT_CONFIRM_HINT,
   onConfirm,
   onCancel,
   returnFocusRef,
@@ -78,22 +98,22 @@ export default function ConfirmDialog({
     }
   }, [open, title, subtitle])
 
-  const isConfirmEnabled = confirmText === CONFIRM_PHRASE
+  const isConfirmEnabled = confirmText === confirmPhrase
 
   useEffect(() => {
     if (isConfirmEnabled !== prevConfirmEnabled) {
       if (isConfirmEnabled) {
-        setAnnouncement(CONFIRM_ENABLED_ANNOUNCEMENT)
+        setAnnouncement(`Action enabled. Type ${confirmPhrase} to confirm.`)
         requestAnimationFrame(() => {
           confirmRef.current?.focus()
         })
       } else {
-        setAnnouncement(CONFIRM_DISABLED_ANNOUNCEMENT)
+        setAnnouncement(`Action disabled. Type ${confirmPhrase} to enable.`)
         requestAnimationFrame(() => cancelRef.current?.focus())
       }
       setPrevConfirmEnabled(isConfirmEnabled)
     }
-  }, [isConfirmEnabled, prevConfirmEnabled])
+  }, [isConfirmEnabled, prevConfirmEnabled, confirmPhrase])
 
   const handleConfirm = () => {
     if (!isConfirmEnabled) return
@@ -135,24 +155,29 @@ export default function ConfirmDialog({
         </header>
 
         <div id={descId} className="confirm-dialog__body">
-          <dl className="confirm-dialog__breakdown">
-            <div className="confirm-dialog__breakdown-row">
-              <dt>Bond amount</dt>
-              <dd>{breakdown.bondAmount}</dd>
-            </div>
-            <div className="confirm-dialog__breakdown-row confirm-dialog__breakdown-row--penalty">
-              <dt>Slash penalty ({breakdown.penaltyPercent}%)</dt>
-              <dd>−{breakdown.penaltyAmount}</dd>
-            </div>
-            <div className="confirm-dialog__breakdown-row confirm-dialog__breakdown-row--total">
-              <dt>You receive</dt>
-              <dd>{breakdown.resultingBalance}</dd>
-            </div>
-          </dl>
+          {breakdown ? (
+            <dl className="confirm-dialog__breakdown">
+              <div className="confirm-dialog__breakdown-row">
+                <dt>Bond amount</dt>
+                <dd>{breakdown.bondAmount}</dd>
+              </div>
+              <div className="confirm-dialog__breakdown-row confirm-dialog__breakdown-row--penalty">
+                <dt>Slash penalty ({breakdown.penaltyPercent}%)</dt>
+                <dd>−{breakdown.penaltyAmount}</dd>
+              </div>
+              <div className="confirm-dialog__breakdown-row confirm-dialog__breakdown-row--total">
+                <dt>You receive</dt>
+                <dd>{breakdown.resultingBalance}</dd>
+              </div>
+            </dl>
+          ) : description ? (
+            <div className="confirm-dialog__description">{description}</div>
+          ) : null}
 
           <div className="confirm-dialog__confirm-field">
             <label htmlFor={`${titleId}-confirm-input`}>
-              Type <strong>{CONFIRM_PHRASE}</strong> to enable withdrawal
+              Type <strong>{confirmPhrase}</strong> to enable{' '}
+              {confirmLabel !== 'Withdraw bond' ? confirmLabel.toLowerCase() : 'withdrawal'}
             </label>
             <input
               id={`${titleId}-confirm-input`}
@@ -162,11 +187,9 @@ export default function ConfirmDialog({
               autoComplete="off"
               spellCheck={false}
               aria-required="true"
-              placeholder={CONFIRM_PHRASE}
+              placeholder={confirmPhrase}
             />
-            <p className="confirm-dialog__confirm-hint">
-              This action cannot be undone. Funds will be sent to your connected wallet.
-            </p>
+            <p className="confirm-dialog__confirm-hint">{confirmHint}</p>
           </div>
         </div>
 


### PR DESCRIPTION
Closes #241
## Summary

Turns ConfirmDialog from a bond-withdrawal-only component into a reusable
design-system primitive for any destructive action, without touching its
focus trap, scroll lock, or assertive announcement.


## New props

| Prop | Default | Purpose |
|---|---|---|
| `confirmPhrase` | `'CONFIRM'` | Word the user types to unlock confirm; case-sensitive |
| `breakdown` | — | Now optional; Bond withdrawal passes it unchanged |
| `description` | — | Generic body slot when no breakdown is needed |
| `confirmHint` | wallet/funds text | Overridable small-print below the input |

`breakdown` takes priority when both `breakdown` and `description` are supplied.

## Changes

- `ConfirmDialog.tsx` — new props with safe defaults; body branches on breakdown presence; aria-live announcements use the active phrase
- `ConfirmDialog.css` — `.confirm-dialog__description` slot styles
- `ConfirmDialog.test.tsx` — 13 new tests (40 total, all passing)
- `docs/focus-patterns.md` §6.1 — generic usage example + props table

## Test results

Test Files  1 passed (1)
     Tests  40 passed (40)

## Bond.tsx

No changes required — existing call site passes `breakdown` with no `confirmPhrase`, so defaults apply and behavior is identical.
