### PR TITLE
feat(settings): add draft state, dirty-gated Save, and Cancel revert

### DIFF
--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -13,7 +13,14 @@ interface SettingsState {
   setAddressDisplay: (s: string) => void
   setToastsEnabled: (b: boolean) => void
   setAutoDismiss: (s: string) => void
-  saveSettings: () => void
+  saveSettings: (
+    overrides?: Partial<
+      Pick<
+        SettingsState,
+        'themeMode' | 'network' | 'addressDisplay' | 'toastsEnabled' | 'autoDismiss'
+      >
+    >
+  ) => void
   cancelSettings: () => void
   hasUnsavedChanges: boolean
 }
@@ -103,11 +110,32 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
   }, [themeMode, network, addressDisplay, toastsEnabled, autoDismiss])
 
   // Explicit save function
-  const saveSettings = () => {
+  const saveSettings = (
+    overrides?: Partial<
+      Pick<
+        SettingsState,
+        'themeMode' | 'network' | 'addressDisplay' | 'toastsEnabled' | 'autoDismiss'
+      >
+    >
+  ) => {
     try {
-      const payload = { themeMode, network, addressDisplay, toastsEnabled, autoDismiss }
+      const payload = overrides ?? {
+        themeMode,
+        network,
+        addressDisplay,
+        toastsEnabled,
+        autoDismiss,
+      }
       localStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
-      setOriginalSettings({ themeMode, network, addressDisplay, toastsEnabled, autoDismiss })
+      setOriginalSettings(
+        payload as {
+          themeMode: ThemeMode
+          network: string
+          addressDisplay: string
+          toastsEnabled: boolean
+          autoDismiss: string
+        }
+      )
     } catch {
       // ignore
     }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from 'react'
 import { useSettings } from '../context/SettingsContext'
 import ThemeToggle from '../components/ThemeToggle'
 import { useToast } from '../components/ToastProvider'
@@ -20,22 +21,73 @@ export default function Settings() {
     autoDismiss,
     setAutoDismiss,
     saveSettings,
-    cancelSettings,
   } = useSettings()
   const { addToast } = useToast()
 
   useDocumentTitle('Settings')
 
+  const [draft, setDraft] = useState({
+    themeMode: themeMode as 'light' | 'dark' | 'system',
+    network,
+    addressDisplay,
+    toastsEnabled,
+    autoDismiss,
+  })
+
+  const isDirty =
+    draft.themeMode !== themeMode ||
+    draft.network !== network ||
+    draft.addressDisplay !== addressDisplay ||
+    draft.toastsEnabled !== toastsEnabled ||
+    draft.autoDismiss !== autoDismiss
+
+  const updateDraft = (key: string, value: string | boolean) => {
+    setDraft((prev) => ({ ...prev, [key]: value }))
+  }
+
   const handleSave = () => {
-    saveSettings()
+    if (!isDirty) return
+    const payload = {
+      themeMode: draft.themeMode,
+      network: draft.network,
+      addressDisplay: draft.addressDisplay,
+      toastsEnabled: draft.toastsEnabled,
+      autoDismiss: draft.autoDismiss,
+    }
+    setThemeMode(payload.themeMode)
+    setNetwork(payload.network)
+    setAddressDisplay(payload.addressDisplay)
+    setToastsEnabled(payload.toastsEnabled)
+    setAutoDismiss(payload.autoDismiss)
+    saveSettings(payload)
     addToast('success', 'Settings saved successfully')
   }
 
   const handleCancel = () => {
-    cancelSettings()
+    if (isDirty) {
+      const confirmed = window.confirm(
+        'You have unsaved changes. Are you sure you want to discard them?'
+      )
+      if (!confirmed) return
+    }
+    setDraft({
+      themeMode: themeMode as 'light' | 'dark' | 'system',
+      network,
+      addressDisplay,
+      toastsEnabled,
+      autoDismiss,
+    })
     addToast('info', 'Settings reverted to last saved state')
-    window.history.back()
   }
+
+  useEffect(() => {
+    if (!isDirty) return
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault()
+    }
+    window.addEventListener('beforeunload', handler)
+    return () => window.removeEventListener('beforeunload', handler)
+  }, [isDirty])
 
   return (
     <div className="settings-page">
@@ -48,15 +100,30 @@ export default function Settings() {
         <FormField id="theme-seg" label="Theme">
           <div role="radiogroup" aria-label="Theme mode" style={{ display: 'flex', gap: '0.5rem' }}>
             <label>
-              <input type="radio" name="theme" checked={themeMode === 'light'} onChange={() => setThemeMode('light')} />{' '}
+              <input
+                type="radio"
+                name="theme"
+                checked={draft.themeMode === 'light'}
+                onChange={() => updateDraft('themeMode', 'light')}
+              />{' '}
               Light
             </label>
             <label>
-              <input type="radio" name="theme" checked={themeMode === 'dark'} onChange={() => setThemeMode('dark')} />{' '}
+              <input
+                type="radio"
+                name="theme"
+                checked={draft.themeMode === 'dark'}
+                onChange={() => updateDraft('themeMode', 'dark')}
+              />{' '}
               Dark
             </label>
             <label>
-              <input type="radio" name="theme" checked={themeMode === 'system'} onChange={() => setThemeMode('system')} />{' '}
+              <input
+                type="radio"
+                name="theme"
+                checked={draft.themeMode === 'system'}
+                onChange={() => updateDraft('themeMode', 'system')}
+              />{' '}
               System
             </label>
           </div>
@@ -65,7 +132,10 @@ export default function Settings() {
         <FormField id="theme-toggle" label="Quick toggle">
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
             <ThemeToggle />
-            <span className="form-hint">Use the quick toggle to flip light/dark immediately.</span>
+            <span className="form-hint">
+              Use the quick toggle to flip light/dark immediately. Theme radio buttons above apply
+              on Save.
+            </span>
           </div>
         </FormField>
       </section>
@@ -75,7 +145,14 @@ export default function Settings() {
         <p className="form-hint">Choose the Stellar network to interact with.</p>
 
         <FormField id="network-select" label="Stellar Network">
-          <Select value={network} onChange={setNetwork} options={[{ value: 'public', label: 'Public (Mainnet)' }, { value: 'test', label: 'Test (Testnet)' }]} />
+          <Select
+            value={draft.network}
+            onChange={(v) => updateDraft('network', v)}
+            options={[
+              { value: 'public', label: 'Public (Mainnet)' },
+              { value: 'test', label: 'Test (Testnet)' },
+            ]}
+          />
         </FormField>
       </section>
 
@@ -88,15 +165,30 @@ export default function Settings() {
           <FormField id="address-display" label="Address format">
             <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
               <label>
-                <input type="radio" name="address" checked={addressDisplay === 'full'} onChange={() => setAddressDisplay('full')} />{' '}
+                <input
+                  type="radio"
+                  name="address"
+                  checked={draft.addressDisplay === 'full'}
+                  onChange={() => updateDraft('addressDisplay', 'full')}
+                />{' '}
                 Full (G...)
               </label>
               <label>
-                <input type="radio" name="address" checked={addressDisplay === 'short'} onChange={() => setAddressDisplay('short')} />{' '}
+                <input
+                  type="radio"
+                  name="address"
+                  checked={draft.addressDisplay === 'short'}
+                  onChange={() => updateDraft('addressDisplay', 'short')}
+                />{' '}
                 Short (G...…)
               </label>
               <label>
-                <input type="radio" name="address" checked={addressDisplay === 'friendly'} onChange={() => setAddressDisplay('friendly')} />{' '}
+                <input
+                  type="radio"
+                  name="address"
+                  checked={draft.addressDisplay === 'friendly'}
+                  onChange={() => updateDraft('addressDisplay', 'friendly')}
+                />{' '}
                 Friendly (when available)
               </label>
             </div>
@@ -109,13 +201,17 @@ export default function Settings() {
         <p className="form-hint">Control toast and notification behavior.</p>
 
         <FormField id="toasts-enabled" label="Enable toasts">
-          <Toggle checked={toastsEnabled} onChange={setToastsEnabled} ariaLabel="Enable toasts" />
+          <Toggle
+            checked={draft.toastsEnabled}
+            onChange={(v) => updateDraft('toastsEnabled', v)}
+            ariaLabel="Enable toasts"
+          />
         </FormField>
 
         <FormField id="auto-dismiss" label="Auto-dismiss duration">
           <Select
-            value={autoDismiss}
-            onChange={setAutoDismiss}
+            value={draft.autoDismiss}
+            onChange={(v) => updateDraft('autoDismiss', v)}
             options={[
               { value: 'off', label: 'Off (require manual dismiss)' },
               { value: '3s', label: '3 seconds' },
@@ -141,8 +237,14 @@ export default function Settings() {
       </section>
 
       <div className="settings-actions">
-        <button type="button" onClick={handleSave} style={{ padding: '0.5rem 0.75rem' }}>
-          Save
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={!isDirty}
+          aria-disabled={!isDirty}
+          style={{ padding: '0.5rem 0.75rem' }}
+        >
+          {isDirty ? 'Save' : 'Saved'}
         </button>
         <button type="button" onClick={handleCancel} style={{ padding: '0.5rem 0.75rem' }}>
           Cancel


### PR DESCRIPTION
## Summary
- Replaced immediate-write settings controls with local draft state
- Save button is disabled until changes are detected (dirty state)
- On Save, commits draft to SettingsContext and shows a success toast
- On Cancel with unsaved changes, prompts confirmation before discarding
- Added `beforeunload` navigation guard when there are unsaved changes
- `saveSettings()` now accepts an optional overrides payload to avoid stale closure reads
- Quick theme toggle (ThemeToggle) remains immediate; theme radio buttons use draft model

Closes #249