### PR TITLE
docs(wallet): add wallet integration reference

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,7 +26,7 @@ graph TD
 ### Context Responsibilities
 
 1. **`SettingsProvider`**: Manages global user preferences (theme mode, network, address display) and application settings (toast toggles and auto-dismiss timing). It must sit high in the tree because it reads from `localStorage` and applies the data-theme immediately.
-2. **`WalletProvider`**: Manages Stellar wallet connection state, exposed address, and connect/disconnect functionality. Depends on `SettingsProvider` for network preferences.
+2. **`WalletProvider`**: Manages Stellar wallet connection state, exposed address, and connect/disconnect functionality. Depends on `SettingsProvider` for network preferences. See [Wallet Integration](./WALLET_INTEGRATION.md) for the `useWallet` return shape, Freighter wrapper, connection state machine, and wallet-gated UX contract.
 3. **`ToastProvider`**: Exposes `addToast` and `removeToast` functions for global notifications. **Must be placed inside `SettingsProvider`**, because the toast component reads `toastsEnabled` and `autoDismiss` preferences via `useSettings()` to calculate timeout bounds and global mute states.
 
 ### The Route Table & Layout Shell

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,10 +68,15 @@ This directory contains comprehensive design specifications and implementation g
    - Testing guide and troubleshooting
    - [Decision Matrix](./mobile-navigation-DECISION.md) | [Reconnaissance Report](./mobile-nav-RECON.md) | [Figma Rules](./figma-nav-rules.md)
 
-9. **[Architecture Overview](./ARCHITECTURE.md)** ⭐ NEW
-   - Provider tree and routing architecture
-   - Context responsibilities
-   - Theming flow and mock data boundaries
+10. **[Architecture Overview](./ARCHITECTURE.md)** ⭐ NEW
+    - Provider tree and routing architecture
+    - Context responsibilities
+    - Theming flow and mock data boundaries
+
+11. **[Wallet Integration](./WALLET_INTEGRATION.md)**
+    - `useWallet` return shape and provider boundary
+    - Freighter client wrapper and connection state machine
+    - Disconnected, not-installed, rejected, and network-mismatch UX contract
 
 ### Quick Start
 
@@ -186,6 +191,7 @@ sanitizeUSDCInput(nextValue: string): string
 ```
 
 **Usage Examples:**
+
 ```typescript
 import { formatUsdc, normalizeUSDC, formatUSDC, sanitizeUSDCInput } from '@/lib/format'
 
@@ -203,6 +209,7 @@ sanitizeUSDCInput('$1,000.50') // → "1000.50"
 ```
 
 **Behavior Preservation:**
+
 - Thousands separators maintained for display
 - Decimal precision fixed at 2 places
 - Empty values handled gracefully
@@ -224,6 +231,7 @@ truncateAddress(address: string | undefined | null): string
 ```
 
 **Usage Examples:**
+
 ```typescript
 import { isValidStellarAddress, truncateAddress } from '@/lib/stellar'
 
@@ -236,6 +244,7 @@ truncateAddress('GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA')
 ```
 
 **Behavior Preservation:**
+
 - Exact 56-character validation
 - 'G' prefix requirement
 - Uppercase alphanumeric characters only
@@ -248,6 +257,7 @@ truncateAddress('GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA')
 All components should now import from these centralized modules instead of maintaining local implementations:
 
 **Before:**
+
 ```typescript
 // In component files
 export function normalizeUSDC(rawValue: string) { ... }
@@ -255,6 +265,7 @@ export function isValidStellarAddress(address: string) { ... }
 ```
 
 **After:**
+
 ```typescript
 // Import from centralized modules
 import { normalizeUSDC } from '@/lib/format'
@@ -264,10 +275,12 @@ import { isValidStellarAddress } from '@/lib/stellar'
 ### Test Coverage
 
 Both utility modules have comprehensive test suites with ≥95% branch coverage:
+
 - `src/lib/format.test.ts` - USDC formatting tests
 - `src/lib/stellar.test.ts` - Stellar address tests
 
 Run tests with:
+
 ```bash
 npm test -- --run src/lib/format.test.ts src/lib/stellar.test.ts
 ```
@@ -277,7 +290,7 @@ npm test -- --run src/lib/format.test.ts src/lib/stellar.test.ts
 The following components have been refactored to use the centralized utilities:
 
 1. **AmountInput.tsx** - USDC input formatting and sanitization
-2. **AddressInput.tsx** - Stellar address validation and truncation  
+2. **AddressInput.tsx** - Stellar address validation and truncation
 3. **TrustScore.tsx** - Stellar address validation
 4. **useTrustScore.ts** - Stellar address validation
 5. **Bond.tsx** - USDC display formatting
@@ -288,6 +301,7 @@ The following components have been refactored to use the centralized utilities:
 ### Future Development
 
 When adding new formatting or validation logic:
+
 1. Check if it belongs in the centralized modules
 2. Add comprehensive test coverage
 3. Update this documentation

--- a/docs/WALLET_INTEGRATION.md
+++ b/docs/WALLET_INTEGRATION.md
@@ -1,0 +1,243 @@
+# Wallet Integration
+
+This reference documents the current Stellar wallet layer used by Credence
+Frontend. It covers the `useWallet` API, the Freighter client wrapper, the
+connection state machine, and the UI contract for routes that require a wallet.
+
+Related source:
+
+- `src/context/WalletContext.tsx`
+- `src/hooks/useWallet.ts`
+- `src/lib/freighterClient.ts`
+- `src/pages/Bond.tsx`
+- `src/pages/TrustScore.tsx`
+- `src/pages/Dashboard.tsx`
+
+## Provider Boundary
+
+`WalletProvider` lives inside `SettingsProvider` and outside `ToastProvider` in
+`src/App.tsx`. That order is important because wallet network validation reads
+the active settings network before exposing shared wallet state to route
+components.
+
+```mermaid
+graph TD
+  A["SettingsProvider"] --> B["WalletProvider"]
+  B --> C["ToastProvider"]
+  C --> D["Routes"]
+```
+
+`WalletProvider` calls the hook implementation from `src/hooks/useWallet.ts` and
+adds one compatibility alias:
+
+```ts
+const value = {
+  ...wallet,
+  connected: wallet.isConnected,
+}
+```
+
+Use `isConnected` for new code. The `connected` alias exists for legacy route
+consumers such as `Dashboard`.
+
+## `useWallet` Return Shape
+
+Consumers import `useWallet` from `src/context/WalletContext.tsx`.
+
+| Field          | Type                  | Meaning                                                                                        |
+| -------------- | --------------------- | ---------------------------------------------------------------------------------------------- |
+| `address`      | `string`              | Connected Stellar public key, or an empty string while disconnected.                           |
+| `isConnected`  | `boolean`             | `true` when `address` is non-empty.                                                            |
+| `connected`    | `boolean`             | Legacy alias for `isConnected` exposed by `WalletProvider`.                                    |
+| `isConnecting` | `boolean`             | `true` while a Freighter connection request is in flight.                                      |
+| `error`        | `WalletError \| null` | Last wallet error captured by the hook.                                                        |
+| `connect`      | `() => Promise<void>` | Requests Freighter access, validates the selected network, and starts the wallet watcher.      |
+| `disconnect`   | `() => void`          | Stops the wallet watcher and clears local wallet state.                                        |
+| `network`      | `'public' \| 'test'`  | Credence network selected in settings. Any setting other than `'test'` resolves to `'public'`. |
+
+`WalletError.code` is one of:
+
+- `not_installed`
+- `rejected`
+- `network_mismatch`
+- `unknown`
+
+The hook does not throw wallet errors to callers. It stores failures in `error`
+and leaves `address` empty when a connection cannot be used.
+
+The current source does not expose a single `status` string. When a component
+needs a status label, derive it from the returned fields:
+
+| Derived status | Condition                                                           |
+| -------------- | ------------------------------------------------------------------- |
+| `connecting`   | `isConnecting === true`                                             |
+| `connected`    | `isConnecting === false && isConnected === true`                    |
+| `error`        | `isConnecting === false && error !== null`                          |
+| `disconnected` | `isConnecting === false && isConnected === false && error === null` |
+
+## Consuming The Hook
+
+Use the shared context hook in route components rather than importing the lower
+level hook directly.
+
+```tsx
+import { useWallet } from '../context/WalletContext'
+
+function WalletGatedAction() {
+  const { isConnected, isConnecting, address, error, connect, disconnect } = useWallet()
+
+  if (!isConnected) {
+    return (
+      <Button type="button" disabled={isConnecting} onClick={() => void connect()}>
+        {isConnecting ? 'Connecting...' : 'Connect wallet'}
+      </Button>
+    )
+  }
+
+  return (
+    <div>
+      <code>{address}</code>
+      {error && <p role="alert">{error.message}</p>}
+      <Button type="button" variant="secondary" onClick={disconnect}>
+        Disconnect
+      </Button>
+    </div>
+  )
+}
+```
+
+For route actions, follow the existing `Bond` and `TrustScore` pattern: if the
+wallet is disconnected, call `connect()` and return before continuing the
+protected action.
+
+## Freighter Client Wrapper
+
+`src/lib/freighterClient.ts` is the only module that talks directly to
+`@stellar/freighter-api`.
+
+| Function                        | Behavior                                                                                                                                  |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `checkFreighterInstalled()`     | Lazily imports Freighter and checks `isConnected()`. Returns `false` when running outside the browser or when Freighter reports an error. |
+| `requestFreighterAccess()`      | Calls `requestAccess()` and normalizes success, not-installed, rejected, and unknown failures into a discriminated result.                |
+| `fetchFreighterAddress()`       | Uses `isAllowed()` and `getAddress()` to restore an existing allowed wallet session.                                                      |
+| `fetchFreighterNetwork()`       | Calls `getNetwork()` and maps Freighter's network string into Credence's `'public'` or `'test'` values.                                   |
+| `createWalletWatcher(onChange)` | Starts `WatchWalletChanges`, maps the next network, and returns a `stop()` handle.                                                        |
+| `mapFreighterNetwork(network)`  | Maps strings containing `TEST` to `'test'`, strings containing `PUBLIC` or `MAIN` to `'public'`, and unknown names to `null`.             |
+| `resetFreighterModuleCache()`   | Clears the lazy module cache for tests only.                                                                                              |
+
+`FREIGHTER_INSTALL_URL` points to `https://www.freighter.app/` for UI that wants
+to link users to the extension install page.
+
+## Connection State Machine
+
+The hook's state is derived from `address`, `isConnecting`, and `error`.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Disconnected
+  Disconnected --> Connecting: connect()
+  Connecting --> Connected: requestAccess ok + network matches
+  Connecting --> NotInstalled: Freighter missing
+  Connecting --> Rejected: user rejects access
+  Connecting --> NetworkMismatch: Freighter network differs from settings
+  Connecting --> UnknownError: unexpected failure
+  Connected --> Disconnected: disconnect()
+  Connected --> NetworkMismatch: settings or Freighter network changes
+  Connected --> Connected: WatchWalletChanges updates address
+  NotInstalled --> Connecting: retry connect()
+  Rejected --> Connecting: retry connect()
+  NetworkMismatch --> Connecting: switch network or settings, then retry
+  UnknownError --> Connecting: retry connect()
+```
+
+State details:
+
+- **Disconnected**: `address === ''`, `isConnected === false`, and no connect
+  request is active.
+- **Connecting**: `isConnecting === true`. The hook clears `error` before it
+  starts checking Freighter.
+- **Connected**: `address` has the Stellar public key returned by Freighter and
+  `isConnected === true`.
+- **Not installed**: `error.code === 'not_installed'` and the message is
+  `Freighter extension was not detected.` or `Freighter is not available in this environment.`
+- **Rejected**: `error.code === 'rejected'`; `requestFreighterAccess()` detects
+  rejection, denied, or cancelled messages from Freighter.
+- **Network mismatch**: `error.code === 'network_mismatch'`; the hook clears the
+  address during connect and keeps the error visible if an already connected
+  wallet later differs from the settings network.
+- **Unknown**: `error.code === 'unknown'`; used when Freighter returns no address
+  or an unexpected exception occurs.
+
+On mount, the hook attempts to restore an allowed Freighter session with
+`fetchFreighterAddress()`. If the restored wallet passes network validation, it
+sets `address` and starts the wallet watcher. Cleanup cancels the restore path
+and stops the watcher.
+
+## UX Contract
+
+Wallet-dependent UI should gate the action, not the entire page, unless the
+route has no useful disconnected state.
+
+### Disconnected
+
+- Show an action-oriented warning or empty state with a `Connect wallet` button.
+- Keep explanatory content visible so users understand why the wallet is needed.
+- When a protected action is clicked, call `connect()` and stop the original
+  action until a wallet is connected.
+
+Current examples:
+
+- `Bond` shows a warning banner and changes bond actions to `Connect wallet to continue` or `Connect wallet to withdraw`.
+- `TrustScore` shows a warning banner and uses `Connect wallet to continue` for the lookup button while still allowing address entry.
+- `Dashboard` shows a wallet-required empty state before rendering wallet-backed dashboard cards.
+
+### Connecting
+
+- Treat `isConnecting` as a pending state for the connect request.
+- Avoid firing duplicate protected actions while the connect request is active.
+- `Dashboard` currently renders a dashboard loading skeleton while the wallet is
+  connecting.
+
+### Freighter Not Installed
+
+- Use `error.code === 'not_installed'` to present an install or retry path.
+- The current hook message is `Freighter extension was not detected.` when the
+  browser extension check fails.
+- Link to `FREIGHTER_INSTALL_URL` when the surface has room for an install link.
+
+### Rejected
+
+- Use `error.code === 'rejected'` to let users retry without treating the failure
+  as fatal.
+- Do not continue signing, bonding, or lookup flows after a rejected connection.
+
+### Network Mismatch
+
+- Use `error.code === 'network_mismatch'` to tell users whether Credence expects
+  Mainnet or Testnet.
+- The hook compares `fetchFreighterNetwork()` with the settings network from
+  `SettingsContext`.
+- The source message tells users to update Settings or switch the Freighter
+  network. Keep future UI copy aligned with that recovery path.
+
+### Connected
+
+- Read `address` from the hook for the connected Stellar public key.
+- Use shared display utilities such as `truncateAddress()` when a compact wallet
+  presentation is needed.
+- Keep signing and contract calls behind explicit user actions; the hook only
+  connects and watches the wallet.
+
+## Implementation Notes
+
+- The lower-level hook is browser-safe: it returns early when `window` is
+  unavailable.
+- The Freighter module is imported lazily so server-like test environments do not
+  load the browser extension package.
+- `createWalletWatcher()` updates the address and clears stale errors when
+  Freighter emits wallet changes.
+- `disconnect()` clears local state only; it does not revoke Freighter
+  permissions.
+- The current wallet layer manages connection state only. Real contract reads,
+  writes, and typed backend requests still belong behind the `src/api/` seam
+  described in `ARCHITECTURE.md`.


### PR DESCRIPTION
## Summary

- add `docs/WALLET_INTEGRATION.md` documenting the current wallet provider boundary, `useWallet` return shape, derived connection status, Freighter wrapper, and connection state machine
- document the disconnected, connecting, not-installed, rejected, network-mismatch, and connected UX contracts from the current route implementations
- link the wallet reference from `docs/README.md`
- cross-link the wallet reference from `docs/ARCHITECTURE.md` where `WalletProvider` is described

Closes #326.

## Validation

- `npx prettier --check docs/WALLET_INTEGRATION.md docs/README.md docs/ARCHITECTURE.md` passed.
- `git diff --check -- docs/WALLET_INTEGRATION.md docs/README.md docs/ARCHITECTURE.md` passed.
- Manual source/link check passed for `src/context/WalletContext.tsx`, `src/hooks/useWallet.ts`, `src/lib/freighterClient.ts`, `src/pages/Bond.tsx`, `src/pages/TrustScore.tsx`, `src/pages/Dashboard.tsx`, `docs/README.md`, and `docs/ARCHITECTURE.md`.
- `npm run format:check` was run and still fails on existing formatting drift outside this PR. The changed wallet docs files pass the targeted Prettier check above.

No runtime behavior changes.
