### PR TITLE
refactor(hooks): add reusable clipboard copy hook

### DIFF
--- a/src/components/AddressInput.tsx
+++ b/src/components/AddressInput.tsx
@@ -1,7 +1,8 @@
-import React, { useState, useRef, useCallback } from 'react'
+import React, { useState, useRef } from 'react'
 import { FormField } from './forms/FormField'
 import './AddressInput.css'
 import { isValidStellarAddress, truncateAddress } from '@/lib/stellar'
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
 
 export interface AddressInputProps {
   /** Input id forwarded to FormField for label and description wiring. */
@@ -118,7 +119,7 @@ export default function AddressInput({
 
   const [focused, setFocused] = useState(false)
   const [attempted, setAttempted] = useState(false)
-  const [copied, setCopied] = useState(false)
+  const { copied, copyToClipboard } = useCopyToClipboard()
 
   const isValid = isValidStellarAddress(value)
   const isEmpty = !value
@@ -169,15 +170,9 @@ export default function AddressInput({
     }
   }
 
-  const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(value)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    } catch {
-      // Clipboard API tidak tersedia — fallback diam
-    }
-  }, [value])
+  const handleCopy = async () => {
+    await copyToClipboard(value)
+  }
 
   const error = showError
     ? 'Invalid address. Stellar public keys are 56 characters starting with G.'

--- a/src/hooks/useCopyToClipboard.test.ts
+++ b/src/hooks/useCopyToClipboard.test.ts
@@ -1,0 +1,86 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useCopyToClipboard } from './useCopyToClipboard'
+
+describe('useCopyToClipboard', () => {
+  const originalClipboard = navigator.clipboard
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: originalClipboard,
+    })
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('writes text to the clipboard and resets copied state after the delay', async () => {
+    vi.useFakeTimers()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+
+    const { result } = renderHook(() => useCopyToClipboard({ resetDelay: 500 }))
+
+    await act(async () => {
+      const copied = await result.current.copyToClipboard('GCREDENCE')
+      expect(copied).toBe(true)
+    })
+
+    expect(writeText).toHaveBeenCalledWith('GCREDENCE')
+    expect(result.current.copied).toBe(true)
+    expect(result.current.error).toBeNull()
+
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(result.current.copied).toBe(false)
+  })
+
+  it('returns false and records an error when clipboard writing is unavailable', async () => {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: undefined,
+    })
+
+    const { result } = renderHook(() => useCopyToClipboard())
+
+    await act(async () => {
+      const copied = await result.current.copyToClipboard('GCREDENCE')
+      expect(copied).toBe(false)
+    })
+
+    expect(result.current.copied).toBe(false)
+    expect(result.current.error?.message).toMatch(/not available/i)
+  })
+
+  it('surfaces rejected clipboard writes and allows manual reset', async () => {
+    vi.useFakeTimers()
+    const denied = new DOMException('denied', 'NotAllowedError')
+    const writeText = vi.fn().mockRejectedValue(denied)
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+
+    const { result } = renderHook(() => useCopyToClipboard({ resetDelay: 500 }))
+
+    await act(async () => {
+      const copied = await result.current.copyToClipboard('GCREDENCE')
+      expect(copied).toBe(false)
+    })
+
+    expect(result.current.copied).toBe(false)
+    expect(result.current.error?.message).toBe(denied.message)
+
+    act(() => {
+      result.current.reset()
+    })
+
+    expect(result.current.copied).toBe(false)
+    expect(result.current.error).toBeNull()
+  })
+})

--- a/src/hooks/useCopyToClipboard.ts
+++ b/src/hooks/useCopyToClipboard.ts
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+export const DEFAULT_COPY_RESET_DELAY = 2000
+
+export interface UseCopyToClipboardOptions {
+  resetDelay?: number
+}
+
+export interface UseCopyToClipboardResult {
+  copied: boolean
+  error: Error | null
+  copyToClipboard: (text: string) => Promise<boolean>
+  reset: () => void
+}
+
+function createClipboardError(message: string): Error {
+  return new Error(message)
+}
+
+function normalizeClipboardError(caughtError: unknown): Error {
+  if (caughtError instanceof Error) {
+    return caughtError
+  }
+
+  if (
+    typeof caughtError === 'object' &&
+    caughtError !== null &&
+    'message' in caughtError &&
+    typeof caughtError.message === 'string'
+  ) {
+    return createClipboardError(caughtError.message)
+  }
+
+  return createClipboardError('Clipboard copy failed.')
+}
+
+export function useCopyToClipboard({
+  resetDelay = DEFAULT_COPY_RESET_DELAY,
+}: UseCopyToClipboardOptions = {}): UseCopyToClipboardResult {
+  const [copied, setCopied] = useState(false)
+  const [error, setError] = useState<Error | null>(null)
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const clearResetTimer = useCallback(() => {
+    if (resetTimerRef.current !== null) {
+      clearTimeout(resetTimerRef.current)
+      resetTimerRef.current = null
+    }
+  }, [])
+
+  const reset = useCallback(() => {
+    clearResetTimer()
+    setCopied(false)
+    setError(null)
+  }, [clearResetTimer])
+
+  const copyToClipboard = useCallback(
+    async (text: string) => {
+      clearResetTimer()
+
+      if (
+        typeof navigator === 'undefined' ||
+        typeof navigator.clipboard?.writeText !== 'function'
+      ) {
+        setCopied(false)
+        setError(createClipboardError('Clipboard copy is not available in this browser.'))
+        return false
+      }
+
+      try {
+        await navigator.clipboard.writeText(text)
+        setCopied(true)
+        setError(null)
+
+        if (resetDelay > 0) {
+          resetTimerRef.current = setTimeout(() => {
+            setCopied(false)
+            resetTimerRef.current = null
+          }, resetDelay)
+        }
+
+        return true
+      } catch (caughtError) {
+        setCopied(false)
+        setError(normalizeClipboardError(caughtError))
+        return false
+      }
+    },
+    [clearResetTimer, resetDelay]
+  )
+
+  useEffect(() => clearResetTimer, [clearResetTimer])
+
+  return {
+    copied,
+    error,
+    copyToClipboard,
+    reset,
+  }
+}


### PR DESCRIPTION
## Summary

- Add `useCopyToClipboard` as a shared hook for clipboard write state.
- Move `AddressInput`'s copy-to-clipboard success state and reset timer onto the hook.
- Cover successful writes, unavailable Clipboard API, rejected writes, manual reset, and the existing `AddressInput` clipboard behavior with tests.

Closes #313.

## Verification

- `npm run test -- src/hooks/useCopyToClipboard.test.ts src/components/AddressInput.test.tsx`
- `npx prettier --check src/hooks/useCopyToClipboard.ts src/hooks/useCopyToClipboard.test.ts src/components/AddressInput.tsx`
- `git diff --check -- src/hooks/useCopyToClipboard.ts src/hooks/useCopyToClipboard.test.ts src/components/AddressInput.tsx`

Note: the targeted test command emits the existing duplicate `test:watch` warning from `package.json`, but all targeted tests pass.
