### PR TITLE
feat(amount): validate minimum bond threshold

### DIFF
--- a/src/components/AmountInput.test.tsx
+++ b/src/components/AmountInput.test.tsx
@@ -178,7 +178,9 @@ describe('AmountInput', () => {
       const input = screen.getByRole('textbox')
       const errorId = input.getAttribute('aria-describedby')
       expect(errorId).toBeTruthy()
-      expect(document.getElementById(errorId!)).toHaveTextContent('Amount exceeds available balance.')
+      expect(document.getElementById(errorId!)).toHaveTextContent(
+        'Amount exceeds available balance.'
+      )
     })
 
     it('explicit error prop overrides the internal over-balance error', () => {
@@ -196,6 +198,35 @@ describe('AmountInput', () => {
       renderInput({ value: '1.00', balance: 0 })
       expect(screen.getByRole('button', { name: /set max amount/i })).toBeDisabled()
       expect(screen.getByRole('alert')).toHaveTextContent('Amount exceeds available balance.')
+    })
+  })
+
+  describe('minimum amount validation', () => {
+    it('shows an accessible below-minimum error when value is less than minAmount', () => {
+      renderInput({ value: '25.00', balance: 1000, minAmount: 50 })
+      expect(screen.getByRole('alert')).toHaveTextContent('Minimum bond amount is 50.00 USDC.')
+      expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true')
+    })
+
+    it('does not show a below-minimum error when value equals minAmount', () => {
+      renderInput({ value: '50.00', balance: 1000, minAmount: 50 })
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+
+    it('does not show a below-minimum error for empty values', () => {
+      renderInput({ value: '', balance: 1000, minAmount: 50 })
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+
+    it('keeps explicit error prop ahead of the below-minimum error', () => {
+      renderInput({
+        value: '25.00',
+        balance: 1000,
+        minAmount: 50,
+        error: 'Server-side minimum changed',
+      })
+      expect(screen.getByRole('alert')).toHaveTextContent('Server-side minimum changed')
+      expect(screen.queryByText('Minimum bond amount is 50.00 USDC.')).not.toBeInTheDocument()
     })
   })
 
@@ -221,6 +252,18 @@ describe('AmountInput', () => {
     it('calls onValidityChange(true) when value is empty', () => {
       const onValidityChange = vi.fn()
       renderInput({ value: '', balance: 100, onValidityChange })
+      expect(onValidityChange).toHaveBeenCalledWith(true)
+    })
+
+    it('calls onValidityChange(false) when value is below minAmount', () => {
+      const onValidityChange = vi.fn()
+      renderInput({ value: '25.00', balance: 100, minAmount: 50, onValidityChange })
+      expect(onValidityChange).toHaveBeenCalledWith(false)
+    })
+
+    it('calls onValidityChange(true) when value meets minAmount', () => {
+      const onValidityChange = vi.fn()
+      renderInput({ value: '50.00', balance: 100, minAmount: 50, onValidityChange })
       expect(onValidityChange).toHaveBeenCalledWith(true)
     })
   })

--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -14,6 +14,8 @@ export interface AmountInputProps extends NativeInputProps {
   onChange: (value: string) => void
   /** Available balance used by the Max button, preset disabled states, and over-balance validation. */
   balance: number
+  /** Optional minimum amount required for a valid bond. */
+  minAmount?: number
   /** Quick-select amounts rendered below the input. */
   presets?: number[]
   /** Currency label shown as the input adornment and in button labels. */
@@ -35,6 +37,7 @@ export default function AmountInput({
   value,
   onChange,
   balance,
+  minAmount,
   presets = [100, 500, 1000],
   currencyLabel = 'USDC',
   error,
@@ -58,15 +61,23 @@ export default function AmountInput({
   }, [value])
 
   const isOverBalance = numericValue > 0 && numericValue > balance
+  const isBelowMinimum =
+    minAmount !== undefined && minAmount > 0 && numericValue > 0 && numericValue < minAmount
 
   // Explicit `error` prop always wins; internal over-balance is the fallback.
-  const activeError = error ?? (isOverBalance ? 'Amount exceeds available balance.' : undefined)
+  const activeError =
+    error ??
+    (isOverBalance
+      ? 'Amount exceeds available balance.'
+      : isBelowMinimum
+        ? `Minimum bond amount is ${formatUSDC(minAmount.toFixed(2))} ${currencyLabel}.`
+        : undefined)
   const isInvalid = Boolean(activeError) || ariaInvalid === 'true'
 
   // Notify caller when internal validity changes.
   useEffect(() => {
-    onValidityChange?.(!isOverBalance)
-  }, [isOverBalance, onValidityChange])
+    onValidityChange?.(!isOverBalance && !isBelowMinimum)
+  }, [isBelowMinimum, isOverBalance, onValidityChange])
 
   const displayValue = useMemo(() => {
     if (isFocused) return value
@@ -96,9 +107,8 @@ export default function AmountInput({
   const maxDisabled = balance <= 0
 
   // Merge any caller-supplied aria-describedby with our internal error id.
-  const describedBy = [ariaDescribedBy, activeError ? errorId : undefined]
-    .filter(Boolean)
-    .join(' ') || undefined
+  const describedBy =
+    [ariaDescribedBy, activeError ? errorId : undefined].filter(Boolean).join(' ') || undefined
 
   return (
     <div className="amountInput" data-invalid={isInvalid ? 'true' : 'false'}>


### PR DESCRIPTION
## Summary

- Add an optional `minAmount` prop to `AmountInput`.
- Surface an accessible below-minimum validation message when a positive amount is below the configured minimum bond threshold.
- Keep explicit `error` props higher priority than internal minimum/balance validation.
- Include `minAmount` in `onValidityChange` so callers can gate submission without duplicating validation logic.

Closes #307.

## Verification

- `npm run test -- src/components/AmountInput.test.tsx`
- `npx prettier --check src/components/AmountInput.tsx src/components/AmountInput.test.tsx`
- `git diff --check -- src/components/AmountInput.tsx src/components/AmountInput.test.tsx`

Note: the targeted test command emits the existing duplicate `test:watch` warning from `package.json`, but all targeted tests pass.
