### PR TITLE
feat(address-input): flag connected wallet lookups

### DIFF
--- a/src/components/AddressInput.css
+++ b/src/components/AddressInput.css
@@ -152,6 +152,21 @@
   word-break: break-all;
 }
 
+.address-input-self-note {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 0 var(--credence-space-2);
+  border: 1px solid var(--credence-border-default);
+  border-radius: var(--credence-radius-sm);
+  background: var(--credence-surface-page);
+  color: var(--credence-text-secondary);
+  font-size: var(--credence-font-size-xs);
+  font-weight: var(--credence-font-weight-semibold);
+  line-height: var(--credence-line-height-tight);
+  white-space: nowrap;
+}
+
 /**
  * Copy button: appears inside echo bar, copies full address to clipboard
  */

--- a/src/components/AddressInput.test.tsx
+++ b/src/components/AddressInput.test.tsx
@@ -148,6 +148,40 @@ describe('conditional rendering', () => {
     expect(code?.textContent).toBe(truncateAddress(VALID_KEY))
   })
 
+  it('labels a valid self address as the connected wallet without using the error region', async () => {
+    const user = userEvent.setup()
+    render(
+      <AddressInput
+        id="addr"
+        value={VALID_KEY}
+        selfAddress={VALID_KEY.toLowerCase()}
+        onChange={vi.fn()}
+      />
+    )
+
+    await user.click(screen.getByRole('textbox'))
+    await user.tab()
+
+    expect(screen.getByText('This is your connected wallet')).toBeInTheDocument()
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('does not label invalid or disconnected addresses as self matches', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <AddressInput id="addr" value="bad" selfAddress={VALID_KEY} onChange={vi.fn()} />
+    )
+
+    await user.click(screen.getByRole('textbox'))
+    await user.tab()
+    expect(screen.queryByText('This is your connected wallet')).toBeNull()
+
+    rerender(<AddressInput id="addr" value={VALID_KEY} onChange={vi.fn()} />)
+    await user.click(screen.getByRole('textbox'))
+    await user.tab()
+    expect(screen.queryByText('This is your connected wallet')).toBeNull()
+  })
+
   it('shows character count while there is input', () => {
     render(<AddressInput id="addr" value="GABC" onChange={vi.fn()} />)
     // Use querySelector on the specific count element to avoid matching ancestor nodes

--- a/src/components/AddressInput.tsx
+++ b/src/components/AddressInput.tsx
@@ -14,6 +14,8 @@ export interface AddressInputProps {
   onChange: (value: string) => void
   /** Receives the current 56-character Stellar public key validation state. */
   onValidationChange?: (isValid: boolean) => void
+  /** Connected Stellar public key used to label a valid self lookup. */
+  selfAddress?: string
   /** Disables both the text input and paste button. */
   disabled?: boolean
   /** Additional class names appended to the wrapper. */
@@ -111,6 +113,7 @@ export default function AddressInput({
   value,
   onChange,
   onValidationChange,
+  selfAddress,
   disabled = false,
   className = '',
 }: AddressInputProps) {
@@ -124,6 +127,10 @@ export default function AddressInput({
   const isEmpty = !value
   const showError = attempted && !isValid && !isEmpty
   const showSuccess = attempted && isValid
+  const isSelfAddress =
+    showSuccess &&
+    Boolean(selfAddress) &&
+    value.trim().toUpperCase() === selfAddress?.trim().toUpperCase()
 
   // Notify parent of validation state change
   React.useEffect(() => {
@@ -206,6 +213,9 @@ export default function AddressInput({
         <div className="address-input-echo">
           <span className="address-input-echo-label">Recognized:</span>
           <code className="address-input-echo-value">{truncateAddress(value)}</code>
+          {isSelfAddress && (
+            <span className="address-input-self-note">This is your connected wallet</span>
+          )}
           <button
             type="button"
             onClick={handleCopy}

--- a/src/pages/TrustScore.test.tsx
+++ b/src/pages/TrustScore.test.tsx
@@ -86,6 +86,24 @@ describe('TrustScore', () => {
 
     expect(screen.getByRole('button', { name: /connect wallet to continue/i })).toBeInTheDocument()
   })
+
+  it('fills the lookup input with the connected wallet address', () => {
+    mockConnected = true
+    render(<TrustScore />)
+
+    fireEvent.click(screen.getByRole('button', { name: /use my address/i }))
+
+    expect(screen.getByRole('textbox')).toHaveValue(
+      'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+    )
+  })
+
+  it('hides the self-address shortcut while disconnected', () => {
+    mockConnected = false
+    render(<TrustScore />)
+
+    expect(screen.queryByRole('button', { name: /use my address/i })).toBeNull()
+  })
 })
 
 describe('TrustScore URL sync', () => {

--- a/src/pages/TrustScore.tsx
+++ b/src/pages/TrustScore.tsx
@@ -63,7 +63,7 @@ export default function TrustScore() {
         }
         return next
       },
-      { replace: true },
+      { replace: true }
     )
   }
 
@@ -176,6 +176,7 @@ export default function TrustScore() {
             value={address}
             onChange={handleAddressChange}
             onValidationChange={setIsAddressValid}
+            selfAddress={isConnected ? walletAddress : undefined}
           />
           {isConnected && walletAddress && (
             <Button
@@ -185,7 +186,7 @@ export default function TrustScore() {
               fullWidth
               className="trustScore__buttonRow"
             >
-              Use connected wallet
+              Use my address
             </Button>
           )}
           <Button


### PR DESCRIPTION
## Summary

- Add an optional `selfAddress` prop to `AddressInput` and label valid self-matches as "This is your connected wallet".
- Keep the self-match note informational and outside the error/alert region.
- Rename the Trust Score shortcut to "Use my address" and pass the connected wallet address into `AddressInput`.
- Cover self-match, disconnected behavior, and the Trust Score shortcut in targeted tests.

Fixes https://github.com/CredenceOrg/Credence-Frontend/issues/308.

## Verification

- `npm run test -- src/components/AddressInput.test.tsx src/pages/TrustScore.test.tsx`
  - 2 files passed
  - 35 tests passed
- `npx prettier --check src/components/AddressInput.tsx src/components/AddressInput.css src/components/AddressInput.test.tsx src/pages/TrustScore.tsx src/pages/TrustScore.test.tsx`
- `git diff --check -- src/components/AddressInput.tsx src/components/AddressInput.css src/components/AddressInput.test.tsx src/pages/TrustScore.tsx src/pages/TrustScore.test.tsx`

Note: the repository currently has unrelated local/lockfile noise after dependency installation; this PR only submits the five files listed above.
