### PR TITLE
test(lib): cover formatting helper edge cases

### DIFF
--- a/src/lib/format.test.ts
+++ b/src/lib/format.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { formatUsdc, normalizeUSDC, formatUSDC, formatUSDCDisplay, sanitizeUSDCInput } from './format'
+import {
+  formatUsdc,
+  normalizeUSDC,
+  formatUSDC,
+  formatUSDCDisplay,
+  sanitizeUSDCInput,
+} from './format'
 
 describe('formatUsdc', () => {
   it('formats numeric USDC amounts with suffix', () => {
@@ -13,6 +19,11 @@ describe('formatUsdc', () => {
     expect(formatUsdc(1234.567)).toBe('1,234.57 USDC')
     expect(formatUsdc(0.001)).toBe('0 USDC')
     expect(formatUsdc(0.01)).toBe('0.01 USDC')
+  })
+
+  it('pins the current display behavior for non-finite numeric inputs', () => {
+    expect(formatUsdc(Number.NaN)).toBe('NaN USDC')
+    expect(formatUsdc(Number.POSITIVE_INFINITY)).toBe('∞ USDC')
   })
 })
 
@@ -49,6 +60,12 @@ describe('normalizeUSDC', () => {
     expect(normalizeUSDC('')).toBe('')
     expect(normalizeUSDC('0')).toBe('0.00')
   })
+
+  it('rejects non-finite numeric strings', () => {
+    expect(normalizeUSDC('Infinity')).toBe('')
+    expect(normalizeUSDC('-Infinity')).toBe('')
+    expect(normalizeUSDC('NaN')).toBe('')
+  })
 })
 
 describe('formatUSDC', () => {
@@ -81,6 +98,13 @@ describe('formatUSDC', () => {
     expect(formatUSDC('1000000')).toBe('1,000,000.00')
     expect(formatUSDC('1000000000')).toBe('1,000,000,000.00')
   })
+
+  it('keeps non-finite and empty input available for manual correction', () => {
+    expect(formatUSDC('Infinity')).toBe('Infinity')
+    expect(formatUSDC('-Infinity')).toBe('-Infinity')
+    expect(formatUSDC('NaN')).toBe('NaN')
+    expect(formatUSDC('')).toBe('')
+  })
 })
 
 describe('formatUSDCDisplay', () => {
@@ -91,8 +115,8 @@ describe('formatUSDCDisplay', () => {
   })
 
   it('behaves identically to formatUSDC', () => {
-    const testCases = ['1234.5', '1000', '0.01', '1000000', 'abc', '']
-    testCases.forEach(testCase => {
+    const testCases = ['1234.5', '1000', '0.01', '1000000', 'abc', '', 'Infinity', 'NaN']
+    testCases.forEach((testCase) => {
       expect(formatUSDCDisplay(testCase)).toBe(formatUSDC(testCase))
     })
   })
@@ -133,6 +157,11 @@ describe('sanitizeUSDCInput', () => {
   it('handles multiple decimals by using first one', () => {
     expect(sanitizeUSDCInput('12.34.56')).toBe('12.34')
     expect(sanitizeUSDCInput('100..00')).toBe('100.00')
+  })
+
+  it('preserves a trailing decimal while users are still typing', () => {
+    expect(sanitizeUSDCInput('100.')).toBe('100.')
+    expect(sanitizeUSDCInput('.50')).toBe('0.50')
   })
 
   it('handles negative values by stripping minus sign', () => {

--- a/src/lib/stellar.test.ts
+++ b/src/lib/stellar.test.ts
@@ -8,7 +8,9 @@ describe('isValidStellarAddress', () => {
   it('returns true for valid Stellar public keys', () => {
     expect(isValidStellarAddress(VALID_KEY)).toBe(true)
     // Another valid key
-    expect(isValidStellarAddress('GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H')).toBe(true)
+    expect(isValidStellarAddress('GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H')).toBe(
+      true
+    )
   })
 
   it('returns false for empty strings', () => {
@@ -23,19 +25,34 @@ describe('isValidStellarAddress', () => {
 
   it('returns false for malformed keys', () => {
     // Wrong prefix
-    expect(isValidStellarAddress('SAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA')).toBe(false)
+    expect(isValidStellarAddress('SAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA')).toBe(
+      false
+    )
     // Too short
     expect(isValidStellarAddress('GABC')).toBe(false)
     // Too long
     expect(isValidStellarAddress(VALID_KEY + 'EXTRA')).toBe(false)
     // Invalid characters
-    expect(isValidStellarAddress('GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNa')).toBe(false) // lowercase
-    expect(isValidStellarAddress('GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN!')).toBe(false) // special char
+    expect(isValidStellarAddress('GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNa')).toBe(
+      false
+    ) // lowercase
+    expect(isValidStellarAddress('GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN!')).toBe(
+      false
+    ) // special char
+  })
+
+  it('requires the address to already be trimmed', () => {
+    expect(isValidStellarAddress(` ${VALID_KEY}`)).toBe(false)
+    expect(isValidStellarAddress(`${VALID_KEY} `)).toBe(false)
   })
 
   it('returns false for wrong prefix', () => {
-    expect(isValidStellarAddress('TAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA')).toBe(false)
-    expect(isValidStellarAddress('MAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA')).toBe(false)
+    expect(isValidStellarAddress('TAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA')).toBe(
+      false
+    )
+    expect(isValidStellarAddress('MAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA')).toBe(
+      false
+    )
   })
 
   it('returns false for short keys', () => {
@@ -70,9 +87,16 @@ describe('truncateAddress', () => {
   it('handles exact threshold length addresses', () => {
     const exactly20 = 'G'.repeat(20)
     expect(truncateAddress(exactly20)).toBe(exactly20)
-    
+
     const exactly21 = 'G'.repeat(21)
     expect(truncateAddress(exactly21)).toBe(`${'G'.repeat(12)}...${'G'.repeat(8)}`)
+  })
+
+  it('trims surrounding whitespace before applying the length boundary', () => {
+    expect(truncateAddress(`  ${VALID_KEY}  `)).toBe(
+      `${VALID_KEY.substring(0, 12)}...${VALID_KEY.substring(VALID_KEY.length - 8)}`
+    )
+    expect(truncateAddress('  G1234567890123456789  ')).toBe('G1234567890123456789')
   })
 
   it('returns empty string for empty input', () => {
@@ -88,6 +112,8 @@ describe('truncateAddress', () => {
   it('preserves address casing', () => {
     const mixedCase = 'GaAzI4TcR3Ty5OjHcTjC2A4QsY6CjWjH5IaJtGkIn2Er7LbNvKoCcWnA'
     const truncated = truncateAddress(mixedCase)
-    expect(truncated).toBe(`${mixedCase.substring(0, 12)}...${mixedCase.substring(mixedCase.length - 8)}`)
+    expect(truncated).toBe(
+      `${mixedCase.substring(0, 12)}...${mixedCase.substring(mixedCase.length - 8)}`
+    )
   })
 })


### PR DESCRIPTION
## Summary

- Expand `src/lib/format.test.ts` coverage for USDC formatting edge cases:
  - non-finite numeric display behavior
  - non-finite string rejection/manual correction paths
  - `formatUSDCDisplay` parity with `formatUSDC`
  - trailing-decimal sanitize behavior while users are typing
- Expand `src/lib/stellar.test.ts` coverage for Stellar helper boundaries:
  - addresses with surrounding whitespace are invalid until trimmed by callers
  - truncation trims whitespace before applying the 20-character boundary
  - long-address casing is preserved after truncation

Fixes https://github.com/CredenceOrg/Credence-Frontend/issues/323.

## Verification

- `npm run test -- src/lib/format.test.ts src/lib/stellar.test.ts`
  - 2 files passed
  - 42 tests passed
- `npx prettier --check src/lib/format.test.ts src/lib/stellar.test.ts`
- `git diff --check -- src/lib/format.test.ts src/lib/stellar.test.ts`

I only tested helpers that exist in `src/lib`; there is no relative-time or explorer URL helper in the current tree.
