### PR TITLE
docs(state): add docs/STATE_MANAGEMENT.md mapping Settings/Toast/Wall…

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -6,12 +6,19 @@ This directory contains comprehensive design specifications and implementation g
 
 ### Available Documents
 
-1. **[Testing Guide](./TESTING.md)**
+1. **[State Management](./STATE_MANAGEMENT.md)** ⭐ NEW
+   - Overview of SettingsContext, WalletContext, and ToastProvider
+   - State shape, public hooks, and persistence mechanisms
+   - Provider nesting order (load-bearing dependencies)
+   - Decision guide: when to add new state vs. local vs. URL params
+   - Mock patterns for testing
+
+2. **[Testing Guide](./TESTING.md)**
    - How to run Vitest and generate coverage
    - Render helpers, router wrapper, and mock patterns for matchMedia / localStorage / clipboard
    - File naming conventions and coverage thresholds
 
-2. **Per-route document titles (`useDocumentTitle`)**
+3. **Per-route document titles (`useDocumentTitle`)**
    - `src/hooks/useDocumentTitle.ts` keeps `document.title` in sync with the active route
    - Each page sets a distinct, branded title (e.g. `Bond · Credence`); the 404 page uses `Page Not Found · Credence`
    - Why it matters: screen readers announce the title on navigation, and tabs, history, and bookmarks become distinguishable per page
@@ -26,27 +33,27 @@ This directory contains comprehensive design specifications and implementation g
    }
    ```
 
-3. **[Shared Components Catalog](./COMPONENTS.md)**
+4. **[Shared Components Catalog](./COMPONENTS.md)**
    - Consolidated props, accessibility notes, usage snippets, styling ownership, and `--credence-*` token references for shared UI components
    - Documents severity/variant vocabularies and cross-links focused component docs
 
-4. **[UI States Guide](./UI_STATES_GUIDE.md)**
+5. **[UI States Guide](./UI_STATES_GUIDE.md)**
    - Complete guide for empty states, error states, and loading patterns
    - Microcopy guidelines and tone recommendations
    - When and how to use each state type
    - Validation checklist
 
-5. **[Design Tokens](./DESIGN_TOKENS.md)**
+6. **[Design Tokens](./DESIGN_TOKENS.md)**
    - Canonical `--credence-*` CSS variable reference
    - Color, spacing, radius, typography, and motion scales
    - Guidance for replacing one-off hex values in components
 
-6. **[Motion Guidelines](./motion-guidelines.md)**
+7. **[Motion Guidelines](./motion-guidelines.md)**
    - Motion token strategy and reduced-motion defaults
    - Best practices for animation and transitions
    - Implementation examples for UI micro-interactions
 
-7. **[Figma Design Specs](./FIGMA_DESIGN_SPECS.md)**
+8. **[Figma Design Specs](./FIGMA_DESIGN_SPECS.md)**
    - Visual design specifications
    - Color palette and design tokens
    - Layout measurements and spacing
@@ -54,24 +61,24 @@ This directory contains comprehensive design specifications and implementation g
    - Responsive breakpoints
    - Component organization structure
 
-8. **[Implementation Examples](./IMPLEMENTATION_EXAMPLES.md)**
+9. **[Implementation Examples](./IMPLEMENTATION_EXAMPLES.md)**
    - Practical code examples for each page
    - Reusable hooks and patterns
    - Testing examples
    - Accessibility guidelines
    - Performance considerations
 
-9. **[Mobile Navigation Pattern](./mobile-navigation-pattern.md)** ⭐ NEW
-   - Hybrid responsive navigation (hamburger mobile + horizontal desktop)
-   - Complete implementation guide with code examples
-   - Accessibility requirements (WCAG 2.1 AA)
-   - Testing guide and troubleshooting
-   - [Decision Matrix](./mobile-navigation-DECISION.md) | [Reconnaissance Report](./mobile-nav-RECON.md) | [Figma Rules](./figma-nav-rules.md)
+10. **[Mobile Navigation Pattern](./mobile-navigation-pattern.md)** ⭐ NEW
+    - Hybrid responsive navigation (hamburger mobile + horizontal desktop)
+    - Complete implementation guide with code examples
+    - Accessibility requirements (WCAG 2.1 AA)
+    - Testing guide and troubleshooting
+    - [Decision Matrix](./mobile-navigation-DECISION.md) | [Reconnaissance Report](./mobile-nav-RECON.md) | [Figma Rules](./figma-nav-rules.md)
 
-9. **[Architecture Overview](./ARCHITECTURE.md)** ⭐ NEW
-   - Provider tree and routing architecture
-   - Context responsibilities
-   - Theming flow and mock data boundaries
+11. **[Architecture Overview](./ARCHITECTURE.md)** ⭐ NEW
+    - Provider tree and routing architecture
+    - Context responsibilities
+    - Theming flow and mock data boundaries
 
 ### Quick Start
 
@@ -186,6 +193,7 @@ sanitizeUSDCInput(nextValue: string): string
 ```
 
 **Usage Examples:**
+
 ```typescript
 import { formatUsdc, normalizeUSDC, formatUSDC, sanitizeUSDCInput } from '@/lib/format'
 
@@ -203,6 +211,7 @@ sanitizeUSDCInput('$1,000.50') // → "1000.50"
 ```
 
 **Behavior Preservation:**
+
 - Thousands separators maintained for display
 - Decimal precision fixed at 2 places
 - Empty values handled gracefully
@@ -224,6 +233,7 @@ truncateAddress(address: string | undefined | null): string
 ```
 
 **Usage Examples:**
+
 ```typescript
 import { isValidStellarAddress, truncateAddress } from '@/lib/stellar'
 
@@ -236,6 +246,7 @@ truncateAddress('GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA')
 ```
 
 **Behavior Preservation:**
+
 - Exact 56-character validation
 - 'G' prefix requirement
 - Uppercase alphanumeric characters only
@@ -248,6 +259,7 @@ truncateAddress('GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA')
 All components should now import from these centralized modules instead of maintaining local implementations:
 
 **Before:**
+
 ```typescript
 // In component files
 export function normalizeUSDC(rawValue: string) { ... }
@@ -255,6 +267,7 @@ export function isValidStellarAddress(address: string) { ... }
 ```
 
 **After:**
+
 ```typescript
 // Import from centralized modules
 import { normalizeUSDC } from '@/lib/format'
@@ -264,10 +277,12 @@ import { isValidStellarAddress } from '@/lib/stellar'
 ### Test Coverage
 
 Both utility modules have comprehensive test suites with ≥95% branch coverage:
+
 - `src/lib/format.test.ts` - USDC formatting tests
 - `src/lib/stellar.test.ts` - Stellar address tests
 
 Run tests with:
+
 ```bash
 npm test -- --run src/lib/format.test.ts src/lib/stellar.test.ts
 ```
@@ -277,7 +292,7 @@ npm test -- --run src/lib/format.test.ts src/lib/stellar.test.ts
 The following components have been refactored to use the centralized utilities:
 
 1. **AmountInput.tsx** - USDC input formatting and sanitization
-2. **AddressInput.tsx** - Stellar address validation and truncation  
+2. **AddressInput.tsx** - Stellar address validation and truncation
 3. **TrustScore.tsx** - Stellar address validation
 4. **useTrustScore.ts** - Stellar address validation
 5. **Bond.tsx** - USDC display formatting
@@ -288,6 +303,7 @@ The following components have been refactored to use the centralized utilities:
 ### Future Development
 
 When adding new formatting or validation logic:
+
 1. Check if it belongs in the centralized modules
 2. Add comprehensive test coverage
 3. Update this documentation

--- a/docs/STATE_MANAGEMENT.md
+++ b/docs/STATE_MANAGEMENT.md
@@ -1,0 +1,449 @@
+# State Management
+
+Credence Frontend uses three core context providers to manage shared client state. This guide explains what each context owns, how persistence works, the provider nesting order, and when to add new state.
+
+## Overview
+
+| Context      | File                               | Hook            | Persists                  | Scope                                                     |
+| ------------ | ---------------------------------- | --------------- | ------------------------- | --------------------------------------------------------- |
+| **Settings** | `src/context/SettingsContext.tsx`  | `useSettings()` | Yes (`credence:settings`) | Theme, network, address display, toast preferences        |
+| **Wallet**   | `src/context/WalletContext.tsx`    | `useWallet()`   | Session only              | Stellar wallet connection state and Freighter integration |
+| **Toast**    | `src/components/ToastProvider.tsx` | `useToast()`    | No                        | Notification queue and dismiss timers                     |
+
+---
+
+## 1. SettingsContext — User Preferences & Persistence
+
+**File:** [`src/context/SettingsContext.tsx`](../src/context/SettingsContext.tsx)
+
+### State Shape
+
+```typescript
+interface SettingsState {
+  // Theme mode: 'light', 'dark', or 'system' (respects OS preference)
+  themeMode: 'light' | 'dark' | 'system'
+
+  // Network: 'public' or 'test' (Stellar network)
+  network: string
+
+  // Address display: 'short' or other variants
+  addressDisplay: string
+
+  // Global toggle: enable/disable all toasts
+  toastsEnabled: boolean
+
+  // Auto-dismiss duration: '5s', 'off', or other duration strings
+  autoDismiss: string
+
+  // Flag: true if any field differs from saved state
+  hasUnsavedChanges: boolean
+
+  // Setters (update in-memory state without persisting yet)
+  setThemeMode(m: 'light' | 'dark' | 'system'): void
+  setNetwork(n: string): void
+  setAddressDisplay(s: string): void
+  setToastsEnabled(b: boolean): void
+  setAutoDismiss(s: string): void
+
+  // Persistence actions
+  saveSettings(): void // Persist all fields to localStorage
+  cancelSettings(): void // Discard changes, revert to last saved state
+}
+```
+
+### Public Hook
+
+```typescript
+const { themeMode, network, addressDisplay, toastsEnabled, autoDismiss, hasUnsavedChanges } =
+  useSettings()
+```
+
+### Persistence Mechanism
+
+**Storage key:** `credence:settings` in `localStorage`
+
+**Stored payload:**
+
+```json
+{
+  "themeMode": "light",
+  "network": "public",
+  "addressDisplay": "short",
+  "toastsEnabled": true,
+  "autoDismiss": "5s"
+}
+```
+
+**Load behavior:**
+
+- On mount, reads `credence:settings` from `localStorage`
+- If key does not exist or JSON parsing fails, falls back to defaults (no error thrown)
+- Defaults: `themeMode: 'system'`, `network: 'public'`, `addressDisplay: 'short'`, `toastsEnabled: true`, `autoDismiss: '5s'`
+
+**Save behavior:**
+
+- Call `saveSettings()` to persist current state to `localStorage`
+- Automatically persists on every field change (see [Sync Effect](#sync-effect))
+- Silently ignores write errors (quota exceeded, private browsing, etc.)
+
+### Theme Application
+
+The `themeMode` value is applied to the document root as `data-theme`:
+
+- When `themeMode === 'system'`: reads OS preference via `matchMedia('(prefers-color-scheme: dark)')` and sets `data-theme` to `'light'` or `'dark'`
+- When `themeMode === 'light'` or `'dark'`: sets `data-theme` directly
+- On OS preference change (only when `themeMode === 'system'`), re-evaluates and updates the DOM
+
+**Selector example:**
+
+```css
+[data-theme='light'] .button {
+  background: white;
+}
+[data-theme='dark'] .button {
+  background: #333;
+}
+```
+
+### Legacy Migration
+
+A one-time migration removes the orphaned `'theme'` localStorage key (from the legacy ThemeToggle component) to prevent conflicts.
+
+### Sync Effect
+
+```typescript
+useEffect(() => {
+  const payload = { themeMode, network, addressDisplay, toastsEnabled, autoDismiss }
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
+}, [themeMode, network, addressDisplay, toastsEnabled, autoDismiss])
+```
+
+This effect runs whenever _any_ setting changes, ensuring the saved state stays in sync with in-memory state.
+
+---
+
+## 2. WalletContext — Stellar Wallet Connection
+
+**File:** [`src/context/WalletContext.tsx`](../src/context/WalletContext.tsx)
+**Hook implementation:** [`src/hooks/useWallet.ts`](../src/hooks/useWallet.ts)
+
+### State Shape
+
+```typescript
+interface WalletContextValue {
+  // Connected Stellar public key (56-char address starting with 'G'), or empty string
+  address: string
+
+  // True when a wallet address is available
+  isConnected: boolean
+
+  // Legacy alias for isConnected (kept for backward compatibility)
+  connected: boolean
+
+  // True while a connect request is in flight
+  isConnecting: boolean
+
+  // Last connection error, if any; null otherwise
+  error: WalletError | null
+
+  // Request Freighter access and store the returned public key
+  connect(): Promise<void>
+
+  // Clear the local wallet session (does not disconnect Freighter)
+  disconnect(): void
+
+  // Active Credence network from settings ('public' or 'test')
+  network: CredenceNetwork
+}
+
+interface WalletError {
+  code: 'not_installed' | 'rejected' | 'network_mismatch' | 'unknown'
+  message: string
+}
+```
+
+### Public Hook
+
+```typescript
+const { address, isConnected, connected, isConnecting, error, connect, disconnect, network } =
+  useWallet()
+```
+
+### Wallet Integration
+
+The wallet context wraps the `useWallet()` hook from `src/hooks/useWallet.ts`, which manages Freighter browser extension integration:
+
+- **On mount:** restores the previous session if available (reads from Freighter's storage)
+- **`connect()`:** requests Freighter access, verifies network matches Credence settings, starts a watcher for address changes
+- **`disconnect()`:** clears local session (does not uninstall or disconnect Freighter)
+- **Network mismatch:** if Freighter is on Mainnet but Credence is set to Testnet (or vice versa), sets an error and prevents connection
+- **Error handling:** catches missing extension, user rejection, network mismatch, and unknown errors
+
+### Network Synchronization
+
+The `network` field is read from `useSettings()` at provider initialization. When the user changes `network` in Settings, the wallet verifies that Freighter is on the same network:
+
+```typescript
+const { network } = useSettings() // From SettingsContext
+const wallet = useWallet(network) // Passed to hook
+```
+
+If there is a mismatch, `error.code === 'network_mismatch'` and the user must either:
+
+- Switch Freighter to the correct network, or
+- Change the Credence network setting to match Freighter
+
+---
+
+## 3. ToastProvider — Notification Queue
+
+**File:** [`src/components/ToastProvider.tsx`](../src/components/ToastProvider.tsx)
+
+### State Shape
+
+```typescript
+type ToastSeverity = 'info' | 'success' | 'warning' | 'danger'
+
+interface ToastData {
+  id: string // Unique identifier
+  severity: ToastSeverity // Message type
+  message: string // User-facing text
+}
+
+interface ToastContextValue {
+  // Add a toast to the queue
+  addToast(severity: ToastSeverity, message: string): void
+
+  // Remove a toast by ID
+  removeToast(id: string): void
+
+  // Clear all toasts
+  removeAllToasts(): void
+}
+```
+
+### Public Hook
+
+```typescript
+const { addToast, removeToast, removeAllToasts } = useToast()
+
+// Usage
+addToast('success', 'Bond created')
+addToast('warning', 'Network slow')
+addToast('danger', 'Connection failed')
+```
+
+### Toast Behavior
+
+**Queueing:**
+
+- Maximum 3 toasts displayed at once
+- When a 4th is added, the oldest is removed (FIFO)
+
+**Auto-dismiss:**
+
+- Default timeouts per severity:
+  - `info`: 5 seconds
+  - `success`: 5 seconds
+  - `warning`: 8 seconds
+  - `danger`: 0 seconds (manual dismiss only)
+- Can be overridden by the `autoDismiss` setting from `useSettings()`
+
+**Auto-dismiss override:**
+
+- `autoDismiss === 'off'`: all toasts stay until manually dismissed
+- `autoDismiss === '10s'`: all toasts (except `danger`) dismiss after 10 seconds
+- Parsed as a duration string with format `'Xs'` (e.g., `'3s'`, `'15s'`)
+
+**Accessibility:**
+
+- Polite toasts (`info`, `success`, `warning`) are announced in a `aria-live="polite"` region when the screen reader is idle
+- Danger toasts are announced in a `aria-live="assertive"` region and interrupt immediately
+
+**Settings Dependency:**
+
+- Reads `toastsEnabled` and `autoDismiss` from `useSettings()`
+- If `toastsEnabled === false`, `addToast()` is a no-op (no toast is queued)
+- Uses a ref to avoid recreating `addToast` on every setting change
+
+---
+
+## Provider Nesting Order
+
+The provider tree is composed in `src/App.tsx`. **The nesting order is load-bearing.**
+
+```typescript
+<BrowserRouter>
+  <SettingsProvider>
+    <WalletProvider>
+      <ToastProvider>
+        <ErrorBoundary>
+          <Suspense>
+            <Routes>…</Routes>
+          </Suspense>
+        </ErrorBoundary>
+      </ToastProvider>
+    </WalletProvider>
+  </SettingsProvider>
+</BrowserRouter>
+```
+
+**Why this order matters:**
+
+1. **SettingsProvider must be outermost** — both WalletProvider and ToastProvider depend on it:
+   - `ToastProvider` calls `useSettings()` to read `toastsEnabled` and `autoDismiss`
+   - `WalletProvider` calls `useSettings()` to read the current `network`
+
+2. **WalletProvider before ToastProvider** — wallet connection logic should initialize before toast subscriptions
+
+3. **ToastProvider wraps ErrorBoundary and routes** — ensures toasts can be displayed from any page or component
+
+---
+
+## When to Add New State
+
+### Decision Matrix
+
+Use this checklist to decide where new state should live:
+
+| Case                                             | Solution                                                          |
+| ------------------------------------------------ | ----------------------------------------------------------------- |
+| **Needs to persist across sessions?**            | Add to `SettingsContext`                                          |
+| **User preference (theme, language, locale)?**   | Add to `SettingsContext`                                          |
+| **Transient, session-only (user is typing)?**    | Local state (`useState`) in the component                         |
+| **Needs to be shown as a notification?**         | Use `useToast()` to dispatch                                      |
+| **Wallet-related (balance, transaction state)?** | Local state or a new hook; coordinate with `useWallet()`          |
+| **Shared across 2+ pages?**                      | Consider a new context, but check if `SettingsContext` fits first |
+| **Should be part of the URL?**                   | Use URL params (`useSearchParams()`) or route state               |
+
+### Examples
+
+**✅ Good candidates for SettingsContext:**
+
+- Theme preference
+- Default network (Mainnet vs. Testnet)
+- Address display format (short vs. full)
+- Notification preferences (mute toasts, auto-dismiss duration)
+
+**✅ Good candidates for local state:**
+
+- Form input while user is typing
+- Modal open/closed state (unless shared across pages)
+- Hover/focus state on a button
+
+**✅ Use useToast() for:**
+
+- Confirmation messages after an action
+- Error messages that should not block the UI
+- Non-critical alerts
+
+**❌ Don't add to SettingsContext:**
+
+- Data that changes frequently (not a user preference)
+- Large objects (API responses, search results)
+- State that is only needed on one page
+
+---
+
+## Example: Reading State in a Component
+
+```typescript
+import { useSettings } from '../context/SettingsContext'
+import { useWallet } from '../context/WalletContext'
+import { useToast } from '../components/ToastProvider'
+
+function Bond() {
+  // Read user preferences
+  const { network, toastsEnabled } = useSettings()
+
+  // Read wallet connection state
+  const { address, isConnected, connect, error } = useWallet()
+
+  // Read notification API
+  const { addToast } = useToast()
+
+  async function handleBond() {
+    if (!isConnected) {
+      addToast('warning', 'Connect wallet first')
+      return
+    }
+
+    try {
+      // Bond logic…
+      addToast('success', 'Bond created')
+    } catch (err) {
+      addToast('danger', 'Failed to create bond')
+    }
+  }
+
+  return (
+    <>
+      <p>Network: {network}</p>
+      <p>Wallet: {address ? 'Connected' : 'Disconnected'}</p>
+      {error && <p>Error: {error.message}</p>}
+      <button onClick={handleBond}>Bond</button>
+    </>
+  )
+}
+```
+
+---
+
+## Testing
+
+### Mocking SettingsContext
+
+```typescript
+import { render } from '@testing-library/react'
+import { vi } from 'vitest'
+
+vi.mock('../context/SettingsContext', () => ({
+  useSettings: () => ({
+    themeMode: 'light',
+    network: 'test',
+    addressDisplay: 'short',
+    toastsEnabled: true,
+    autoDismiss: '5s',
+    hasUnsavedChanges: false,
+  }),
+}))
+
+// Test code here
+```
+
+### Mocking useWallet
+
+```typescript
+vi.mock('../context/WalletContext', () => ({
+  useWallet: () => ({
+    address: 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA',
+    isConnected: true,
+    connected: true,
+    isConnecting: false,
+    error: null,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    network: 'public',
+  }),
+}))
+```
+
+### Mocking useToast
+
+```typescript
+vi.mock('../components/ToastProvider', () => ({
+  useToast: () => ({
+    addToast: vi.fn(),
+    removeToast: vi.fn(),
+    removeAllToasts: vi.fn(),
+  }),
+}))
+```
+
+---
+
+## References
+
+- [Architecture Overview](./ARCHITECTURE.md) — System design and routing structure
+- [Design Tokens](./DESIGN_TOKENS.md) — CSS variable reference for theme colors
+- [Contributing Guide](../CONTRIBUTING.md) — Branch and PR workflow

--- a/package-lock.json
+++ b/package-lock.json
@@ -1723,6 +1723,7 @@
       "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -4407,16 +4408,6 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {


### PR DESCRIPTION
docs(state): add STATE_MANAGEMENT.md mapping Settings/Toast/Wallet contexts

## Summary

Documents the three core context providers that manage Credence Frontend's client state. New contributors can now understand state ownership, persistence mechanisms, and provider nesting order without diving into source code.

## Changes

- **docs/STATE_MANAGEMENT.md** (new)
  - Overview table: contexts, files, hooks, persistence, scope
  - SettingsContext: state shape, `useSettings()` hook, localStorage persistence (`credence:settings`), theme application to `data-theme`
  - WalletContext: state shape, `useWallet()` hook, Freighter integration, network synchronization with Settings
  - ToastProvider: state shape, `useToast()` hook, queueing (max 3), auto-dismiss with severity-based timeouts, accessibility (polite + assertive regions)
  - Provider nesting order with explanation of load-bearing dependencies
  - Decision guide: when to add state to a context vs. local vs. URL params, with good/bad examples
  - Testing: mock patterns for each context
  - References: links to ARCHITECTURE.md, DESIGN_TOKENS.md, CONTRIBUTING.md

- **docs/README.md**
  - Added link to STATE_MANAGEMENT.md as item #1 in Available Documents with ⭐ NEW marker
  - Renumbered subsequent items (2–11)

## Key Documentation

### SettingsContext (`src/context/SettingsContext.tsx`)

State: `themeMode`, `network`, `addressDisplay`, `toastsEnabled`, `autoDismiss`

- Persists under `credence:settings` key in localStorage
- Defaults: `themeMode: 'system'`, `network: 'public'`, `addressDisplay: 'short'`, `toastsEnabled: true`, `autoDismiss: '5s'`
- Theme applied to document root as `data-theme` attribute (respects OS preference when `themeMode: 'system'`)
- Corrupt JSON fallback: silently uses defaults

### WalletContext (`src/context/WalletContext.tsx`)

State: `address`, `isConnected`, `connected` (legacy alias), `isConnecting`, `error`, `network`

- Session-only; no persistence
- Reads `network` from SettingsContext; verifies Freighter matches selected network
- Wraps `useWallet()` hook (`src/hooks/useWallet.ts`) for Freighter browser extension integration
- Error codes: `'not_installed'`, `'rejected'`, `'network_mismatch'`, `'unknown'`

### ToastProvider (`src/components/ToastProvider.tsx`)

State: queue of toasts with `id`, `severity`, `message`

- Max 3 toasts; oldest removed when 4th is added
- Auto-dismiss timeouts: `info: 5s`, `success: 5s`, `warning: 8s`, `danger: 0s` (manual only)
- Overridable by `autoDismiss` setting from SettingsContext
- Respects global `toastsEnabled` flag (no-op if false)
- Accessibility: polite region for low-priority, assertive for danger

### Provider Nesting

Closes #325