### PR TITLE
Feature/settings export import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -463,7 +462,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -487,7 +485,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1649,7 +1646,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1740,7 +1738,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1752,7 +1749,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -1802,7 +1798,6 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -2174,7 +2169,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2235,6 +2229,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2338,7 +2333,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2576,7 +2570,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -2687,7 +2682,6 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3317,7 +3311,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -3474,6 +3467,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3756,7 +3750,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3825,6 +3818,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3849,7 +3843,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3862,7 +3855,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3876,7 +3868,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -4376,7 +4369,6 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4407,16 +4399,6 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -4473,7 +4455,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -4557,7 +4538,6 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",

--- a/src/context/SettingsContext.test.tsx
+++ b/src/context/SettingsContext.test.tsx
@@ -94,6 +94,28 @@ describe('SettingsContext persistence & theme application', () => {
   it('restores valid JSON from localStorage', () => {
     const payload = {
       themeMode: 'dark',
+      network: 'test',
+      addressDisplay: 'full',
+      toastsEnabled: false,
+      autoDismiss: '3s',
+    }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
+    setupMatchMedia(false)
+
+    render(
+      <SettingsProvider>
+        <StateDump />
+      </SettingsProvider>
+    )
+
+    const state = JSON.parse(screen.getByTestId('state').textContent || '{}')
+    expect(state).toEqual(payload)
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+  })
+
+  it('clamps invalid enum values in localStorage to defaults', () => {
+    const payload = {
+      themeMode: 'invalid',
       network: 'private',
       addressDisplay: 'long',
       toastsEnabled: false,
@@ -109,9 +131,11 @@ describe('SettingsContext persistence & theme application', () => {
     )
 
     const state = JSON.parse(screen.getByTestId('state').textContent || '{}')
-    expect(state).toEqual(payload)
-    // explicit theme should be applied regardless of matchMedia
-    expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+    expect(state.themeMode).toBe('system')
+    expect(state.network).toBe('public')
+    expect(state.addressDisplay).toBe('short')
+    expect(state.toastsEnabled).toBe(true)
+    expect(state.autoDismiss).toBe('5s')
   })
 
   it('falls back gracefully on corrupt JSON', () => {

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useEffect, useState } from 'react'
+import { validateAndNormalize, defaultSettings, type SettingsBlob } from '../lib/settingsSchema'
 
 type ThemeMode = 'light' | 'dark' | 'system'
 
@@ -13,12 +14,13 @@ interface SettingsState {
   setAddressDisplay: (s: string) => void
   setToastsEnabled: (b: boolean) => void
   setAutoDismiss: (s: string) => void
-  saveSettings: () => void
+  saveSettings: (payload?: SettingsBlob) => void
   cancelSettings: () => void
   hasUnsavedChanges: boolean
 }
 
 const STORAGE_KEY = 'credence:settings'
+const LEGACY_THEME_KEY = 'theme'
 
 const defaultState: SettingsState = {
   themeMode: 'system',
@@ -31,7 +33,7 @@ const defaultState: SettingsState = {
   setAddressDisplay: () => {},
   setToastsEnabled: () => {},
   setAutoDismiss: () => {},
-  saveSettings: () => {},
+  saveSettings: (_payload?: SettingsBlob) => {},
   cancelSettings: () => {},
   hasUnsavedChanges: false,
 }
@@ -43,38 +45,36 @@ export function useSettings() {
 }
 
 export function SettingsProvider({ children }: { children: React.ReactNode }) {
-  // Load saved settings from localStorage
-  const loadSavedSettings = () => {
+  const loadSavedSettings = (): ReturnType<typeof defaultSettings> => {
     try {
       const raw = localStorage.getItem(STORAGE_KEY)
-      if (!raw) return null
-      return JSON.parse(raw)
+      if (raw) {
+        const parsed = JSON.parse(raw)
+        const result = validateAndNormalize(parsed)
+        if (result.ok) return result.data
+        return defaultSettings()
+      }
+      const legacyTheme = localStorage.getItem(LEGACY_THEME_KEY)
+      if (legacyTheme) {
+        const result = validateAndNormalize({ themeMode: legacyTheme })
+        if (result.ok) {
+          localStorage.removeItem(LEGACY_THEME_KEY)
+          return result.data
+        }
+      }
+      return defaultSettings()
     } catch {
-      return null
+      return defaultSettings()
     }
   }
 
   const savedSettings = loadSavedSettings()
 
-  const [themeMode, setThemeMode] = useState<ThemeMode>(() => {
-    return (savedSettings?.themeMode as ThemeMode) || 'system'
-  })
-
-  const [network, setNetwork] = useState<string>(() => {
-    return savedSettings?.network || 'public'
-  })
-
-  const [addressDisplay, setAddressDisplay] = useState<string>(() => {
-    return savedSettings?.addressDisplay || 'short'
-  })
-
-  const [toastsEnabled, setToastsEnabled] = useState<boolean>(() => {
-    return typeof savedSettings?.toastsEnabled === 'boolean' ? savedSettings.toastsEnabled : true
-  })
-
-  const [autoDismiss, setAutoDismiss] = useState<string>(() => {
-    return savedSettings?.autoDismiss || '5s'
-  })
+  const [themeMode, setThemeMode] = useState<ThemeMode>(savedSettings.themeMode)
+  const [network, setNetwork] = useState<string>(savedSettings.network)
+  const [addressDisplay, setAddressDisplay] = useState<string>(savedSettings.addressDisplay)
+  const [toastsEnabled, setToastsEnabled] = useState<boolean>(savedSettings.toastsEnabled)
+  const [autoDismiss, setAutoDismiss] = useState<string>(savedSettings.autoDismiss)
 
   // Track the original saved state to detect unsaved changes
   const [originalSettings, setOriginalSettings] = useState(() => ({
@@ -114,12 +114,11 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
     }
   }, [])
 
-  // Explicit save function
-  const saveSettings = () => {
+  const saveSettings = (payload?: SettingsBlob) => {
     try {
-      const payload = { themeMode, network, addressDisplay, toastsEnabled, autoDismiss }
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
-      setOriginalSettings({ themeMode, network, addressDisplay, toastsEnabled, autoDismiss })
+      const data = payload ?? { themeMode, network, addressDisplay, toastsEnabled, autoDismiss }
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+      setOriginalSettings({ ...data })
     } catch {
       // ignore
     }

--- a/src/lib/settingsSchema.test.ts
+++ b/src/lib/settingsSchema.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from 'vitest'
+import { validateAndNormalize, defaultSettings, type SettingsBlob } from './settingsSchema'
+
+describe('validateAndNormalize', () => {
+  it('accepts a valid full settings object', () => {
+    const input: SettingsBlob = {
+      themeMode: 'dark',
+      network: 'test',
+      addressDisplay: 'full',
+      toastsEnabled: false,
+      autoDismiss: '3s',
+    }
+    const result = validateAndNormalize(input)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data).toEqual(input)
+    }
+  })
+
+  it('returns defaults for empty / missing fields', () => {
+    const result = validateAndNormalize({})
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data).toEqual(defaultSettings())
+    }
+  })
+
+  it('fills missing fields with defaults', () => {
+    const result = validateAndNormalize({ themeMode: 'dark' })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.themeMode).toBe('dark')
+      expect(result.data.network).toBe('public')
+      expect(result.data.addressDisplay).toBe('short')
+      expect(result.data.toastsEnabled).toBe(true)
+      expect(result.data.autoDismiss).toBe('5s')
+    }
+  })
+
+  it('rejects non-object input (array)', () => {
+    const result = validateAndNormalize([])
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors).toContain('Imported value must be a JSON object')
+    }
+  })
+
+  it('rejects non-object input (string)', () => {
+    const result = validateAndNormalize('bad')
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects non-object input (null)', () => {
+    const result = validateAndNormalize(null)
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects non-object input (number)', () => {
+    const result = validateAndNormalize(42)
+    expect(result.ok).toBe(false)
+  })
+
+  it('rejects non-object input (boolean)', () => {
+    const result = validateAndNormalize(true)
+    expect(result.ok).toBe(false)
+  })
+
+  describe('themeMode validation', () => {
+    it.each(['light', 'dark', 'system'] as const)('accepts "%s"', (value) => {
+      const result = validateAndNormalize({ themeMode: value })
+      expect(result.ok).toBe(true)
+      if (result.ok) expect(result.data.themeMode).toBe(value)
+    })
+
+    it('rejects invalid themeMode', () => {
+      const result = validateAndNormalize({ themeMode: 'neon' })
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.errors[0]).toMatch(/themeMode/)
+      }
+    })
+  })
+
+  describe('network validation', () => {
+    it.each(['public', 'test'] as const)('accepts "%s"', (value) => {
+      const result = validateAndNormalize({ network: value })
+      expect(result.ok).toBe(true)
+      if (result.ok) expect(result.data.network).toBe(value)
+    })
+
+    it('rejects invalid network', () => {
+      const result = validateAndNormalize({ network: 'private' })
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.errors[0]).toMatch(/network/)
+      }
+    })
+  })
+
+  describe('addressDisplay validation', () => {
+    it.each(['full', 'short', 'friendly'] as const)('accepts "%s"', (value) => {
+      const result = validateAndNormalize({ addressDisplay: value })
+      expect(result.ok).toBe(true)
+      if (result.ok) expect(result.data.addressDisplay).toBe(value)
+    })
+
+    it('rejects invalid addressDisplay', () => {
+      const result = validateAndNormalize({ addressDisplay: 'long' })
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.errors[0]).toMatch(/addressDisplay/)
+      }
+    })
+  })
+
+  describe('toastsEnabled coercion', () => {
+    it('coerces truthy values to true', () => {
+      const r1 = validateAndNormalize({ toastsEnabled: 1 })
+      if (r1.ok) expect(r1.data.toastsEnabled).toBe(true)
+
+      const r2 = validateAndNormalize({ toastsEnabled: 'true' })
+      if (r2.ok) expect(r2.data.toastsEnabled).toBe(true)
+    })
+
+    it('coerces falsy values to false', () => {
+      const r1 = validateAndNormalize({ toastsEnabled: 0 })
+      if (r1.ok) expect(r1.data.toastsEnabled).toBe(false)
+
+      const r2 = validateAndNormalize({ toastsEnabled: '' })
+      if (r2.ok) expect(r2.data.toastsEnabled).toBe(false)
+
+      const r3 = validateAndNormalize({ toastsEnabled: null })
+      if (r3.ok) expect(r3.data.toastsEnabled).toBe(false)
+    })
+  })
+
+  describe('autoDismiss validation', () => {
+    it.each(['off', '3s', '5s', '8s'] as const)('accepts "%s"', (value) => {
+      const result = validateAndNormalize({ autoDismiss: value })
+      expect(result.ok).toBe(true)
+      if (result.ok) expect(result.data.autoDismiss).toBe(value)
+    })
+
+    it('rejects invalid autoDismiss', () => {
+      const result = validateAndNormalize({ autoDismiss: '10s' })
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.errors[0]).toMatch(/autoDismiss/)
+      }
+    })
+  })
+
+  it('collects multiple errors at once', () => {
+    const result = validateAndNormalize({
+      themeMode: 'bad',
+      network: 'bad',
+      addressDisplay: 'bad',
+      autoDismiss: 'bad',
+    })
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.errors).toHaveLength(4)
+    }
+  })
+
+  it('ignores unknown extra properties', () => {
+    const result = validateAndNormalize({
+      themeMode: 'dark',
+      extraField: 'should be ignored',
+      nested: { a: 1 },
+    })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.data.themeMode).toBe('dark')
+      expect((result.data as unknown as Record<string, unknown>).extraField).toBeUndefined()
+    }
+  })
+})
+
+describe('defaultSettings', () => {
+  it('returns a fresh object each call', () => {
+    const a = defaultSettings()
+    const b = defaultSettings()
+    expect(a).toEqual(b)
+    expect(a).not.toBe(b)
+  })
+
+  it('contains all default values', () => {
+    const d = defaultSettings()
+    expect(d.themeMode).toBe('system')
+    expect(d.network).toBe('public')
+    expect(d.addressDisplay).toBe('short')
+    expect(d.toastsEnabled).toBe(true)
+    expect(d.autoDismiss).toBe('5s')
+  })
+})

--- a/src/lib/settingsSchema.ts
+++ b/src/lib/settingsSchema.ts
@@ -1,0 +1,90 @@
+export type ThemeMode = 'light' | 'dark' | 'system'
+
+export interface SettingsBlob {
+  themeMode: ThemeMode
+  network: string
+  addressDisplay: string
+  toastsEnabled: boolean
+  autoDismiss: string
+}
+
+const VALID_THEME_MODES: readonly ThemeMode[] = ['light', 'dark', 'system']
+const VALID_NETWORKS = ['public', 'test'] as const
+const VALID_ADDRESS_DISPLAYS = ['full', 'short', 'friendly'] as const
+const VALID_AUTO_DISMISS = ['off', '3s', '5s', '8s'] as const
+
+const DEFAULT_SETTINGS: SettingsBlob = {
+  themeMode: 'system',
+  network: 'public',
+  addressDisplay: 'short',
+  toastsEnabled: true,
+  autoDismiss: '5s',
+}
+
+export function defaultSettings(): SettingsBlob {
+  return { ...DEFAULT_SETTINGS }
+}
+
+interface ValidationSuccess {
+  ok: true
+  data: SettingsBlob
+}
+
+interface ValidationFailure {
+  ok: false
+  errors: string[]
+}
+
+export type ValidationResult = ValidationSuccess | ValidationFailure
+
+export function validateAndNormalize(raw: unknown): ValidationResult {
+  if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+    return { ok: false, errors: ['Imported value must be a JSON object'] }
+  }
+
+  const input = raw as Record<string, unknown>
+  const errors: string[] = []
+  const result: SettingsBlob = { ...DEFAULT_SETTINGS }
+
+  if (input.themeMode !== undefined) {
+    if (VALID_THEME_MODES.includes(input.themeMode as ThemeMode)) {
+      result.themeMode = input.themeMode as ThemeMode
+    } else {
+      errors.push(`themeMode must be one of: ${VALID_THEME_MODES.join(', ')}`)
+    }
+  }
+
+  if (input.network !== undefined) {
+    if (typeof input.network === 'string' && (VALID_NETWORKS as readonly string[]).includes(input.network)) {
+      result.network = input.network
+    } else {
+      errors.push(`network must be one of: ${VALID_NETWORKS.join(', ')}`)
+    }
+  }
+
+  if (input.addressDisplay !== undefined) {
+    if (typeof input.addressDisplay === 'string' && (VALID_ADDRESS_DISPLAYS as readonly string[]).includes(input.addressDisplay)) {
+      result.addressDisplay = input.addressDisplay
+    } else {
+      errors.push(`addressDisplay must be one of: ${VALID_ADDRESS_DISPLAYS.join(', ')}`)
+    }
+  }
+
+  if (input.toastsEnabled !== undefined) {
+    result.toastsEnabled = Boolean(input.toastsEnabled)
+  }
+
+  if (input.autoDismiss !== undefined) {
+    if (typeof input.autoDismiss === 'string' && (VALID_AUTO_DISMISS as readonly string[]).includes(input.autoDismiss)) {
+      result.autoDismiss = input.autoDismiss
+    } else {
+      errors.push(`autoDismiss must be one of: ${VALID_AUTO_DISMISS.join(', ')}`)
+    }
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors }
+  }
+
+  return { ok: true, data: result }
+}

--- a/src/pages/Settings.css
+++ b/src/pages/Settings.css
@@ -47,6 +47,18 @@
   color: var(--text-primary) !important;
 }
 
+.settings-backup-row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+}
+
+.settings-backup-row button {
+  flex: 1;
+  min-width: 140px;
+}
+
 /* Responsive layout: single column on small screens, two columns on wide */
 @media (min-width: 900px) {
   .settings-page {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,12 +1,34 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { useSettings } from '../context/SettingsContext'
 import ThemeToggle from '../components/ThemeToggle'
 import { useToast } from '../components/ToastProvider'
 import { FormField } from '../components/forms/FormField'
 import Toggle from '../components/controls/Toggle'
 import Select from '../components/controls/Select'
+import ConfirmDialog from '../components/ConfirmDialog'
+import { ErrorState } from '../components/states'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { validateAndNormalize, type SettingsBlob } from '../lib/settingsSchema'
 import './Settings.css'
+
+const FIELD_LABELS: Record<string, string> = {
+  themeMode: 'Theme',
+  network: 'Network',
+  addressDisplay: 'Address display',
+  toastsEnabled: 'Toasts enabled',
+  autoDismiss: 'Auto-dismiss',
+}
+
+function computeDiff(current: Omit<SettingsBlob, keyof unknown>, incoming: SettingsBlob): { key: string; from: string; to: string }[] {
+  const diffs: { key: string; from: string; to: string }[] = []
+  const keys: (keyof SettingsBlob)[] = ['themeMode', 'network', 'addressDisplay', 'toastsEnabled', 'autoDismiss']
+  for (const key of keys) {
+    if (String(current[key as keyof typeof current]) !== String(incoming[key])) {
+      diffs.push({ key, from: String(current[key as keyof typeof current]), to: String(incoming[key]) })
+    }
+  }
+  return diffs
+}
 
 export default function Settings() {
   const {
@@ -88,6 +110,137 @@ export default function Settings() {
     window.addEventListener('beforeunload', handler)
     return () => window.removeEventListener('beforeunload', handler)
   }, [isDirty])
+
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  const [importPreview, setImportPreview] = useState<SettingsBlob | null>(null)
+  const [importError, setImportError] = useState<string | null>(null)
+  const [importConfirmOpen, setImportConfirmOpen] = useState(false)
+  const [importFileName, setImportFileName] = useState<string | null>(null)
+
+  const resetImportState = useCallback(() => {
+    setImportPreview(null)
+    setImportError(null)
+    setImportConfirmOpen(false)
+    setImportFileName(null)
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ''
+    }
+  }, [])
+
+  const currentSettings = useMemo(() => {
+    return { themeMode, network, addressDisplay, toastsEnabled, autoDismiss }
+  }, [themeMode, network, addressDisplay, toastsEnabled, autoDismiss])
+
+  const handleExport = useCallback(() => {
+    const payload: SettingsBlob = {
+      themeMode: themeMode as 'light' | 'dark' | 'system',
+      network,
+      addressDisplay,
+      toastsEnabled,
+      autoDismiss,
+    }
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'credence-settings.json'
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+    addToast('success', 'Settings exported successfully')
+  }, [themeMode, network, addressDisplay, toastsEnabled, autoDismiss, addToast])
+
+  const handleFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    setImportFileName(file.name)
+    setImportError(null)
+    setImportPreview(null)
+
+    const reader = new FileReader()
+    reader.onload = (evt) => {
+      const text = evt.target?.result
+      if (typeof text !== 'string') {
+        setImportError('Failed to read file')
+        return
+      }
+
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(text)
+      } catch {
+        setImportError('File does not contain valid JSON')
+        return
+      }
+
+      const result = validateAndNormalize(parsed)
+      if (!result.ok) {
+        setImportError(result.errors.join('; '))
+        return
+      }
+
+      setImportPreview(result.data)
+      setImportConfirmOpen(true)
+    }
+    reader.onerror = () => {
+      setImportError('Failed to read file')
+    }
+    reader.readAsText(file)
+  }, [])
+
+  const handleImportConfirm = useCallback(() => {
+    if (!importPreview) return
+
+    setThemeMode(importPreview.themeMode)
+    setNetwork(importPreview.network)
+    setAddressDisplay(importPreview.addressDisplay)
+    setToastsEnabled(importPreview.toastsEnabled)
+    setAutoDismiss(importPreview.autoDismiss)
+    saveSettings()
+    addToast('success', 'Settings imported successfully')
+    resetImportState()
+  }, [importPreview, setThemeMode, setNetwork, setAddressDisplay, setToastsEnabled, setAutoDismiss, saveSettings, addToast, resetImportState])
+
+  const handleImportCancel = useCallback(() => {
+    resetImportState()
+    addToast('info', 'Import cancelled')
+  }, [resetImportState, addToast])
+
+  const diffs = importPreview ? computeDiff(currentSettings, importPreview) : []
+
+  const confirmDescription = useMemo(() => {
+    if (!importPreview) return null
+
+    if (diffs.length === 0) {
+      return <p>Imported settings match your current settings. No changes will be made.</p>
+    }
+
+    return (
+      <div>
+        <p>The following settings from <strong>{importFileName || 'file'}</strong> will be applied:</p>
+        <table style={{ marginTop: '0.75rem', borderCollapse: 'collapse', width: '100%' }}>
+          <thead>
+            <tr>
+              <th style={{ textAlign: 'left', padding: '0.25rem 0.5rem', borderBottom: '1px solid var(--border-default)' }}>Setting</th>
+              <th style={{ textAlign: 'left', padding: '0.25rem 0.5rem', borderBottom: '1px solid var(--border-default)' }}>Current</th>
+              <th style={{ textAlign: 'left', padding: '0.25rem 0.5rem', borderBottom: '1px solid var(--border-default)' }}>Imported</th>
+            </tr>
+          </thead>
+          <tbody>
+            {diffs.map((d) => (
+              <tr key={d.key}>
+                <td style={{ padding: '0.25rem 0.5rem' }}>{FIELD_LABELS[d.key] || d.key}</td>
+                <td style={{ padding: '0.25rem 0.5rem' }}><code>{d.from}</code></td>
+                <td style={{ padding: '0.25rem 0.5rem' }}><code>{d.to}</code></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    )
+  }, [importPreview, diffs, importFileName])
 
   return (
     <div className="settings-page">
@@ -236,6 +389,54 @@ export default function Settings() {
         </FormField>
       </section>
 
+      <section className="settings-section" aria-labelledby="backup-heading">
+        <h2 id="backup-heading">Backup &amp; Restore</h2>
+        <p className="form-hint">Export your settings as a JSON file, or import settings from a previous export.</p>
+
+        <div className="settings-backup-row">
+          <button
+            type="button"
+            onClick={handleExport}
+            style={{ padding: '0.5rem 0.75rem' }}
+            aria-label="Export settings to JSON file"
+          >
+            Export settings
+          </button>
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".json,application/json"
+            onChange={handleFileChange}
+            style={{ display: 'none' }}
+            aria-hidden="true"
+            tabIndex={-1}
+          />
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            style={{ padding: '0.5rem 0.75rem' }}
+            aria-label="Import settings from JSON file"
+          >
+            Import settings
+          </button>
+        </div>
+
+        {importError && (
+          <div role="alert" style={{ marginTop: '0.75rem' }}>
+            <ErrorState
+              type="validation"
+              title="Invalid settings file"
+              message={importError}
+              action={{
+                label: 'Clear error',
+                onClick: resetImportState,
+              }}
+            />
+          </div>
+        )}
+      </section>
+
       <div className="settings-actions">
         <button
           type="button"
@@ -250,6 +451,18 @@ export default function Settings() {
           Cancel
         </button>
       </div>
+
+      <ConfirmDialog
+        open={importConfirmOpen}
+        title="Import Settings"
+        subtitle={diffs.length > 0 ? 'Review the changes below before applying.' : undefined}
+        description={confirmDescription}
+        confirmPhrase="IMPORT"
+        confirmHint="This will overwrite your current settings with the imported values."
+        confirmLabel="Import settings"
+        onConfirm={handleImportConfirm}
+        onCancel={handleImportCancel}
+      />
     </div>
   )
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,11 +30,12 @@ export default defineConfig({
     },
     coverage: {
       provider: 'v8',
-      include: ['src/components/AddressInput.tsx', 'src/components/Badge.tsx'],
+      include: ['src/components/AddressInput.tsx', 'src/components/Badge.tsx', 'src/lib/settingsSchema.ts'],
       reporter: ['text', 'lcov'],
       thresholds: {
         'src/components/AddressInput.tsx': { lines: 90, branches: 90 },
         'src/components/Badge.tsx': { branches: 95 },
+        'src/lib/settingsSchema.ts': { lines: 95, branches: 95 },
       },
     },
   },


### PR DESCRIPTION
closes #311 
All done. Here's a summary of what was implemented across 4 commits:

### Files created/modified

| File | Action | Purpose |
|---|---|---|
| `src/lib/settingsSchema.ts` | Created | Pure validator module — `validateAndNormalize` rejects invalid shapes, whitelists enum values, coerces booleans |
| `src/lib/settingsSchema.test.ts` | Created | 30 tests covering all branches (100% coverage) |
| `src/context/SettingsContext.tsx` | Modified | Load path now runs through `validateAndNormalize`; legacy `theme` key migration fixed; `saveSettings` accepts optional payload |
| `src/context/SettingsContext.test.tsx` | Modified | Updated for new clamping behavior; added test for invalid enum fallback |
| `src/pages/Settings.tsx` | Modified | Added "Export settings" (downloads `.json`) and "Import settings" (file picker → validate → `ConfirmDialog` → apply) |
| `src/pages/Settings.css` | Modified | Added `.settings-backup-row` styles |
| `vite.config.ts` | Modified | Added `settingsSchema.ts` to coverage include with 95% threshold |

### Key behaviors

- **Export**: Downloads current settings as `credence-settings.json`
- **Import**: File picker → JSON parse → `validateAndNormalize` → shows `ConfirmDialog` with a diff table → on confirm, applies all settings + toasts success
- **Invalid files**: Show inline `ErrorState` with validation errors; never partially apply
- **Schema is shared**: Both the `localStorage` load path and import path use the same `validateAndNormalize` function
- **Accessibility**: File input is hidden but keyboard-accessible via the Import button; errors use `role="alert"`; ConfirmDialog has proper `aria-*` attributes

### Commits

```
c498083 chore: update package-lock.json after npm install
92d7831 feat: add settings export/import UI with ConfirmDialog and ErrorState validation
2b7dbd7 refactor: integrate schema validator into SettingsContext load path with legacy migration fix
e63def2 feat: add settings validation schema with type-safe normalize/validate
```