### PR TITLE
ci: add GitHub Actions workflow for lint, format, build, and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+
+jobs:
+  quality:
+    name: Quality Gate
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check formatting
+        run: npm run format:check
+
+      - name: Run linter
+        run: npm run lint
+
+      - name: Build and typecheck
+        run: npm run build
+
+      - name: Run tests
+        run: npm run test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Credence Frontend
+# Credence Frontend [![CI Status](https://github.com/CredenceOrg/Credence-Frontend/actions/workflows/ci.yml/badge.svg)](https://github.com/CredenceOrg/Credence-Frontend/actions/workflows/ci.yml)
 
 Web UI for the Credence economic trust protocol. Connect a Stellar wallet, create or manage USDC bonds, and view trust scores.
 
@@ -24,6 +24,17 @@ npm run dev
 ```
 
 App runs at [http://localhost:5173](http://localhost:5173). API requests to `/api` are proxied to the backend (default `http://localhost:3000`).
+
+## Continuous Integration
+
+Every pull request and push to the `main` branch is validated by a GitHub Actions workflow. The quality gate ensures that the code compiles, is correctly formatted, passes all linting rules, and that all tests pass:
+
+- `npm run format:check`
+- `npm run lint`
+- `npm run build`
+- `npm run test`
+
+If any of these steps fail, the CI workflow will fail, and the PR cannot be merged until the issues are resolved.
 
 ## Configuration
 


### PR DESCRIPTION
### What was done
- Created a GitHub Actions continuous integration workflow in `.github/workflows/ci.yml`.
- Configured the workflow to run on every push and pull request to the `main` and `master` branches using the `ubuntu-latest` runner.
- Added aggressive npm dependency caching via `actions/setup-node@v4`.
- Enforced automated quality gating using the existing repo scripts: `npm run format:check`, `npm run lint`, `npm run build`, and `npm run test`.
- Added a CI status badge to the top of `README.md`.
- Added a "Continuous Integration" section in `README.md` to document the gating requirements for future contributors.

### Why it was done
Prior to this workflow, code with undefined variables and formatting discrepancies could merge directly into `main` undetected, resulting in broken pages (e.g., `Bond.tsx`, `TrustScore.tsx`). This CI pipeline turns compilation and formatting checks into a hard automated gate, ensuring a clean open-source contribution flow.

### How it was verified
- Verified locally that the defined npm scripts correctly surface the existing code quality issues in the repository.
- As expected, the workflow will correctly catch the pre-existing Prettier discrepancies (36 unformatted files) and linting/Vitest errors (`AmountInput.test.ts` missing a test suite and using explicit `any`). This proves the CI infrastructure is accurately intercepting faulty commits.

Closes #156 