### PR TITLE
feat: add transaction actions to bond toasts

### DIFF
--- a/src/components/CreateBondFlow.test.tsx
+++ b/src/components/CreateBondFlow.test.tsx
@@ -430,6 +430,10 @@ describe('CreateBondFlow – step 4 confirm', () => {
     await user.click(screen.getByRole('checkbox'))
     fireEvent.click(screen.getByRole('button', { name: /Confirm & Create Bond/i }))
     expect(screen.getByText(/Step 1: Enter Bond Amount/i)).toBeInTheDocument()
+    expect(screen.getByText(/Bond created successfully/i)).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /view on explorer/i }).getAttribute('href')).toContain(
+      '/explorer/public/tx/'
+    )
   })
 })
 

--- a/src/components/CreateBondFlow.tsx
+++ b/src/components/CreateBondFlow.tsx
@@ -47,6 +47,8 @@ const calcUnlockDate = (days: number) => {
 // ---------------------------------------------------------------------------
 const ReviewDivider = () => <div className="createBondFlow__reviewDivider" />
 
+const MOCK_CREATE_BOND_TX_HASH = '4c2a90f8e1b7d6c3a5f0918273b4c6d8e0a1f2b3c4d5e6f708192a3b4c5d6e7f'
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -111,7 +113,7 @@ export default function CreateBondFlow({ onComplete, onCancel }: CreateBondFlowP
   }
 
   const handleConfirm = () => {
-    addToast('success', 'Bond created successfully.')
+    addToast('success', 'Bond created successfully.', { hash: MOCK_CREATE_BOND_TX_HASH })
     if (onComplete) {
       onComplete()
     } else {

--- a/src/components/Toast.css
+++ b/src/components/Toast.css
@@ -62,6 +62,60 @@
   min-width: 0;
 }
 
+.toast__content {
+  display: grid;
+  flex: 1;
+  min-width: 0;
+  gap: var(--credence-space-2);
+}
+
+.toast__transaction {
+  display: grid;
+  gap: var(--credence-space-1);
+}
+
+.toast__hash {
+  width: fit-content;
+  max-width: 100%;
+  padding: 0.125rem 0.375rem;
+  border-radius: var(--credence-radius-sm);
+  background: rgb(255 255 255 / 0.45);
+  color: inherit;
+  font-size: 0.78rem;
+  overflow-wrap: anywhere;
+}
+
+.toast__transaction-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--credence-space-2);
+  align-items: center;
+}
+
+.toast__copy,
+.toast__explorer {
+  border: 1px solid currentColor;
+  border-radius: var(--credence-radius-sm);
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.75rem;
+  line-height: 1;
+  padding: 0.35rem 0.5rem;
+  text-decoration: none;
+}
+
+.toast__copy:hover,
+.toast__explorer:hover {
+  opacity: 0.8;
+}
+
+.toast__copy-status {
+  min-height: 1rem;
+  font-size: 0.75rem;
+}
+
 .toast__dismiss {
   flex-shrink: 0;
   background: none;

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,6 +1,12 @@
+import { useState } from 'react'
 import './Toast.css'
 
 export type ToastSeverity = 'info' | 'success' | 'warning' | 'danger'
+
+export interface ToastActionMeta {
+  hash: string
+  network?: string
+}
 
 const ICONS: Record<ToastSeverity, React.ReactNode> = {
   info: (
@@ -71,6 +77,7 @@ export interface ToastData {
   id: string
   severity: ToastSeverity
   message: string
+  action?: ToastActionMeta
 }
 
 interface ToastProps {
@@ -78,7 +85,36 @@ interface ToastProps {
   onDismiss: (id: string) => void
 }
 
+function truncateHash(hash: string) {
+  if (hash.length <= 18) return hash
+  return `${hash.slice(0, 8)}...${hash.slice(-6)}`
+}
+
+function getExplorerNetwork(network?: string) {
+  if (network === 'testnet' || network === 'futurenet') return network
+  return 'public'
+}
+
+function getExplorerUrl(hash: string, network?: string) {
+  return `https://stellar.expert/explorer/${getExplorerNetwork(network)}/tx/${hash}`
+}
+
 export default function Toast({ toast, onDismiss }: ToastProps) {
+  const [copyMessage, setCopyMessage] = useState('')
+  const transactionHash = toast.action?.hash
+
+  const handleCopyHash = async () => {
+    if (!transactionHash) return
+
+    try {
+      await navigator.clipboard.writeText(transactionHash)
+      setCopyMessage('Copied transaction hash.')
+      setTimeout(() => setCopyMessage(''), 2000)
+    } catch {
+      setCopyMessage('Could not copy transaction hash.')
+    }
+  }
+
   return (
     <div
       className={`toast toast--${toast.severity}`}
@@ -89,6 +125,34 @@ export default function Toast({ toast, onDismiss }: ToastProps) {
       </div>
       <div className="toast__content">
         <span className="toast__message">{toast.message}</span>
+        {transactionHash && (
+          <div className="toast__transaction">
+            <code className="toast__hash" title={transactionHash}>
+              {truncateHash(transactionHash)}
+            </code>
+            <div className="toast__transaction-actions">
+              <button
+                type="button"
+                className="toast__copy"
+                onClick={handleCopyHash}
+                aria-label="Copy transaction hash"
+              >
+                Copy
+              </button>
+              <a
+                className="toast__explorer"
+                href={getExplorerUrl(transactionHash, toast.action?.network)}
+                target="_blank"
+                rel="noreferrer"
+              >
+                View on explorer
+              </a>
+            </div>
+            <span className="toast__copy-status" aria-live="polite" aria-atomic="true">
+              {copyMessage}
+            </span>
+          </div>
+        )}
       </div>
       <button
         type="button"

--- a/src/components/ToastProvider.test.tsx
+++ b/src/components/ToastProvider.test.tsx
@@ -18,6 +18,15 @@ function TestComponent() {
     <div>
       <button onClick={() => addToast('info', 'Info Message')}>Add Info</button>
       <button onClick={() => addToast('danger', 'Danger Message')}>Add Danger</button>
+      <button
+        onClick={() =>
+          addToast('success', 'Transaction submitted', {
+            hash: '4c2a90f8e1b7d6c3a5f0918273b4c6d8e0a1f2b3c4d5e6f708192a3b4c5d6e7f',
+          })
+        }
+      >
+        Add Transaction
+      </button>
       <button onClick={removeAllToasts}>Remove All</button>
     </div>
   )
@@ -29,11 +38,14 @@ describe('ToastProvider', () => {
     vi.mocked(SettingsContextModule.useSettings).mockReturnValue({
       toastsEnabled: true,
       autoDismiss: '5s',
+      network: 'testnet',
     } as ReturnType<typeof SettingsContextModule.useSettings>)
   })
 
   afterEach(() => {
-    vi.runOnlyPendingTimers()
+    act(() => {
+      vi.runOnlyPendingTimers()
+    })
     vi.useRealTimers()
     vi.clearAllMocks()
   })
@@ -74,6 +86,7 @@ describe('ToastProvider', () => {
     vi.mocked(SettingsContextModule.useSettings).mockReturnValue({
       toastsEnabled: false,
       autoDismiss: '5s',
+      network: 'testnet',
     } as ReturnType<typeof SettingsContextModule.useSettings>)
 
     rerender(
@@ -99,6 +112,7 @@ describe('ToastProvider', () => {
     vi.mocked(SettingsContextModule.useSettings).mockReturnValue({
       toastsEnabled: true,
       autoDismiss: '3s',
+      network: 'testnet',
     } as ReturnType<typeof SettingsContextModule.useSettings>)
 
     rerender(
@@ -146,6 +160,7 @@ describe('ToastProvider', () => {
     vi.mocked(SettingsContextModule.useSettings).mockReturnValue({
       toastsEnabled: true,
       autoDismiss: 'off',
+      network: 'testnet',
     } as ReturnType<typeof SettingsContextModule.useSettings>)
 
     fireEvent.click(screen.getByText('Add Danger'))
@@ -189,5 +204,34 @@ describe('ToastProvider', () => {
     )
 
     expect(screen.getByLabelText('Notifications')).toHaveAttribute('aria-live', 'polite')
+  })
+
+  it('renders transaction hash actions without breaking the existing addToast API', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.assign(navigator, {
+      clipboard: { writeText },
+    })
+
+    render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>
+    )
+
+    fireEvent.click(screen.getByText('Add Transaction'))
+
+    expect(screen.getByText('Transaction submitted')).toBeInTheDocument()
+    expect(screen.getByText('4c2a90f8...5d6e7f')).toBeInTheDocument()
+
+    const explorerLink = screen.getByRole('link', { name: /view on explorer/i })
+    expect(explorerLink.getAttribute('href')).toContain('/explorer/testnet/tx/')
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /copy transaction hash/i }))
+    })
+
+    expect(writeText).toHaveBeenCalledWith(
+      '4c2a90f8e1b7d6c3a5f0918273b4c6d8e0a1f2b3c4d5e6f708192a3b4c5d6e7f'
+    )
   })
 })

--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useState, useCallback, useRef, type ReactNode } from 'react'
 import { useSettings } from '../context/SettingsContext'
-import Toast, { type ToastData, type ToastSeverity } from './Toast'
+import Toast, { type ToastActionMeta, type ToastData, type ToastSeverity } from './Toast'
 import './Toast.css'
 
 const MAX_TOASTS = 3
@@ -13,7 +13,7 @@ const TIMEOUTS: Record<ToastSeverity, number> = {
 }
 
 interface ToastContextValue {
-  addToast: (severity: ToastSeverity, message: string) => void
+  addToast: (severity: ToastSeverity, message: string, action?: ToastActionMeta) => void
   removeToast: (id: string) => void
   removeAllToasts: () => void
 }
@@ -27,14 +27,14 @@ export function useToast() {
 }
 
 export default function ToastProvider({ children }: { children: ReactNode }) {
-  const { toastsEnabled, autoDismiss } = useSettings()
+  const { toastsEnabled, autoDismiss, network } = useSettings()
 
   /**
    * We use a ref to track the current settings to avoid recreating `addToast`
    * on every setting change, which would cause unnecessary re-renders of consumers.
    */
-  const settingsRef = useRef({ toastsEnabled, autoDismiss })
-  settingsRef.current = { toastsEnabled, autoDismiss }
+  const settingsRef = useRef({ toastsEnabled, autoDismiss, network })
+  settingsRef.current = { toastsEnabled, autoDismiss, network }
 
   const [toasts, setToasts] = useState<ToastData[]>([])
   const idCounter = useRef(0)
@@ -56,14 +56,22 @@ export default function ToastProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const addToast = useCallback(
-    (severity: ToastSeverity, message: string) => {
-      const { toastsEnabled, autoDismiss } = settingsRef.current
+    (severity: ToastSeverity, message: string, action?: ToastActionMeta) => {
+      const { toastsEnabled, autoDismiss, network } = settingsRef.current
 
       // respect global toast enable setting
       if (!toastsEnabled) return
       const id = String(++idCounter.current)
       setToasts((prev: ToastData[]) => {
-        const next = [...prev, { id, severity, message }]
+        const next = [
+          ...prev,
+          {
+            id,
+            severity,
+            message,
+            action: action ? { ...action, network: action.network ?? network } : undefined,
+          },
+        ]
         return next.length > MAX_TOASTS ? next.slice(next.length - MAX_TOASTS) : next
       })
 
@@ -87,7 +95,7 @@ export default function ToastProvider({ children }: { children: ReactNode }) {
         timeoutsMap.current.set(id, timerId)
       }
     },
-    [removeToast, toastsEnabled, autoDismiss]
+    [removeToast, toastsEnabled, autoDismiss, network]
   )
 
   /** Toasts split by politeness: danger → assertive; all others → polite. */

--- a/src/pages/Bond.tsx
+++ b/src/pages/Bond.tsx
@@ -7,13 +7,14 @@ import Badge, { type BadgeVariant } from '../components/Badge'
 import ActionCard from '../components/ActionCard'
 import Button from '../components/Button'
 import EmptyState from '../components/states/EmptyState'
+import type { ConfirmDialogPenaltyBreakdown } from '../components/ConfirmDialog'
 import { useWallet } from '../context/WalletContext'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { formatUsdc } from '../lib/format'
-import { getPenaltyRate, computeWithdrawBreakdown } from '../lib/penalty'
-import type { MockBond } from '../lib/penalty'
 
 const ConfirmDialog = lazy(() => import('../components/ConfirmDialog'))
+
+const MOCK_WITHDRAW_TX_HASH = '9f1c4d8a2b6e3a7c5d0f18b2436c9a71e0f5d2c8b4a3916e7c0d5a2f8b9e4c31'
 
 type BondStatus = 'active' | 'locked' | 'grace-period'
 
@@ -217,7 +218,7 @@ export default function Bond() {
         `Bond withdrawn. ${formatUsdc(penaltyUsdc)} was slashed per early withdrawal policy.`
       )
     } else {
-      addToast('success', 'Bond withdrawn successfully.')
+      addToast('success', 'Bond withdrawn successfully.', { hash: MOCK_WITHDRAW_TX_HASH })
     }
     setWithdrawTarget(null)
   }, [withdrawTarget, withdrawBreakdown, addToast])


### PR DESCRIPTION
Closes #304

## Summary
- Added optional transaction metadata to the shared toast API without changing the existing `addToast(severity, message)` usage.
- Shows a truncated transaction hash, a copy action, and a network-aware Stellar Expert link when a success toast includes a hash.
- Updated bond create and withdraw success flows to pass mock transaction hashes for the demo flow.
- Kept danger toasts in the existing assertive region and non-danger toasts in the polite notification region.

## Validation
- `npm.cmd test -- src/components/ToastProvider.test.tsx src/components/CreateBondFlow.test.tsx` passed: 55 tests.
- `npm.cmd exec -- eslint src/components/Toast.tsx src/components/ToastProvider.tsx src/components/CreateBondFlow.tsx src/pages/Bond.tsx src/components/ToastProvider.test.tsx src/components/CreateBondFlow.test.tsx` passed.
- `git diff --check` passed, with normal Windows line-ending warnings only.
- Hidden/bidi control-character scan passed for changed files.

## Note
- `npm.cmd run build` is currently blocked by existing unrelated TypeScript errors outside this change, including missing `LEGACY_THEME_KEY`, `ErrorBoundary`, `RouteErrorPage`, and older test export mismatches. I did not change those in this PR to keep this fix focused.