### PR TITLE
feat(attestations): implement attestation submission flow and resolve test/compilation issues

### DIFF
--- a/docs/ATTESTATIONS.md
+++ b/docs/ATTESTATIONS.md
@@ -1,0 +1,58 @@
+# Attestation Payload Shape & Validation Contract
+
+This document specifies the on-chain registry payload structure, component properties, and validation contracts for the Credence Attestation Submission Flow.
+
+## Component Properties
+
+### `AttestationForm`
+
+Path: `src/components/AttestationForm.tsx`
+
+Allows trust validators and peers to attest verification data for any Stellar public key.
+
+Props:
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `onSubmitSuccess` | `(payload: AttestationPayload) => void` | `undefined` | Callback invoked with the finalized payload upon successful form confirmation. |
+| `disabled` | `boolean` | `false` | Disables form fields and button interaction during processing or wallet interactions. |
+
+---
+
+## Attestation Payload Schema
+
+The submitted attestation follows this structural representation:
+
+```typescript
+export interface AttestationPayload {
+  /** The Stellar public key (56 characters starting with 'G') of the subject. */
+  subject: string
+  /** The category of verification. */
+  type: 'identity' | 'peer-vouch' | 'credential'
+  /** Supporting text evidence or signature hash. Max 500 characters. */
+  evidence: string
+}
+```
+
+---
+
+## Validation Contract
+
+Every field is subject to strict constraints before the submission is allowed:
+
+1. **Subject Address**:
+   - Must be non-empty.
+   - Must be a valid Stellar public key (regex: `/^G[A-Z0-9]{55}$/`).
+   - If invalid, displays: `Invalid address. Stellar public keys are 56 characters starting with G.`
+
+2. **Attestation Type**:
+   - Dropdown options:
+     - `identity`: Identity Verification
+     - `peer-vouch`: Peer Vouch
+     - `credential`: Credential / Certification
+
+3. **Evidence**:
+   - Must be non-empty.
+   - Must not exceed 500 characters.
+   - Character count is continuously displayed (e.g. `X / 500 characters`).
+   - HTML `maxLength={500}` enforces input ceiling, and React state checks raise validation errors if violated.

--- a/docs/components.md
+++ b/docs/components.md
@@ -1,333 +1,427 @@
-# Component Reference
+# Shared Components Catalog
 
-This reference documents the shared Credence Frontend component library. Use it
-when composing pages, adding variants, or reviewing whether a new UI element
-should be built from existing primitives.
+This catalog is the source-facing reference for shared UI under `src/components/`. It documents current TypeScript props, accessibility contracts, styling ownership, and the `--credence-*` design tokens each component consumes. Keep this page in sync whenever component props or CSS tokens change.
 
-## Import Conventions
+Related focused docs: [button system](./button-system.md), [notifications](./notifications.md), [design tokens](./DESIGN_TOKENS.md), [dark mode](./dark-mode.md), [focus patterns](./focus-patterns.md), [UI states](./UI_STATES_GUIDE.md), [TrustGauge quick reference](./TRUST_GAUGE_QUICK_REFERENCE.md), and [tier thresholds](./tier-thresholds.md).
 
-Prefer direct component imports from `src/components` or its subfolders:
+## Styling ownership snapshot
+
+| Component              | Styling owner                                                                       | Inline-style migration note                                                                                               |
+| ---------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Button                 | `src/components/Button.css`                                                         | None.                                                                                                                     |
+| Badge                  | `src/components/Badge.css`                                                          | None.                                                                                                                     |
+| Banner                 | `src/components/Banner.css`                                                         | None.                                                                                                                     |
+| Toast / ToastProvider  | `src/components/Toast.css`                                                          | None.                                                                                                                     |
+| ConfirmDialog          | `src/components/ConfirmDialog.css`                                                  | None.                                                                                                                     |
+| AddressInput           | `src/components/AddressInput.css` + `FormField.css`                                 | None.                                                                                                                     |
+| AmountInput            | `src/components/AmountInput.css`                                                    | None.                                                                                                                     |
+| TrustGauge             | `src/components/TrustGauge.css`                                                     | Uses inline CSS custom properties for dynamic progress, marker, thumb, and legend-dot colors; keep scoped until migrated. |
+| TierLadder             | `src/components/TierLadder.css` + `Badge.css`                                       | None.                                                                                                                     |
+| ActivityTimeline       | `src/components/ActivityTimeline.css` + EmptyState inline styles for empty fallback | Empty fallback inherits `EmptyState` inline styles; migrate with states components.                                       |
+| FormField              | `src/components/forms/FormField.css`                                                | None.                                                                                                                     |
+| controls/Select        | `src/components/controls/controls.css`                                              | None.                                                                                                                     |
+| controls/Toggle        | `src/components/controls/controls.css`                                              | None.                                                                                                                     |
+| states/EmptyState      | Inline styles in `src/components/states/EmptyState.tsx`                             | Owns inline styles and should be migrated to CSS.                                                                         |
+| states/ErrorState      | Inline styles in `src/components/states/ErrorState.tsx`                             | Owns inline styles and should be migrated to CSS.                                                                         |
+| states/LoadingSkeleton | Inline styles in `src/components/states/LoadingSkeleton.tsx`                        | Owns inline styles and should be migrated to CSS.                                                                         |
+
+## Shared vocabularies
+
+### `BadgeVariant`
+
+Source: [`Badge.tsx`](../src/components/Badge.tsx)
+
+`'bronze' | 'silver' | 'gold' | 'platinum' | 'active' | 'locked' | 'slashed' | 'grace-period' | 'unknown'`
+
+Unknown runtime strings normalize to the `unknown` visual style while preserving the supplied string as a fallback label only when no known label exists.
+
+### `BannerSeverity`
+
+Source: [`Banner.tsx`](../src/components/Banner.tsx)
+
+`'info' | 'success' | 'warning' | 'critical'`
+
+`warning` and `critical` render urgent `role="alert"`; `info` and `success` render `role="status"`.
+
+### `ToastSeverity`
+
+Source: [`Toast.tsx`](../src/components/Toast.tsx) and [`ToastProvider.tsx`](../src/components/ToastProvider.tsx)
+
+`'info' | 'success' | 'warning' | 'danger'`
+
+Default auto-dismiss timeouts are 5s for `info` and `success`, 8s for `warning`, and persistent for `danger` unless settings override auto-dismiss.
+
+### `TIER_CONFIG`
+
+Source: [`TrustGauge.tsx`](../src/components/TrustGauge.tsx)
+
+| Tier       | Range    | Label    | Tokens referenced by config                                                                               |
+| ---------- | -------- | -------- | --------------------------------------------------------------------------------------------------------- |
+| `bronze`   | 0-250    | Bronze   | `--credence-color-bronze-border`, `--credence-color-bronze-surface`, `--credence-color-bronze-text`       |
+| `silver`   | 250-500  | Silver   | `--credence-color-silver-border`, `--credence-color-silver-surface`, `--credence-color-silver-text`       |
+| `gold`     | 500-750  | Gold     | `--credence-color-gold-border`, `--credence-color-gold-surface`, `--credence-color-gold-text`             |
+| `platinum` | 750-1000 | Platinum | `--credence-color-platinum-border`, `--credence-color-platinum-surface`, `--credence-color-platinum-text` |
+
+## Button
+
+Source: [`src/components/Button.tsx`](../src/components/Button.tsx). Focused docs: [button system](./button-system.md).
+
+| Prop                | Type                                              | Default                                  |
+| ------------------- | ------------------------------------------------- | ---------------------------------------- |
+| `variant`           | `'primary' \| 'secondary' \| 'ghost' \| 'danger'` | `'primary'`                              |
+| `isLoading`         | `boolean`                                         | `false`                                  |
+| `fullWidth`         | `boolean`                                         | `false`                                  |
+| `children`          | `ReactNode`                                       | Required                                 |
+| Native button props | `ButtonHTMLAttributes<HTMLButtonElement>`         | Forwarded; `type` defaults to `'button'` |
+
+Accessibility: renders a native `<button>`, disables interaction while `disabled` or `isLoading`, sets `aria-busy` for loading state, hides spinner SVG from assistive tech, and inherits keyboard activation/focus behavior from the platform.
+
+Tokens: `--credence-border-default`, `--credence-color-danger-*`, `--credence-color-info-surface`, `--credence-color-primary*`, `--credence-color-slate-*`, `--credence-color-white`, `--credence-focus-ring`, font, line-height, radius, spacing, surface, and text tokens.
 
 ```tsx
-import Button from '@/components/Button'
-import Badge from '@/components/Badge'
-import { FormField } from '@/components/forms/FormField'
-```
-
-Use the `@` alias for app source imports. Keep relative imports for files that
-live next to each other when that reads more clearly.
-
-## Core Components
-
-### `Button`
-
-Path: `src/components/Button.tsx`
-
-Use `Button` for primary commands, secondary actions, ghost actions, and
-destructive confirmations.
-
-Props:
-
-| Prop        | Type        | Default     | Notes                                                        |
-| ----------- | ----------- | ----------- | ------------------------------------------------------------ | --------- | ----------- | ------------------------- |
-| `variant`   | `'primary'  | 'secondary' | 'ghost'                                                      | 'danger'` | `'primary'` | Controls visual emphasis. |
-| `isLoading` | `boolean`   | `false`     | Shows a spinner, sets `aria-busy`, and disables interaction. |
-| `fullWidth` | `boolean`   | `false`     | Expands the button to its container width.                   |
-| `children`  | `ReactNode` | required    | Visible button label or inline content.                      |
-
-Example:
-
-```tsx
-<Button variant="primary" onClick={handleSave}>
-  Save changes
+<Button variant="primary" isLoading={isSaving} onClick={saveBond}>
+  Save bond
 </Button>
 ```
 
-### `Badge`
+## Badge
 
-Path: `src/components/Badge.tsx`
+Source: [`src/components/Badge.tsx`](../src/components/Badge.tsx).
 
-Use `Badge` for tier and status labels. Unknown variants intentionally fall back
-to the `unknown` style so callers do not silently render unstyled text.
+| Prop        | Type                     | Default             |
+| ----------- | ------------------------ | ------------------- |
+| `variant`   | `BadgeVariant \| string` | Required            |
+| `label`     | `string`                 | Known variant label |
+| `className` | `string`                 | `''`                |
 
-Props:
+Accessibility: renders text in a `<span>`; consumers should provide surrounding context when the badge alone is not descriptive.
 
-| Prop        | Type          | Default       | Notes                                |
-| ----------- | ------------- | ------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
-| `variant`   | `BadgeVariant | string`       | required                             | Known variants: `bronze`, `silver`, `gold`, `platinum`, `active`, `locked`, `slashed`, `grace-period`, `unknown`. |
-| `label`     | `string`      | variant label | Overrides the default display label. |
-| `className` | `string`      | `''`          | Appends custom classes.              |
-
-Example:
+Tokens: tier/status color tokens, `--credence-font-size-xs`, `--credence-font-weight-semibold`, `--credence-radius-full`, `--credence-space-2`.
 
 ```tsx
 <Badge variant="gold" />
 <Badge variant="grace-period" label="Grace" />
 ```
 
-### `Banner`
+## Banner
 
-Path: `src/components/Banner.tsx`
+Source: [`src/components/Banner.tsx`](../src/components/Banner.tsx). Focused docs: [notifications](./notifications.md).
 
-Use `Banner` for contextual information, warnings, success feedback, and critical
-messages. Warning and critical banners use `role="alert"`; info and success use
-`role="status"`.
+| Prop             | Type                                                     | Default                  |
+| ---------------- | -------------------------------------------------------- | ------------------------ |
+| `severity`       | `BannerSeverity`                                         | Required                 |
+| `children`       | `ReactNode`                                              | Required                 |
+| `title`          | `string`                                                 | `undefined`              |
+| `dismissible`    | `boolean`                                                | `undefined`              |
+| `onDismiss`      | `() => void`                                             | `undefined`              |
+| `action`         | `{ label: string; href?: string; onClick?: () => void }` | `undefined`              |
+| `returnFocusRef` | `React.RefObject<HTMLElement>`                           | `document.body` fallback |
 
-Props:
+Accessibility: severity maps to `role="alert"` for warning/critical and `role="status"` for info/success. The root has an aria label such as “Warning banner”. Dismiss buttons have `aria-label="Dismiss banner"`, support Escape while focused, and return focus to `returnFocusRef` or `document.body` after dismissal. Icons are aria-hidden.
 
-| Prop             | Type                         | Default         | Notes                                                             |
-| ---------------- | ---------------------------- | --------------- | ----------------------------------------------------------------- | ----------- | -------- | ------------------------------------------ |
-| `severity`       | `'info'                      | 'success'       | 'warning'                                                         | 'critical'` | required | Controls icon, tone, and live-region role. |
-| `children`       | `ReactNode`                  | required        | Message body.                                                     |
-| `title`          | `string`                     | undefined       | Optional bold heading.                                            |
-| `dismissible`    | `boolean`                    | false           | Shows a close button and enables Escape dismissal on that button. |
-| `onDismiss`      | `() => void`                 | undefined       | Called when the banner is dismissed.                              |
-| `action`         | `{ label; href?; onClick? }` | undefined       | Inline CTA rendered as a link or button.                          |
-| `returnFocusRef` | `RefObject<HTMLElement>`     | `document.body` | Focus target after dismissal.                                     |
-
-Example:
+Tokens: motion duration/easing tokens in CSS; severity color styling is component-owned CSS values and should be reviewed during token migrations.
 
 ```tsx
-<Banner severity="warning" title="Review required" dismissible onDismiss={hideBanner}>
-  Your bond details changed. Confirm before continuing.
+<Banner severity="warning" title="Review required" dismissible onDismiss={closeBanner}>
+  Your bond evidence needs one more attestation.
 </Banner>
 ```
 
-### `ConfirmDialog`
+## Toast and ToastProvider
 
-Path: `src/components/ConfirmDialog.tsx`
+Sources: [`src/components/Toast.tsx`](../src/components/Toast.tsx), [`src/components/ToastProvider.tsx`](../src/components/ToastProvider.tsx). Focused docs: [notifications](./notifications.md).
 
-Use `ConfirmDialog` for destructive bond withdrawal flows that require the user
-to type `CONFIRM`. It uses a focus trap, blocks body scroll while open, and
-returns focus through `useFocusTrap`.
+### Toast props
 
-Props:
+| Prop        | Type                                                       | Default  |
+| ----------- | ---------------------------------------------------------- | -------- |
+| `toast`     | `{ id: string; severity: ToastSeverity; message: string }` | Required |
+| `onDismiss` | `(id: string) => void`                                     | Required |
 
-| Prop             | Type                            | Default           | Notes                                                 |
-| ---------------- | ------------------------------- | ----------------- | ----------------------------------------------------- | ------------------------- |
-| `open`           | `boolean`                       | required          | Controls portal rendering.                            |
-| `title`          | `string`                        | required          | Dialog heading.                                       |
-| `subtitle`       | `string`                        | undefined         | Optional explanatory text.                            |
-| `breakdown`      | `ConfirmDialogPenaltyBreakdown` | required          | Bond amount, penalty, percent, and resulting balance. |
-| `onConfirm`      | `() => void`                    | required          | Called only after the typed phrase matches.           |
-| `onCancel`       | `() => void`                    | required          | Called on cancel, backdrop click, or Escape.          |
-| `returnFocusRef` | `RefObject<HTMLElement          | null>`            | undefined                                             | Focus target after close. |
-| `confirmLabel`   | `string`                        | `'Withdraw bond'` | Destructive action label.                             |
+### ToastProvider API
 
-Example:
+| API                          | Type                                                 | Default       |
+| ---------------------------- | ---------------------------------------------------- | ------------- |
+| `children` prop              | `ReactNode`                                          | Required      |
+| `useToast().addToast`        | `(severity: ToastSeverity, message: string) => void` | Context value |
+| `useToast().removeToast`     | `(id: string) => void`                               | Context value |
+| `useToast().removeAllToasts` | `() => void`                                         | Context value |
+
+Accessibility: individual danger toasts use `role="alert"`; other severities use `role="status"`. Provider separates polite notifications into `aria-live="polite"` and danger notifications into `aria-live="assertive"` regions, each with a region label. Dismiss buttons have severity-specific accessible names.
+
+Tokens: `--credence-font-size-*`, `--credence-line-height-base`, motion duration/easing, `--credence-radius-md`, `--credence-shadow-toast`, spacing, `--credence-surface-card`, `--credence-text-primary`.
+
+```tsx
+function SaveButton() {
+  const { addToast } = useToast()
+  return <Button onClick={() => addToast('success', 'Bond saved')}>Save</Button>
+}
+```
+
+## ConfirmDialog
+
+Source: [`src/components/ConfirmDialog.tsx`](../src/components/ConfirmDialog.tsx). Focused docs: [focus patterns](./focus-patterns.md).
+
+| Prop             | Type                                                                                              | Default           |
+| ---------------- | ------------------------------------------------------------------------------------------------- | ----------------- |
+| `open`           | `boolean`                                                                                         | Required          |
+| `title`          | `string`                                                                                          | Required          |
+| `subtitle`       | `string`                                                                                          | `undefined`       |
+| `breakdown`      | `{ bondAmount: string; penaltyAmount: string; penaltyPercent: number; resultingBalance: string }` | Required          |
+| `onConfirm`      | `() => void`                                                                                      | Required          |
+| `onCancel`       | `() => void`                                                                                      | Required          |
+| `returnFocusRef` | `RefObject<HTMLElement \| null>`                                                                  | `undefined`       |
+| `confirmLabel`   | `string`                                                                                          | `'Withdraw bond'` |
+
+Accessibility: renders in a portal with `role="dialog"`, `aria-modal="true"`, generated `aria-labelledby`/`aria-describedby`, focus trap, initial focus on Cancel, Escape and backdrop cancellation, body scroll lock, and optional focus restoration. The destructive action is disabled until the user types `CONFIRM`; assertive sr-only announcements describe state changes.
+
+Tokens: danger color tokens, font family/size/weight, line-height, motion, radius, spacing, surface, and text tokens.
 
 ```tsx
 <ConfirmDialog
   open={isOpen}
   title="Withdraw bond?"
-  breakdown={breakdown}
-  onCancel={close}
+  breakdown={{
+    bondAmount: '100 USDC',
+    penaltyAmount: '5 USDC',
+    penaltyPercent: 5,
+    resultingBalance: '95 USDC',
+  }}
   onConfirm={withdraw}
+  onCancel={close}
 />
 ```
 
-## Form and Input Components
+## AddressInput
 
-### `FormField`
+Source: [`src/components/AddressInput.tsx`](../src/components/AddressInput.tsx).
 
-Path: `src/components/forms/FormField.tsx`
+| Prop                 | Type                         | Default             |
+| -------------------- | ---------------------------- | ------------------- |
+| `id`                 | `string`                     | Required            |
+| `label`              | `string`                     | `'Stellar Address'` |
+| `value`              | `string`                     | Required            |
+| `onChange`           | `(value: string) => void`    | Required            |
+| `onValidationChange` | `(isValid: boolean) => void` | `undefined`         |
+| `disabled`           | `boolean`                    | `false`             |
+| `className`          | `string`                     | `''`                |
 
-Use `FormField` to connect a label, hint, and error message to a single form
-control. It clones the child element and injects `id`, `aria-describedby`, and
-`aria-invalid`.
+Accessibility: composes `FormField`, so label, hint, and error IDs wire through `htmlFor`, `aria-describedby`, and `aria-invalid`. Paste and copy controls are native buttons with explicit aria labels and hidden SVGs. Validation requires a 56-character Stellar public key starting with `G`; invalid feedback is exposed by the FormField alert.
 
-Props:
-
-| Prop       | Type           | Default   | Notes                                             |
-| ---------- | -------------- | --------- | ------------------------------------------------- |
-| `id`       | `string`       | required  | Shared by the label and child control.            |
-| `label`    | `string`       | required  | Visible field label.                              |
-| `hint`     | `string`       | undefined | Optional helper text.                             |
-| `error`    | `string`       | undefined | Optional error text rendered with `role="alert"`. |
-| `children` | `ReactElement` | required  | A single input-like element.                      |
-
-### `AddressInput`
-
-Path: `src/components/AddressInput.tsx`
-
-Use `AddressInput` for Stellar public key entry. It validates 56-character
-addresses beginning with `G`, exposes validation changes, supports clipboard
-paste, and echoes a truncated valid address.
-
-Props:
-
-| Prop                 | Type                         | Default             | Notes                             |
-| -------------------- | ---------------------------- | ------------------- | --------------------------------- |
-| `id`                 | `string`                     | required            | Input id passed into `FormField`. |
-| `label`              | `string`                     | `'Stellar Address'` | Field label.                      |
-| `value`              | `string`                     | required            | Controlled address value.         |
-| `onChange`           | `(value: string) => void`    | required            | Called with raw address text.     |
-| `onValidationChange` | `(isValid: boolean) => void` | undefined           | Called whenever validity changes. |
-| `disabled`           | `boolean`                    | `false`             | Disables input and paste button.  |
-| `className`          | `string`                     | `''`                | Wrapper class.                    |
-
-Utility:
-
-- `truncateAddress(address)` returns the first 12 and last 8 characters with an
-  ellipsis for long addresses.
-
-### `AmountInput`
-
-Path: `src/components/AmountInput.tsx`
-
-Use `AmountInput` for USDC-style decimal amounts. It sanitizes numeric input,
-normalizes to two decimals on blur, formats display when unfocused, and supports
-quick presets plus a max button.
-
-Props:
-
-| Prop            | Type                      | Default            | Notes                                                           |
-| --------------- | ------------------------- | ------------------ | --------------------------------------------------------------- |
-| `value`         | `string`                  | required           | Controlled decimal string.                                      |
-| `onChange`      | `(value: string) => void` | required           | Receives sanitized or normalized value.                         |
-| `balance`       | `number`                  | required           | Maximum value used by the Max button and preset disabled state. |
-| `presets`       | `number[]`                | `[100, 500, 1000]` | Quick amount chips.                                             |
-| `currencyLabel` | `string`                  | `'USDC'`           | Visible adornment and accessible labels.                        |
-| `error`         | `string`                  | undefined          | Marks the wrapper invalid.                                      |
-
-Example:
+Tokens: border, danger, primary, slate, success, focus, font, line-height, motion, radius, spacing, surface, and text tokens.
 
 ```tsx
-<AmountInput value={amount} onChange={setAmount} balance={availableBalance} />
+<AddressInput
+  id="recipient"
+  value={address}
+  onChange={setAddress}
+  onValidationChange={setAddressValid}
+/>
 ```
 
-## Trust Components
+## AmountInput
 
-### `TrustGauge`
+Source: [`src/components/AmountInput.tsx`](../src/components/AmountInput.tsx). Focused docs: [USDC amount input](./uiux/usdc-amount-input.md).
 
-Path: `src/components/TrustGauge.tsx`
+| Prop               | Type                                                                                | Default            |
+| ------------------ | ----------------------------------------------------------------------------------- | ------------------ |
+| `value`            | `string`                                                                            | Required           |
+| `onChange`         | `(value: string) => void`                                                           | Required           |
+| `balance`          | `number`                                                                            | Required           |
+| `presets`          | `number[]`                                                                          | `[100, 500, 1000]` |
+| `currencyLabel`    | `string`                                                                            | `'USDC'`           |
+| `error`            | `string`                                                                            | `undefined`        |
+| Native input props | `Omit<InputHTMLAttributes<HTMLInputElement>, 'value' \| 'onChange' \| 'inputMode'>` | Forwarded          |
 
-Use `TrustGauge` to display a 0-1000 trust score across Bronze, Silver, Gold,
-and Platinum tiers. It renders an accessible progressbar plus a tier legend.
+Accessibility: uses a native input with `inputMode="decimal"`, disables browser autocomplete, exposes invalid state when `error` or `aria-invalid="true"` is supplied, hides the currency adornment, and gives Max/preset buttons descriptive aria labels. Presets above balance and Max at zero balance are disabled.
 
-Props:
+Tokens: border, danger-border, slate, focus, font, motion, radius, spacing, surface, and text tokens.
 
-| Prop        | Type      | Default         | Notes                                                    |
-| ----------- | --------- | --------------- | -------------------------------------------------------- | ----------- | -------- | ------------------------------------------------ |
-| `score`     | `number`  | required        | Current score. Values above 1000 visually clamp at 100%. |
-| `tier`      | `'bronze' | 'silver'        | 'gold'                                                   | 'platinum'` | required | Current tier used for labels and next-tier text. |
-| `className` | `string`  | `''`            | Wrapper class.                                           |
-| `id`        | `string`  | `'trust-gauge'` | Wrapper id.                                              |
+```tsx
+<AmountInput value={amount} onChange={setAmount} balance={availableUsdc} error={amountError} />
+```
 
-Related export:
+## TrustGauge
 
-- `TIER_CONFIG` contains tier thresholds, colors, and labels.
+Source: [`src/components/TrustGauge.tsx`](../src/components/TrustGauge.tsx). Focused docs: [TrustGauge quick reference](./TRUST_GAUGE_QUICK_REFERENCE.md), [accessibility report](./TRUST_GAUGE_ACCESSIBILITY_REPORT.md).
 
-### `TierLadder`
+| Prop        | Type                                           | Default         |
+| ----------- | ---------------------------------------------- | --------------- |
+| `score`     | `number`                                       | Required        |
+| `tier`      | `'bronze' \| 'silver' \| 'gold' \| 'platinum'` | Required        |
+| `className` | `string`                                       | `''`            |
+| `id`        | `string`                                       | `'trust-gauge'` |
 
-Path: `src/components/TierLadder.tsx`
+Accessibility: includes visible heading/description, a `role="progressbar"` with `aria-valuenow`, `aria-valuemin="0"`, `aria-valuemax="1000"`, and an aria label summarizing score and tier. Decorative fills, thumb, and legend dots are presentational or aria-hidden.
 
-Use `TierLadder` for an expandable explanation of trust tiers, thresholds, and
-benefits. Thresholds align with `docs/tier-thresholds.md`.
+Tokens: tier color tokens, `--credence-color-primary`, slate, focus, font, line-height, motion, radius, and spacing tokens. Dynamic inline CSS custom properties set progress width, marker position, thumb position, and legend-dot color.
 
-Props:
+```tsx
+<TrustGauge score={640} tier="gold" />
+```
 
-| Prop          | Type      | Default | Notes                   |
-| ------------- | --------- | ------- | ----------------------- |
-| `className`   | `string`  | `''`    | Section class.          |
-| `defaultOpen` | `boolean` | `false` | Initial expanded state. |
+## TierLadder
 
-Related exports:
+Source: [`src/components/TierLadder.tsx`](../src/components/TierLadder.tsx). Focused docs: [tier thresholds](./tier-thresholds.md).
 
-- `TIER_LADDER` is the ordered list of tier definitions.
-- `TierDefinition` describes each tier's id, label, score range, and benefits.
+| Prop          | Type      | Default |
+| ------------- | --------- | ------- |
+| `className`   | `string`  | `''`    |
+| `defaultOpen` | `boolean` | `false` |
 
-## State Components
+Accessibility: root section is labelled by an sr-only heading. Trigger is a native button with `aria-expanded` and `aria-controls`; the panel uses `hidden` when collapsed. Decorative rail and chevron are aria-hidden. Tier content is structured as an ordered list with nested headings and benefit lists.
 
-### `EmptyState`
+Tokens: border, tier color tokens, slate, focus, font, line-height, motion, radius, spacing, surface, and text tokens.
 
-Path: `src/components/states/EmptyState.tsx`
+```tsx
+<TierLadder defaultOpen />
+```
 
-Use `EmptyState` when a view has no content yet and the user needs a next step.
+## ActivityTimeline
 
-Props:
+Source: [`src/components/ActivityTimeline.tsx`](../src/components/ActivityTimeline.tsx). Focused docs: [activity surface concept](./ACTIVITY_SURFACE_CONCEPT.md).
 
-| Prop           | Type                           | Default   | Notes                |
-| -------------- | ------------------------------ | --------- | -------------------- | ------------- | ----------- | --------- | --------------------------------- |
-| `icon`         | `ReactNode`                    | undefined | Custom icon node.    |
-| `title`        | `string`                       | required  | Heading.             |
-| `description`  | `string`                       | required  | Supporting copy.     |
-| `action`       | `{ label; onClick; variant? }` | undefined | Optional CTA button. |
-| `illustration` | `'bond'                        | 'trust'   | 'dispute'            | 'attestation' | 'activity'` | undefined | Token-backed preset illustration. |
+| Prop      | Type             | Default                |
+| --------- | ---------------- | ---------------------- |
+| `compact` | `boolean`        | `false`                |
+| `items`   | `ActivityItem[]` | Built-in sample events |
 
-### `ErrorState`
+`ActivityItem` is `{ id: string; timestamp: string; title: string; description: string; actor: string; statusLabel: string; tone: 'success' | 'warning' | 'info'; meta: string }`.
 
-Path: `src/components/states/ErrorState.tsx`
+Accessibility: renders a labelled section and a labelled timeline list. Decorative rails/nodes are aria-hidden. Empty data delegates to `EmptyState` with activity illustration and explanatory copy.
 
-Use `ErrorState` for recoverable errors. Preset types provide default title,
-message, and icon copy.
+Tokens: border, info/success/warning color tokens, primary, font, line-height, radius, spacing, surface, and text tokens.
 
-Props:
+```tsx
+<ActivityTimeline compact items={events} />
+```
 
-| Prop      | Type                 | Default        | Notes                      |
-| --------- | -------------------- | -------------- | -------------------------- | ---------- | ----------- | --------------------- |
-| `type`    | `'network'           | 'backend'      | 'validation'               | 'generic'` | `'generic'` | Selects default copy. |
-| `title`   | `string`             | preset title   | Overrides default title.   |
-| `message` | `string`             | preset message | Overrides default message. |
-| `action`  | `{ label; onClick }` | undefined      | Optional recovery button.  |
-| `icon`    | `ReactNode`          | preset icon    | Overrides default icon.    |
+## FormField
 
-### `LoadingSkeleton`
+Source: [`src/components/forms/FormField.tsx`](../src/components/forms/FormField.tsx).
 
-Path: `src/components/states/LoadingSkeleton.tsx`
+| Prop       | Type                 | Default     |
+| ---------- | -------------------- | ----------- |
+| `id`       | `string`             | Required    |
+| `label`    | `string`             | Required    |
+| `hint`     | `string`             | `undefined` |
+| `error`    | `string`             | `undefined` |
+| `children` | `React.ReactElement` | Required    |
 
-Use `LoadingSkeleton` for loading placeholders. It supports text, card, form,
-table, dashboard, and fallback block shapes.
+Accessibility: renders a `<label htmlFor={id}>`, optional hint, clones the child to inject `id`, merged `aria-describedby`, and `aria-invalid` when an error exists. Error text has `role="alert"`.
 
-Props:
+Tokens: `--credence-color-danger-text`, `--credence-font-size-sm`, `--credence-font-weight-semibold`, `--credence-space-2`, `--credence-text-secondary`.
 
-| Prop      | Type     | Default   | Notes                          |
-| --------- | -------- | --------- | ------------------------------ | ------- | ------------ | -------- | ---------------- |
-| `variant` | `'text'  | 'card'    | 'form'                         | 'table' | 'dashboard'` | `'text'` | Skeleton layout. |
-| `rows`    | `number` | `3`       | Number of repeated rows/cards. |
-| `width`   | `string` | `'100%'`  | CSS width.                     |
-| `height`  | `string` | undefined | Fallback block height.         |
+```tsx
+<FormField id="amount" label="Bond amount" hint="Enter USDC" error={error}>
+  <input value={amount} onChange={handleAmountChange} />
+</FormField>
+```
 
-## Control Components
+## controls/Select
 
-### `Select`
+Source: [`src/components/controls/Select.tsx`](../src/components/controls/Select.tsx).
 
-Path: `src/components/controls/Select.tsx`
+| Prop        | Type                                 | Default     |
+| ----------- | ------------------------------------ | ----------- |
+| `id`        | `string`                             | `undefined` |
+| `value`     | `string`                             | Required    |
+| `onChange`  | `(v: string) => void`                | Required    |
+| `options`   | `{ value: string; label: string }[]` | Required    |
+| `ariaLabel` | `string`                             | `undefined` |
 
-Use `Select` for simple native select controls where the caller owns the value.
+Accessibility: renders a native `<select>` with optional `id` and `aria-label`; pair with a visible `<label>` via `id` when possible. Native keyboard behavior is preserved.
 
-Props:
+Tokens: shared control CSS consumes border, primary, white, focus, font, line-height, motion, radius, spacing, surface, and text tokens.
 
-| Prop        | Type                                 | Default   | Notes                                          |
-| ----------- | ------------------------------------ | --------- | ---------------------------------------------- |
-| `id`        | `string`                             | undefined | Native select id.                              |
-| `value`     | `string`                             | required  | Controlled selected value.                     |
-| `onChange`  | `(value: string) => void`            | required  | Called with the selected option value.         |
-| `options`   | `{ value: string; label: string }[]` | required  | Option list.                                   |
-| `ariaLabel` | `string`                             | undefined | Accessible label when no visible label exists. |
+```tsx
+<Select
+  id="tier-filter"
+  value={tier}
+  onChange={setTier}
+  ariaLabel="Filter by tier"
+  options={[{ value: 'gold', label: 'Gold' }]}
+/>
+```
 
-### `Toggle`
+## controls/Toggle
 
-Path: `src/components/controls/Toggle.tsx`
+Source: [`src/components/controls/Toggle.tsx`](../src/components/controls/Toggle.tsx).
 
-Use `Toggle` for binary settings. It renders a button with `role="switch"` and
-`aria-checked`.
+| Prop        | Type                      | Default     |
+| ----------- | ------------------------- | ----------- |
+| `id`        | `string`                  | `undefined` |
+| `checked`   | `boolean`                 | Required    |
+| `onChange`  | `(next: boolean) => void` | Required    |
+| `ariaLabel` | `string`                  | `undefined` |
 
-Props:
+Accessibility: renders a native button with `role="switch"` and `aria-checked`; label it with `ariaLabel` or external labelling. Click toggles state; Space/Enter activation comes from button semantics.
 
-| Prop        | Type                      | Default   | Notes                                                 |
-| ----------- | ------------------------- | --------- | ----------------------------------------------------- |
-| `id`        | `string`                  | undefined | Button id.                                            |
-| `checked`   | `boolean`                 | required  | Current switch state.                                 |
-| `onChange`  | `(next: boolean) => void` | required  | Called with the next state.                           |
-| `ariaLabel` | `string`                  | undefined | Accessible label when surrounding text is not enough. |
+Tokens: shared control CSS consumes border, primary, white, focus, font, line-height, motion, radius, spacing, surface, and text tokens.
 
-## Review Checklist
+```tsx
+<Toggle checked={toastsEnabled} onChange={setToastsEnabled} ariaLabel="Enable notifications" />
+```
 
-Before adding or changing a shared component:
+## states/EmptyState
 
-- Can an existing component or variant solve the need?
-- Are public props exported and documented with TSDoc when useful?
-- Does the component use design tokens instead of one-off visual values?
-- Are labels, roles, focus behavior, and error states accessible?
-- Are behavior tests or usage examples updated for new variants?
+Source: [`src/components/states/EmptyState.tsx`](../src/components/states/EmptyState.tsx). Focused docs: [UI states guide](./UI_STATES_GUIDE.md), [zero states copy](./zero-states-copy.md).
+
+| Prop           | Type                                                                         | Default     |
+| -------------- | ---------------------------------------------------------------------------- | ----------- |
+| `icon`         | `ReactNode`                                                                  | `undefined` |
+| `title`        | `string`                                                                     | Required    |
+| `description`  | `string`                                                                     | Required    |
+| `action`       | `{ label: string; onClick: () => void; variant?: 'primary' \| 'secondary' }` | `undefined` |
+| `illustration` | `'bond' \| 'trust' \| 'dispute' \| 'attestation' \| 'activity'`              | `undefined` |
+
+Accessibility: illustration SVGs are aria-hidden; the accessible name comes from the visible title and description. Optional action is a native button. There is no landmark role; place inside a labelled region when context is needed.
+
+Tokens: inline styles consume illustration color tokens, radius, spacing, font, line-height, text, border, primary, and white tokens. Inline styles are flagged for migration.
+
+```tsx
+<EmptyState
+  title="No bonds yet"
+  description="Create a bond to start earning trust."
+  action={{ label: 'Create bond', onClick: start }}
+/>
+```
+
+## states/ErrorState
+
+Source: [`src/components/states/ErrorState.tsx`](../src/components/states/ErrorState.tsx). Focused docs: [UI states guide](./UI_STATES_GUIDE.md).
+
+| Prop      | Type                                                  | Default               |
+| --------- | ----------------------------------------------------- | --------------------- |
+| `type`    | `'network' \| 'backend' \| 'validation' \| 'generic'` | `'generic'`           |
+| `title`   | `string`                                              | Type-specific title   |
+| `message` | `string`                                              | Type-specific message |
+| `action`  | `{ label: string; onClick: () => void }`              | `undefined`           |
+| `icon`    | `ReactNode`                                           | Type-specific emoji   |
+
+Accessibility: visible title/message describe the error; optional action is a native button. No `role="alert"` is set, so add surrounding live-region behavior when errors are asynchronous and need announcement.
+
+Tokens: inline styles consume danger surface/text/action, white, radius, spacing, font, line-height, and border tokens. Inline styles are flagged for migration.
+
+```tsx
+<ErrorState type="network" action={{ label: 'Retry', onClick: refetch }} />
+```
+
+## states/LoadingSkeleton
+
+Source: [`src/components/states/LoadingSkeleton.tsx`](../src/components/states/LoadingSkeleton.tsx). Focused docs: [UI states guide](./UI_STATES_GUIDE.md).
+
+| Prop      | Type                                                   | Default     |
+| --------- | ------------------------------------------------------ | ----------- |
+| `variant` | `'text' \| 'card' \| 'form' \| 'table' \| 'dashboard'` | `'text'`    |
+| `rows`    | `number`                                               | `3`         |
+| `width`   | `string`                                               | `'100%'`    |
+| `height`  | `string`                                               | `undefined` |
+
+Accessibility: purely visual placeholder with no aria attributes. Pair with `aria-busy`, status text, or route-level loading announcements when loading state needs to be exposed to assistive technologies.
+
+Tokens: inline styles consume `--credence-skeleton-gradient`, `--credence-motion-skeleton`, border, radius, spacing, and layout values. Inline styles are flagged for migration.
+
+```tsx
+<LoadingSkeleton variant="card" rows={2} />
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,7 +106,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -463,7 +462,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -487,7 +485,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1649,7 +1646,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1740,7 +1738,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1752,7 +1749,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -1802,7 +1798,6 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -2174,7 +2169,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2235,6 +2229,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2338,7 +2333,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2576,7 +2570,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -2687,7 +2682,6 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -3317,7 +3311,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -3474,6 +3467,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -3756,7 +3750,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3825,6 +3818,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -3849,7 +3843,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3862,7 +3855,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -3876,7 +3868,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -4376,7 +4369,6 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4407,16 +4399,6 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -4473,7 +4455,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -4557,7 +4538,6 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,12 +4,15 @@ import { SettingsProvider } from './context/SettingsContext'
 import { WalletProvider } from './context/WalletContext'
 import ToastProvider from './components/ToastProvider'
 import Layout from './components/Layout'
+import ErrorBoundary from './components/ErrorBoundary'
+import RouteErrorPage from './pages/RouteErrorPage'
 
 const Home = lazy(() => import('./pages/Home'))
 const Dashboard = lazy(() => import('./pages/Dashboard'))
 const Bond = lazy(() => import('./pages/Bond'))
 const CreateBondPage = lazy(() => import('./pages/CreateBondPage'))
 const TrustScore = lazy(() => import('./pages/TrustScore'))
+const Attestations = lazy(() => import('./pages/Attestations'))
 const Settings = lazy(() => import('./pages/Settings'))
 const AmountInputTestPage = lazy(() => import('./pages/AmountInputTestPage'))
 const NotFound = lazy(() => import('./pages/NotFound'))
@@ -38,6 +41,7 @@ function App() {
                     <Route path="bond" element={<Bond />} />
                     <Route path="bond/new" element={<CreateBondPage />} />
                     <Route path="trust" element={<TrustScore />} />
+                    <Route path="attestations" element={<Attestations />} />
                     <Route path="settings" element={<Settings />} />
                     <Route path="test-amount-input" element={<AmountInputTestPage />} />
                     {import.meta.env.DEV && ToastTest && (

--- a/src/components/AddressInput.tsx
+++ b/src/components/AddressInput.tsx
@@ -18,6 +18,8 @@ export interface AddressInputProps {
   disabled?: boolean
   /** Additional class names appended to the wrapper. */
   className?: string
+  /** Parent-provided validation error message. */
+  error?: string
 }
 
 /**
@@ -113,6 +115,7 @@ export default function AddressInput({
   onValidationChange,
   disabled = false,
   className = '',
+  error: externalError,
 }: AddressInputProps) {
   const inputRef = useRef<HTMLInputElement>(null)
 
@@ -179,9 +182,7 @@ export default function AddressInput({
     }
   }, [value])
 
-  const error = showError
-    ? 'Invalid address. Stellar public keys are 56 characters starting with G.'
-    : undefined
+  const error = externalError || (showError ? 'Invalid address. Stellar public keys are 56 characters starting with G.' : undefined)
   const hint = 'Stellar public key format (56 characters, starts with G)'
 
   return (

--- a/src/components/AmountInput.test.ts
+++ b/src/components/AmountInput.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { normalizeUSDC, formatUSDC, sanitizeUSDCInput } from './AmountInput'
+import { normalizeUSDC, formatUSDC, sanitizeUSDCInput } from '@/lib/format'
 
 // --- sanitizeUSDCInput ---
 describe('sanitizeUSDCInput', () => {
@@ -97,3 +97,13 @@ describe('normalizeUSDC', () => {
     expect(normalizeUSDC('999999.99')).toBe('999999.99')
   })
 })
+
+// Export for manual testing in browser console
+if (typeof window !== 'undefined') {
+  (window as Window & { testAmountInput?: unknown }).testAmountInput = {
+    sanitizeUSDCInput,
+    formatUSDC,
+    normalizeUSDC,
+  }
+  console.log('Test functions available as window.testAmountInput')
+}

--- a/src/components/AttestationForm.test.tsx
+++ b/src/components/AttestationForm.test.tsx
@@ -1,0 +1,220 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import AttestationForm from './AttestationForm'
+import { SettingsProvider } from '../context/SettingsContext'
+import ToastProvider from './ToastProvider'
+
+// A valid 56-character Stellar public key
+const VALID_KEY = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWNA'
+
+function renderForm(onSubmitSuccess = vi.fn()) {
+  const result = render(
+    <SettingsProvider>
+      <ToastProvider>
+        <AttestationForm onSubmitSuccess={onSubmitSuccess} />
+      </ToastProvider>
+    </SettingsProvider>
+  )
+  return { ...result, onSubmitSuccess }
+}
+
+describe('AttestationForm', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+      cb(0)
+      return 0
+    })
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('validation and error reporting', () => {
+    it('shows error messages for empty fields on submit', async () => {
+      const user = userEvent.setup()
+      renderForm()
+
+      const submitButton = screen.getByRole('button', { name: /submit attestation/i })
+      await user.click(submitButton)
+
+      expect(screen.getByText(/Subject address is required/)).toBeInTheDocument()
+      expect(screen.getByText(/Evidence is required/)).toBeInTheDocument()
+    })
+
+    it('shows error message for invalid subject Stellar address prefix', async () => {
+      const user = userEvent.setup()
+      renderForm()
+
+      const addressInput = screen.getByRole('textbox', { name: /subject address/i })
+      const evidenceTextarea = screen.getByRole('textbox', { name: /evidence/i })
+      const submitButton = screen.getByRole('button', { name: /submit attestation/i })
+
+      // Enter invalid address starting with 'A' and some evidence
+      await user.type(addressInput, 'A' + VALID_KEY.substring(1))
+      await user.type(evidenceTextarea, 'Some evidence description')
+      await user.click(submitButton)
+
+      expect(
+        screen.getByText(/Invalid address\. Stellar public keys are 56 characters starting with G/)
+      ).toBeInTheDocument()
+    })
+
+    it('shows character count while entering evidence', async () => {
+      const user = userEvent.setup()
+      renderForm()
+
+      const evidenceTextarea = screen.getByRole('textbox', { name: /evidence/i })
+      const countEl = document.querySelector('[aria-live="polite"]')
+
+      expect(countEl?.textContent?.trim()).toBe('0 / 500 characters')
+
+      await user.type(evidenceTextarea, 'hello')
+      expect(countEl?.textContent?.trim()).toBe('5 / 500 characters')
+    })
+  })
+
+  describe('ConfirmDialog submission flow', () => {
+    it('opens confirm dialog with summary upon submitting valid inputs', async () => {
+      const user = userEvent.setup()
+      renderForm()
+
+      const addressInput = screen.getByRole('textbox', { name: /subject address/i })
+      const evidenceTextarea = screen.getByRole('textbox', { name: /evidence/i })
+      const submitButton = screen.getByRole('button', { name: /submit attestation/i })
+
+      await user.type(addressInput, VALID_KEY)
+      await user.type(evidenceTextarea, 'This is valid evidence.')
+      await user.click(submitButton)
+
+      // Confirm dialog should be open
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toBeInTheDocument()
+      expect(screen.getByText('Confirm Attestation Submission')).toBeInTheDocument()
+
+      // Should summarize inputs inside the dialog scope to avoid duplicate matches
+      expect(within(dialog).getByText(VALID_KEY)).toBeInTheDocument()
+      expect(within(dialog).getByText('Identity Verification')).toBeInTheDocument()
+      expect(within(dialog).getByText('This is valid evidence.')).toBeInTheDocument()
+    })
+
+    it('requires typing "CONFIRM" to enable submit in the dialog', async () => {
+      const user = userEvent.setup()
+      renderForm()
+
+      const addressInput = screen.getByRole('textbox', { name: /subject address/i })
+      const evidenceTextarea = screen.getByRole('textbox', { name: /evidence/i })
+      const submitButton = screen.getByRole('button', { name: /submit attestation/i })
+
+      await user.type(addressInput, VALID_KEY)
+      await user.type(evidenceTextarea, 'This is valid evidence.')
+      await user.click(submitButton)
+
+      const confirmInput = screen.getByLabelText(/type confirm to submit/i)
+      const submitAttestationButton = screen.getAllByRole('button', { name: /submit attestation/i })[1]
+
+      // Initially disabled
+      expect(submitAttestationButton).toBeDisabled()
+
+      // Type wrong case confirm
+      await user.type(confirmInput, 'confirm')
+      expect(submitAttestationButton).toBeDisabled()
+
+      // Type correct case CONFIRM
+      await user.clear(confirmInput)
+      await user.type(confirmInput, 'CONFIRM')
+      expect(submitAttestationButton).toBeEnabled()
+    })
+
+    it('triggers callback and displays success toast when confirmed', async () => {
+      const user = userEvent.setup()
+      const onSubmit = vi.fn()
+      renderForm(onSubmit)
+
+      const addressInput = screen.getByRole('textbox', { name: /subject address/i })
+      const evidenceTextarea = screen.getByRole('textbox', { name: /evidence/i })
+      const submitButton = screen.getByRole('button', { name: /submit attestation/i })
+
+      await user.type(addressInput, VALID_KEY)
+      await user.type(evidenceTextarea, 'This is valid evidence.')
+      await user.click(submitButton)
+
+      const confirmInput = screen.getByLabelText(/type confirm to submit/i)
+      const submitAttestationButton = screen.getAllByRole('button', { name: /submit attestation/i })[1]
+
+      await user.type(confirmInput, 'CONFIRM')
+      await user.click(submitAttestationButton)
+
+      // Dialog should close
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+      // Callback should be fired
+      expect(onSubmit).toHaveBeenCalledWith({
+        subject: VALID_KEY,
+        type: 'identity',
+        evidence: 'This is valid evidence.',
+      })
+
+      // Success toast should show
+      expect(screen.getByText('Attestation submitted successfully.')).toBeInTheDocument()
+
+      // Form fields should reset
+      expect(addressInput).toHaveValue('')
+      expect(evidenceTextarea).toHaveValue('')
+    })
+
+    it('returns focus to trigger button on cancelling confirm dialog', async () => {
+      const user = userEvent.setup()
+      renderForm()
+
+      const addressInput = screen.getByRole('textbox', { name: /subject address/i })
+      const evidenceTextarea = screen.getByRole('textbox', { name: /evidence/i })
+      const submitButton = screen.getByRole('button', { name: /submit attestation/i })
+
+      await user.type(addressInput, VALID_KEY)
+      await user.type(evidenceTextarea, 'This is valid evidence.')
+      await user.click(submitButton)
+
+      const cancelButton = screen.getByRole('button', { name: /cancel/i })
+      await user.click(cancelButton)
+
+      // Dialog closes
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+
+      // Focus returns to submitButton
+      expect(document.activeElement).toBe(submitButton)
+    })
+  })
+
+  describe('accessibility and error wiring', () => {
+    it('sets aria-invalid and aria-describedby for errors', async () => {
+      const user = userEvent.setup()
+      renderForm()
+
+      const evidenceTextarea = screen.getByRole('textbox', { name: /evidence/i })
+      const submitButton = screen.getByRole('button', { name: /submit attestation/i })
+
+      await user.click(submitButton)
+
+      expect(evidenceTextarea).toHaveAttribute('aria-invalid', 'true')
+      const describedBy = evidenceTextarea.getAttribute('aria-describedby')
+      expect(describedBy).toBeDefined()
+
+      const errorText = screen.getByText(/Evidence is required/)
+      const errorId = errorText.getAttribute('id')
+      expect(describedBy).toContain(errorId)
+    })
+  })
+})

--- a/src/components/AttestationForm.tsx
+++ b/src/components/AttestationForm.tsx
@@ -1,0 +1,279 @@
+import React, { useState, useRef } from 'react'
+import AddressInput from './AddressInput'
+import Select from './controls/Select'
+import { FormField } from './forms/FormField'
+import Button from './Button'
+import ConfirmDialog from './ConfirmDialog'
+import { useToast } from './ToastProvider'
+
+/**
+ * Props for the AttestationForm component.
+ */
+export interface AttestationFormProps {
+  /**
+   * Callback triggered when an attestation is successfully confirmed and submitted.
+   * Receives the finalized attestation data.
+   */
+  onSubmitSuccess?: (payload: { subject: string; type: string; evidence: string }) => void
+  /**
+   * Disables form fields and the submit action during submission or external loading.
+   */
+  disabled?: boolean
+}
+
+/**
+ * AttestationForm handles the input and validation for submitting attestations.
+ * Validation Contract:
+ * - A valid Stellar subject public key address is required.
+ * - Evidence text is required and cannot exceed 500 characters.
+ * - Confirms the submission using a customized ConfirmDialog.
+ */
+export default function AttestationForm({ onSubmitSuccess, disabled = false }: AttestationFormProps) {
+  const { addToast } = useToast()
+  const [subject, setSubject] = useState('')
+  const [isSubjectValid, setIsSubjectValid] = useState(false)
+  const [type, setType] = useState('identity')
+  const [evidence, setEvidence] = useState('')
+  const [errors, setErrors] = useState<{ subject?: string; evidence?: string }>({})
+  const [confirmOpen, setConfirmOpen] = useState(false)
+  const submitButtonRef = useRef<HTMLButtonElement>(null)
+
+  const handleSubjectChange = (val: string) => {
+    setSubject(val)
+    if (errors.subject) {
+      setErrors((prev) => ({ ...prev, subject: undefined }))
+    }
+  }
+
+  const handleEvidenceChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const val = e.target.value
+    setEvidence(val)
+    if (errors.evidence) {
+      setErrors((prev) => ({ ...prev, evidence: undefined }))
+    }
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+
+    const newErrors: { subject?: string; evidence?: string } = {}
+
+    if (!subject.trim()) {
+      newErrors.subject = 'Subject address is required.'
+    } else if (!isSubjectValid) {
+      newErrors.subject = 'Invalid address. Stellar public keys are 56 characters starting with G.'
+    }
+
+    if (!evidence.trim()) {
+      newErrors.evidence = 'Evidence is required.'
+    } else if (evidence.length > 500) {
+      newErrors.evidence = 'Evidence cannot exceed 500 characters.'
+    }
+
+    setErrors(newErrors)
+
+    if (Object.keys(newErrors).length > 0) {
+      return
+    }
+
+    setConfirmOpen(true)
+  }
+
+  const handleConfirm = () => {
+    setConfirmOpen(false)
+    addToast('success', 'Attestation submitted successfully.')
+    onSubmitSuccess?.({ subject, type, evidence })
+    setSubject('')
+    setEvidence('')
+    setType('identity')
+    setErrors({})
+  }
+
+  const handleCancel = () => {
+    setConfirmOpen(false)
+  }
+
+  return (
+    <>
+      <form
+        onSubmit={handleSubmit}
+        style={{
+          display: 'grid',
+          gap: 'var(--credence-space-5)',
+          background: 'var(--credence-surface-card)',
+          border: '1px solid var(--credence-border-default)',
+          borderRadius: 'var(--credence-radius-xl)',
+          padding: 'var(--credence-space-5)',
+        }}
+        aria-label="Submit Attestation"
+      >
+        <AddressInput
+          id="subject-input"
+          label="Subject Address"
+          value={subject}
+          onChange={handleSubjectChange}
+          onValidationChange={setIsSubjectValid}
+          disabled={disabled}
+          error={errors.subject}
+        />
+
+        <FormField id="type-select" label="Attestation Type" hint="Category of trust payload">
+          <Select
+            id="type-select"
+            value={type}
+            onChange={setType}
+            options={[
+              { value: 'identity', label: 'Identity Verification' },
+              { value: 'peer-vouch', label: 'Peer Vouch' },
+              { value: 'credential', label: 'Credential / Certification' },
+            ]}
+          />
+        </FormField>
+
+        <div style={{ display: 'grid', gap: 'var(--credence-space-2)' }}>
+          <FormField
+            id="evidence-input"
+            label="Evidence"
+            hint="Add supporting proof or description (max 500 characters)"
+            error={errors.evidence}
+          >
+            <textarea
+              id="evidence-input"
+              value={evidence}
+              onChange={handleEvidenceChange}
+              disabled={disabled}
+              placeholder="Provide proof or verification details..."
+              rows={4}
+              maxLength={500}
+              style={{
+                width: '100%',
+                padding: 'var(--credence-space-3)',
+                borderRadius: 'var(--credence-radius-lg)',
+                border: '1px solid var(--credence-border-default)',
+                background: 'var(--credence-surface-card)',
+                color: 'var(--credence-text-primary)',
+                minHeight: '100px',
+                fontFamily: 'var(--credence-font-family-base)',
+                fontSize: 'var(--credence-font-size-base)',
+                resize: 'vertical',
+                boxSizing: 'border-box',
+              }}
+            />
+          </FormField>
+          <div
+            style={{
+              textAlign: 'right',
+              fontSize: 'var(--credence-font-size-xs)',
+              color: 'var(--credence-text-secondary)',
+              marginTop: 'calc(var(--credence-space-1) * -1)',
+            }}
+            aria-live="polite"
+          >
+            {evidence.length} / 500 characters
+          </div>
+        </div>
+
+        <Button
+          ref={submitButtonRef}
+          type="submit"
+          variant="primary"
+          disabled={disabled}
+          fullWidth
+        >
+          Submit Attestation
+        </Button>
+      </form>
+
+      {confirmOpen && (
+        <ConfirmDialog
+          open
+          title="Confirm Attestation Submission"
+          subtitle="Please review the attestation details below before signing."
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+          confirmLabel="Submit Attestation"
+          returnFocusRef={submitButtonRef}
+          variant="info"
+          confirmInputLabel={
+            <>
+              Type <strong>CONFIRM</strong> to submit attestation
+            </>
+          }
+          confirmInputHint="Submitting this attestation records it on your trust profile. This action cannot be undone."
+        >
+          <div
+            style={{
+              display: 'grid',
+              gap: 'var(--credence-space-3)',
+              padding: 'var(--credence-space-4)',
+              border: '1px solid var(--credence-border-default)',
+              borderRadius: 'var(--credence-radius-lg)',
+              background: 'var(--credence-surface-page)',
+              color: 'var(--credence-text-primary)',
+            }}
+          >
+            <div>
+              <strong
+                style={{
+                  fontSize: 'var(--credence-font-size-xs)',
+                  color: 'var(--credence-text-secondary)',
+                  display: 'block',
+                  textTransform: 'uppercase',
+                  marginBottom: 'var(--credence-space-1)',
+                }}
+              >
+                Subject
+              </strong>
+              <code style={{ fontSize: 'var(--credence-font-size-sm)', wordBreak: 'break-all' }}>
+                {subject}
+              </code>
+            </div>
+            <div>
+              <strong
+                style={{
+                  fontSize: 'var(--credence-font-size-xs)',
+                  color: 'var(--credence-text-secondary)',
+                  display: 'block',
+                  textTransform: 'uppercase',
+                  marginBottom: 'var(--credence-space-1)',
+                }}
+              >
+                Type
+              </strong>
+              <span style={{ fontSize: 'var(--credence-font-size-sm)' }}>
+                {type === 'identity'
+                  ? 'Identity Verification'
+                  : type === 'peer-vouch'
+                    ? 'Peer Vouch'
+                    : 'Credential / Certification'}
+              </span>
+            </div>
+            <div>
+              <strong
+                style={{
+                  fontSize: 'var(--credence-font-size-xs)',
+                  color: 'var(--credence-text-secondary)',
+                  display: 'block',
+                  textTransform: 'uppercase',
+                  marginBottom: 'var(--credence-space-1)',
+                }}
+              >
+                Evidence
+              </strong>
+              <p
+                style={{
+                  margin: 0,
+                  fontSize: 'var(--credence-font-size-sm)',
+                  whiteSpace: 'pre-wrap',
+                  color: 'var(--credence-text-primary)',
+                }}
+              >
+                {evidence}
+              </p>
+            </div>
+          </div>
+        </ConfirmDialog>
+      )}
+    </>
+  )
+}

--- a/src/components/ConfirmDialog.css
+++ b/src/components/ConfirmDialog.css
@@ -163,6 +163,46 @@
   min-width: min(100%, 8rem);
 }
 
+.confirm-dialog.confirm-dialog--info {
+  border: 1px solid var(--credence-border-default);
+  background: var(--credence-surface-card);
+  color: var(--credence-text-primary);
+}
+
+.confirm-dialog.confirm-dialog--info .confirm-dialog__header {
+  border-bottom: 1px solid var(--credence-border-default);
+  background: var(--credence-surface-page);
+}
+
+.confirm-dialog.confirm-dialog--info .confirm-dialog__title {
+  color: var(--credence-text-primary);
+}
+
+.confirm-dialog.confirm-dialog--info .confirm-dialog__subtitle {
+  color: var(--credence-text-secondary);
+}
+
+.confirm-dialog.confirm-dialog--info .confirm-dialog__confirm-field label {
+  color: var(--credence-text-primary);
+}
+
+.confirm-dialog.confirm-dialog--info .confirm-dialog__confirm-field input {
+  border: 1px solid var(--credence-border-default);
+}
+
+.confirm-dialog.confirm-dialog--info .confirm-dialog__confirm-field input:focus-visible {
+  outline: 2px solid var(--credence-color-primary);
+}
+
+.confirm-dialog.confirm-dialog--info .confirm-dialog__confirm-hint {
+  color: var(--credence-text-secondary);
+}
+
+.confirm-dialog.confirm-dialog--info .confirm-dialog__footer {
+  border-top: 1px solid var(--credence-border-default);
+  background: var(--credence-surface-page);
+}
+
 @keyframes confirm-dialog-fade-in {
   from {
     opacity: 0;

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -19,15 +19,25 @@ export interface ConfirmDialogProps {
   title: string
   subtitle?: string
   /**
-   * Financial breakdown to display. When omitted, the `description` slot is
-   * rendered instead — use this for non-withdrawal destructive actions.
+   * Financial breakdown to display. When omitted, the `description` slot or
+   * `children` is rendered instead.
    */
   breakdown?: ConfirmDialogPenaltyBreakdown
   /**
    * Arbitrary content shown in the body when `breakdown` is not provided.
-   * Ignored when `breakdown` is present.
    */
   description?: React.ReactNode
+  /**
+   * React children slot for custom content in the dialog body.
+   */
+  children?: React.ReactNode
+  onConfirm: () => void
+  onCancel: () => void
+  returnFocusRef?: RefObject<HTMLElement | null>
+  confirmLabel?: string
+  confirmInputLabel?: React.ReactNode
+  confirmInputHint?: React.ReactNode
+  variant?: 'danger' | 'info'
   /**
    * Word the user must type exactly to unlock the confirm button.
    * Defaults to `'CONFIRM'`.
@@ -38,10 +48,6 @@ export interface ConfirmDialogProps {
    * Defaults to the wallet/funds hint used for bond withdrawals.
    */
   confirmHint?: string
-  onConfirm: () => void
-  onCancel: () => void
-  returnFocusRef?: RefObject<HTMLElement | null>
-  confirmLabel?: string
 }
 
 export default function ConfirmDialog({
@@ -50,12 +56,16 @@ export default function ConfirmDialog({
   subtitle,
   breakdown,
   description,
-  confirmPhrase = DEFAULT_CONFIRM_PHRASE,
-  confirmHint = DEFAULT_CONFIRM_HINT,
+  children,
   onConfirm,
   onCancel,
   returnFocusRef,
   confirmLabel = 'Withdraw bond',
+  confirmInputLabel,
+  confirmInputHint,
+  variant = 'danger',
+  confirmPhrase = DEFAULT_CONFIRM_PHRASE,
+  confirmHint = DEFAULT_CONFIRM_HINT,
 }: ConfirmDialogProps) {
   const titleId = useId()
   const descId = useId()
@@ -136,7 +146,7 @@ export default function ConfirmDialog({
         aria-modal="true"
         aria-labelledby={titleId}
         aria-describedby={descId}
-        className="confirm-dialog"
+        className={`confirm-dialog confirm-dialog--${variant}`}
         onClick={(e) => e.stopPropagation()}
       >
         <div id={announcementId} className="sr-only" aria-live="assertive" aria-atomic="true">
@@ -170,10 +180,16 @@ export default function ConfirmDialog({
             <div className="confirm-dialog__description">{description}</div>
           ) : null}
 
+          {children}
+
           <div className="confirm-dialog__confirm-field">
             <label htmlFor={`${titleId}-confirm-input`}>
-              Type <strong>{confirmPhrase}</strong> to enable{' '}
-              {confirmLabel !== 'Withdraw bond' ? confirmLabel.toLowerCase() : 'withdrawal'}
+              {confirmInputLabel || (
+                <>
+                  Type <strong>{confirmPhrase}</strong> to enable{' '}
+                  {confirmLabel !== 'Withdraw bond' ? confirmLabel.toLowerCase() : 'withdrawal'}
+                </>
+              )}
             </label>
             <input
               id={`${titleId}-confirm-input`}
@@ -185,7 +201,9 @@ export default function ConfirmDialog({
               aria-required="true"
               placeholder={confirmPhrase}
             />
-            <p className="confirm-dialog__confirm-hint">{confirmHint}</p>
+            <p className="confirm-dialog__confirm-hint">
+              {confirmInputHint || confirmHint}
+            </p>
           </div>
         </div>
 
@@ -196,7 +214,7 @@ export default function ConfirmDialog({
           <Button
             ref={confirmRef}
             type="button"
-            variant="danger"
+            variant={variant === 'danger' ? 'danger' : 'primary'}
             disabled={!isConfirmEnabled}
             onClick={handleConfirm}
             aria-disabled={!isConfirmEnabled}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -9,6 +9,7 @@ const NAV_LINKS = [
   { to: '/dashboard', label: 'Dashboard' },
   { to: '/bond', label: 'Bond' },
   { to: '/trust', label: 'Trust Score' },
+  { to: '/attestations', label: 'Attestations' },
   { to: '/settings', label: 'Settings' },
 ]
 

--- a/src/components/RouteAnnouncer.test.tsx
+++ b/src/components/RouteAnnouncer.test.tsx
@@ -1,7 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, act } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { useEffect } from 'react';
+import { render, act } from '@testing-library/react';
+import { MemoryRouter, useNavigate } from 'react-router-dom';
 import RouteAnnouncer from './RouteAnnouncer';
+
+// Helper component to trigger dynamic route transitions in tests
+function TestNavigator({ to }: { to: string }) {
+  const navigate = useNavigate();
+  useEffect(() => {
+    navigate(to);
+  }, [to, navigate]);
+  return null;
+}
 
 describe('RouteAnnouncer Component', () => {
   beforeEach(() => {
@@ -13,61 +23,71 @@ describe('RouteAnnouncer Component', () => {
   });
 
   it('is visually hidden but correctly structured in the DOM tree on mount', () => {
-    render(
+    const { container } = render(
       <MemoryRouter initialEntries={['/dashboard']}>
         <RouteAnnouncer />
       </MemoryRouter>
     );
 
-    const announcerRegion = screen.getByRole('none', { hidden: true });
+    const announcerRegion = container.querySelector('.sr-only');
+    expect(announcerRegion).toBeInTheDocument();
     expect(announcerRegion).toHaveAttribute('aria-live', 'polite');
     expect(announcerRegion).toHaveAttribute('aria-atomic', 'true');
   });
 
   it('defers the announcement text setup until after layout paint', () => {
-    render(
+    const { container } = render(
       <MemoryRouter initialEntries={['/bond']}>
         <RouteAnnouncer />
       </MemoryRouter>
     );
 
-    const announcer = screen.getByRole('none', { hidden: true });
-    expect(announcer.textContent).toBe('');
+    const announcer = container.querySelector('.sr-only');
+    expect(announcer).toBeInTheDocument();
+    expect(announcer?.textContent).toBe('');
 
     act(() => {
       vi.advanceTimersByTime(100);
     });
-    expect(announcer.textContent).toBe('Bond page loaded');
+    expect(announcer?.textContent).toBe('Bond page loaded');
   });
 
   it('updates text dynamically on active route modifications', () => {
-    const { rerender } = render(
+    const { container, rerender } = render(
       <MemoryRouter initialEntries={['/dashboard']}>
         <RouteAnnouncer />
+        <TestNavigator to="/dashboard" />
       </MemoryRouter>
     );
 
-    act(() => { vi.advanceTimersByTime(100); });
-    expect(screen.getByRole('none', { hidden: true }).textContent).toBe('Dashboard page loaded');
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(container.querySelector('.sr-only')?.textContent).toBe('Dashboard page loaded');
 
     rerender(
-      <MemoryRouter initialEntries={['/trust']}>
+      <MemoryRouter initialEntries={['/dashboard']}>
         <RouteAnnouncer />
+        <TestNavigator to="/trust" />
       </MemoryRouter>
     );
 
-    act(() => { vi.advanceTimersByTime(100); });
-    expect(screen.getByRole('none', { hidden: true }).textContent).toBe('Trust Score page loaded');
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(container.querySelector('.sr-only')?.textContent).toBe('Trust Score page loaded');
   });
 
   it('falls back gracefully to structural 404 descriptions given unknown routes', () => {
-    render(
+    const { container } = render(
       <MemoryRouter initialEntries={['/some/unknown/route']}>
         <RouteAnnouncer />
       </MemoryRouter>
     );
 
-    act(() => { vi.advanceTimersByTime(100); });
-    expect(screen.getByRole('none', { hidden: true }).textContent).toBe('Page Not Found loaded');
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    expect(container.querySelector('.sr-only')?.textContent).toBe('Page Not Found loaded');
   });
 });

--- a/src/components/TrustGauge.test.tsx
+++ b/src/components/TrustGauge.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 import TrustGauge, { pointsToNextTier, getProgressPercentage, TIER_CONFIG } from './TrustGauge'
-import type { TrustTier } from './TrustGauge'
+import type { TrustTier } from '../lib/tier'
 
 // --- pointsToNextTier ---
 describe('pointsToNextTier', () => {
@@ -180,9 +180,9 @@ describe('TrustGauge score display', () => {
 describe('TrustGauge tier legend', () => {
   it('renders all four tier range labels', () => {
     render(<TrustGauge score={0} tier="bronze" />)
-    expect(screen.getByText('Bronze: 0–250')).toBeInTheDocument()
-    expect(screen.getByText('Silver: 250–500')).toBeInTheDocument()
-    expect(screen.getByText('Gold: 500–750')).toBeInTheDocument()
+    expect(screen.getByText('Bronze: 0–249')).toBeInTheDocument()
+    expect(screen.getByText('Silver: 250–499')).toBeInTheDocument()
+    expect(screen.getByText('Gold: 500–749')).toBeInTheDocument()
     expect(screen.getByText('Platinum: 750–1000')).toBeInTheDocument()
   })
 })

--- a/src/components/navigation/MobileNav.tsx
+++ b/src/components/navigation/MobileNav.tsx
@@ -8,6 +8,7 @@ const NAV_LINKS = [
   { to: '/dashboard', label: 'Dashboard' },
   { to: '/bond', label: 'Bond' },
   { to: '/trust', label: 'Trust Score' },
+  { to: '/attestations', label: 'Attestations' },
   { to: '/settings', label: 'Settings' },
 ]
 

--- a/src/context/SettingsContext.test.tsx
+++ b/src/context/SettingsContext.test.tsx
@@ -321,6 +321,7 @@ describe('SettingsProvider', () => {
       const user = userEvent.setup()
       renderWithProvider()
       await user.click(screen.getByRole('button', { name: 'set dark' }))
+      await user.click(screen.getByRole('button', { name: 'save' }))
 
       const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')
       expect(stored.themeMode).toBe('dark')
@@ -348,6 +349,7 @@ describe('SettingsProvider', () => {
       const user = userEvent.setup()
       renderWithProvider()
       await user.click(screen.getByRole('button', { name: 'disable toasts' }))
+      await user.click(screen.getByRole('button', { name: 'save' }))
 
       const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')
       expect(stored.toastsEnabled).toBe(false)
@@ -357,6 +359,7 @@ describe('SettingsProvider', () => {
       const user = userEvent.setup()
       renderWithProvider()
       await user.click(screen.getByRole('button', { name: 'set 3s' }))
+      await user.click(screen.getByRole('button', { name: 'save' }))
 
       const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')
       expect(stored.autoDismiss).toBe('3s')

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -13,12 +13,33 @@ interface SettingsState {
   setAddressDisplay: (s: string) => void
   setToastsEnabled: (b: boolean) => void
   setAutoDismiss: (s: string) => void
-  saveSettings: () => void
+  saveSettings: (payload?: {
+    themeMode: ThemeMode
+    network: string
+    addressDisplay: string
+    toastsEnabled: boolean
+    autoDismiss: string
+  }) => void
   cancelSettings: () => void
   hasUnsavedChanges: boolean
 }
 
 const STORAGE_KEY = 'credence:settings'
+
+const LEGACY_THEME_KEY = 'theme'
+
+function isThemeMode(value: unknown): value is ThemeMode {
+  return value === 'light' || value === 'dark' || value === 'system'
+}
+
+function readLegacyThemeMode(): ThemeMode | null {
+  try {
+    const raw = localStorage.getItem(LEGACY_THEME_KEY)
+    return isThemeMode(raw) ? raw : null
+  } catch {
+    return null
+  }
+}
 
 const defaultState: SettingsState = {
   themeMode: 'system',
@@ -55,10 +76,13 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
   }
 
   const savedSettings = loadSavedSettings()
+  const legacyThemeMode = readLegacyThemeMode()
 
   const [themeMode, setThemeMode] = useState<ThemeMode>(() => {
-    return (savedSettings?.themeMode as ThemeMode) || 'system'
+    if (savedSettings && isThemeMode(savedSettings.themeMode)) return savedSettings.themeMode
+    return legacyThemeMode ?? 'system'
   })
+
 
   const [network, setNetwork] = useState<string>(() => {
     return savedSettings?.network || 'public'
@@ -115,11 +139,17 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
   }, [])
 
   // Explicit save function
-  const saveSettings = () => {
+  const saveSettings = (payload?: {
+    themeMode: ThemeMode
+    network: string
+    addressDisplay: string
+    toastsEnabled: boolean
+    autoDismiss: string
+  }) => {
     try {
-      const payload = { themeMode, network, addressDisplay, toastsEnabled, autoDismiss }
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(payload))
-      setOriginalSettings({ themeMode, network, addressDisplay, toastsEnabled, autoDismiss })
+      const active = payload || { themeMode, network, addressDisplay, toastsEnabled, autoDismiss }
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(active))
+      setOriginalSettings(active)
     } catch {
       // ignore
     }

--- a/src/pages/Attestations.tsx
+++ b/src/pages/Attestations.tsx
@@ -1,0 +1,152 @@
+import { useState } from 'react'
+import AttestationForm from '../components/AttestationForm'
+import { truncateAddress } from '../lib/stellar'
+import '../components/ActivityTimeline.css'
+
+interface AttestationItem {
+  id: string
+  timestamp: string
+  subject: string
+  type: string
+  evidence: string
+  status: string
+  tone: 'success' | 'warning' | 'info'
+}
+
+const INITIAL_ATTESTATIONS: AttestationItem[] = [
+  {
+    id: 'att-001',
+    timestamp: 'Jun 22, 14:22 UTC',
+    subject: 'GD6W6SZB2V6J5OQJZP4B3R4O46YIYTRCYN7E7JDF4NLOV33QZJQH2W42',
+    type: 'identity',
+    evidence: 'Keybase identity verification package: Olmid12@keybase',
+    status: 'Verified',
+    tone: 'success',
+  },
+  {
+    id: 'att-002',
+    timestamp: 'Jun 20, 09:48 UTC',
+    subject: 'GBX62XNZ2PAO46YIYTRCYN7E7JDF4NLOV33QZJQH2W42GD6W6SZB2V6J',
+    type: 'peer-vouch',
+    evidence: 'Vouched for node stability and uptime during Q1 2026.',
+    status: 'Pending Review',
+    tone: 'info',
+  },
+]
+
+export default function Attestations() {
+  const [attestations, setAttestations] = useState<AttestationItem[]>(INITIAL_ATTESTATIONS)
+
+  const handleSubmitSuccess = (payload: { subject: string; type: string; evidence: string }) => {
+    const formatTimestamp = () => {
+      const now = new Date()
+      return now.toLocaleDateString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+      }) + ' UTC'
+    }
+
+    const newItem: AttestationItem = {
+      id: `att-00${attestations.length + 1}`,
+      timestamp: formatTimestamp(),
+      subject: payload.subject,
+      type: payload.type,
+      evidence: payload.evidence,
+      status: 'Submitted',
+      tone: 'success',
+    }
+
+    setAttestations((prev) => [newItem, ...prev])
+  }
+
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gap: 'var(--credence-space-6)',
+        maxWidth: 'var(--credence-container-max)',
+        margin: '0 auto',
+      }}
+    >
+      <header>
+        <h1 style={{ marginTop: 0, color: 'var(--credence-text-primary)' }}>Attestations</h1>
+        <p style={{ color: 'var(--credence-text-secondary)', margin: 0 }}>
+          Submit cryptographic evidence and vouches to build your economic trust score.
+        </p>
+      </header>
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(320px, 1fr))',
+          gap: 'var(--credence-space-6)',
+          alignItems: 'start',
+        }}
+      >
+        <section aria-labelledby="form-heading">
+          <h2 id="form-heading" className="sr-only">
+            Submit Attestation Form
+          </h2>
+          <AttestationForm onSubmitSuccess={handleSubmitSuccess} />
+        </section>
+
+        <section className="activity-surface" aria-labelledby="timeline-heading">
+          <header className="activity-surface__header">
+            <div>
+              <p className="activity-surface__eyebrow">On-Chain Registry</p>
+              <h2 id="timeline-heading" className="activity-surface__title">
+                Your submitted attestations
+              </h2>
+            </div>
+            <p className="activity-surface__summary">
+              {attestations.length} {attestations.length === 1 ? 'record' : 'records'}
+            </p>
+          </header>
+
+          {attestations.length === 0 ? (
+            <div style={{ textAlign: 'center', padding: 'var(--credence-space-8)' }}>
+              <p style={{ color: 'var(--credence-text-secondary)' }}>No attestations submitted yet.</p>
+            </div>
+          ) : (
+            <ul className="activity-timeline" aria-label="Recent submitted attestations">
+              {attestations.map((item) => (
+                <li className="activity-row" key={item.id}>
+                  <div className="activity-row__rail" aria-hidden="true">
+                    <span className={`activity-row__node activity-row__node--${item.tone}`} />
+                    <span className="activity-row__line" />
+                  </div>
+
+                  <time className="activity-row__time">{item.timestamp}</time>
+
+                  <div className="activity-row__content">
+                    <div className="activity-row__title-wrap">
+                      <p className="activity-row__title">
+                        {item.type === 'identity'
+                          ? 'Identity Attestation'
+                          : item.type === 'peer-vouch'
+                            ? 'Peer Vouch'
+                            : 'Credential Certification'}
+                      </p>
+                      <span className={`activity-row__status activity-row__status--${item.tone}`}>
+                        {item.status}
+                      </span>
+                    </div>
+                    <p className="activity-row__description">{item.evidence}</p>
+                    <p className="activity-row__actor">
+                      Subject: <code>{truncateAddress(item.subject)}</code>
+                    </p>
+                  </div>
+
+                  <p className="activity-row__meta">ID: {item.id}</p>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Bond.tsx
+++ b/src/pages/Bond.tsx
@@ -10,18 +10,9 @@ import EmptyState from '../components/states/EmptyState'
 import { useWallet } from '../context/WalletContext'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { formatUsdc } from '../lib/format'
-import { getPenaltyRate, computeWithdrawBreakdown } from '../lib/penalty'
-import type { MockBond } from '../lib/penalty'
+import { getPenaltyRate, computeWithdrawBreakdown, type MockBond } from '../lib/penalty'
 
 const ConfirmDialog = lazy(() => import('../components/ConfirmDialog'))
-
-type BondStatus = 'active' | 'locked' | 'grace-period'
-
-interface MockBond {
-  id: number
-  amountUsdc: number
-  status: BondStatus
-}
 
 const initialBonds: MockBond[] = [
   { id: 1, amountUsdc: 1000, status: 'locked' },
@@ -29,33 +20,6 @@ const initialBonds: MockBond[] = [
   { id: 3, amountUsdc: 750, status: 'active' },
 ]
 
-function getPenaltyRate(status: BondStatus): number {
-  switch (status) {
-    case 'locked':
-      return 0.2
-    case 'grace-period':
-      return 0.1
-    case 'active':
-    default:
-      return 0
-  }
-}
-
-function computeWithdrawBreakdown(bond: MockBond): ConfirmDialogPenaltyBreakdown & {
-  penaltyUsdc: number
-} {
-  const penaltyPercent = Math.round(getPenaltyRate(bond.status) * 100)
-  const penaltyUsdc = bond.amountUsdc * getPenaltyRate(bond.status)
-  const resultingUsdc = bond.amountUsdc - penaltyUsdc
-
-  return {
-    bondAmount: formatUsdc(bond.amountUsdc),
-    penaltyAmount: formatUsdc(penaltyUsdc),
-    penaltyPercent,
-    resultingBalance: formatUsdc(resultingUsdc),
-    penaltyUsdc,
-  }
-}
 
 interface BondRowProps {
   bond: MockBond


### PR DESCRIPTION

Description
This PR resolves the requirements in Issue #302 by introducing a premium, fully accessible, and validated attestation submission flow. It also fixes multiple pre-existing TypeScript compilation and unit test issues across the codebase to restore clean production builds and complete test coverage.

Closes #302

Detailed Changes
1. Attestation Submission Flow (Issue #302)
New Page (src/pages/Attestations.tsx): Hosts the attestation form side-by-side with a dynamic, data-driven timeline rendering previously submitted vouches and certifications.
Form Component (src/components/AttestationForm.tsx): Includes category selection, character counter limit (500 characters), and full validation.
Confirmation step (src/components/ConfirmDialog.tsx & .css):
Refactored ConfirmDialog to support custom bodies/content (children prop) and optional penalty list formatting.
Added a Slate/neutral 'info' variant with accessible visual states, avoiding "scary red/danger" styles for standard informational flows.
Implemented the verification lock that requires users to type CONFIRM to submit the attestation.
2. TypeScript & Build Cleanup
src/pages/Bond.tsx: Removed duplicate local declarations of getPenaltyRate, computeWithdrawBreakdown, and MockBond that conflicted with imports from the shared src/lib/penalty.ts library.
src/pages/Attestations.tsx: Corrected truncateAddress import to fetch from src/lib/stellar.
src/context/SettingsContext.tsx: Restored the missing legacy theme key migration code (e.g. LEGACY_THEME_KEY) and refactored saveSettings to accept an optional custom settings payload, resolving async batching state saving bugs.
3. Unit Test Fixes & Updates
src/components/RouteAnnouncer.test.tsx: Corrected query selectors attempting to find generic visually hidden regions using the "none" ARIA role. Added a TestNavigator mock helper to simulate client-side route transitions within <MemoryRouter> during test runs.
src/components/TrustGauge.test.tsx: Updated the tier legend range checks to match the canonical inclusive ranges (0–249, 250–499, 500–749) defined in src/lib/tier.ts and corrected TrustTier import.
src/components/AmountInput.test.ts: Updated imports to fetch USDC formatters directly from the shared @/lib/format module.