### PR TITLE
feat: add keyboard shortcuts help dialog (closes #306)

### DIFF
--- a/src/components/KeyboardShortcutsDialog.css
+++ b/src/components/KeyboardShortcutsDialog.css
@@ -1,0 +1,221 @@
+/* ─── Backdrop ─────────────────────────────────────────────────────────────── */
+
+.shortcuts-dialog__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--credence-space-4);
+  background: rgba(15, 23, 42, 0.55);
+  animation: shortcuts-dialog-fade-in var(--credence-motion-duration-fast)
+    var(--credence-motion-easing-decelerate);
+}
+
+[data-theme='dark'] .shortcuts-dialog__backdrop {
+  background: rgba(0, 0, 0, 0.65);
+}
+
+/* ─── Dialog panel ─────────────────────────────────────────────────────────── */
+
+.shortcuts-dialog {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 34rem;
+  max-height: min(90vh, 44rem);
+  overflow: hidden;
+  border: 1px solid var(--credence-border-default);
+  border-radius: var(--credence-radius-xl);
+  background: var(--credence-surface-card);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.2);
+  color: var(--credence-text-primary);
+}
+
+[data-theme='dark'] .shortcuts-dialog {
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
+}
+
+/* ─── Header ───────────────────────────────────────────────────────────────── */
+
+.shortcuts-dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--credence-space-5) var(--credence-space-5) var(--credence-space-4);
+  border-bottom: 1px solid var(--credence-border-default);
+  background: var(--credence-surface-card);
+  flex-shrink: 0;
+}
+
+.shortcuts-dialog__title {
+  margin: 0;
+  font-size: var(--credence-font-size-lg);
+  font-weight: var(--credence-font-weight-bold);
+  line-height: var(--credence-line-height-tight);
+  color: var(--credence-text-primary);
+}
+
+.shortcuts-dialog__close {
+  /* Override ghost button defaults for compact icon button */
+  padding: var(--credence-space-2) !important;
+  line-height: 1;
+  font-size: var(--credence-font-size-base);
+  color: var(--credence-text-secondary);
+}
+
+.shortcuts-dialog__close:hover {
+  color: var(--credence-text-primary);
+}
+
+/* ─── Body / shortcut list ─────────────────────────────────────────────────── */
+
+.shortcuts-dialog__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--credence-space-5);
+  display: grid;
+  gap: var(--credence-space-6);
+}
+
+.shortcuts-dialog__group {
+  display: grid;
+  gap: var(--credence-space-3);
+}
+
+.shortcuts-dialog__group-heading {
+  margin: 0;
+  font-size: var(--credence-font-size-xs);
+  font-weight: var(--credence-font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--credence-text-secondary);
+}
+
+.shortcuts-dialog__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid var(--credence-border-default);
+  border-radius: var(--credence-radius-lg);
+  overflow: hidden;
+}
+
+.shortcuts-dialog__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--credence-space-4);
+  padding: var(--credence-space-3) var(--credence-space-4);
+  font-size: var(--credence-font-size-sm);
+  border-bottom: 1px solid var(--credence-border-default);
+}
+
+.shortcuts-dialog__item:last-child {
+  border-bottom: none;
+}
+
+.shortcuts-dialog__label {
+  color: var(--credence-text-primary);
+  line-height: var(--credence-line-height-base);
+}
+
+/* ─── kbd styling ──────────────────────────────────────────────────────────── */
+
+.shortcuts-dialog__keys {
+  display: flex;
+  align-items: center;
+  gap: var(--credence-space-1);
+  flex-shrink: 0;
+}
+
+.shortcuts-dialog__key-group {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--credence-space-1);
+}
+
+.shortcuts-dialog__key-plus {
+  color: var(--credence-text-secondary);
+  font-size: var(--credence-font-size-xs);
+  user-select: none;
+}
+
+.shortcuts-dialog__kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.75rem;
+  padding: var(--credence-space-1) var(--credence-space-2);
+  border: 1px solid var(--credence-border-default);
+  border-bottom-width: 2px;
+  border-radius: var(--credence-radius-sm);
+  background: var(--credence-surface-page);
+  font-family: var(--credence-font-family-base);
+  font-size: var(--credence-font-size-xs);
+  font-weight: var(--credence-font-weight-semibold);
+  color: var(--credence-text-primary);
+  line-height: 1;
+  white-space: nowrap;
+}
+
+[data-theme='dark'] .shortcuts-dialog__kbd {
+  background: var(--credence-color-slate-700);
+  border-color: var(--credence-color-slate-600);
+}
+
+/* ─── Footer ───────────────────────────────────────────────────────────────── */
+
+.shortcuts-dialog__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--credence-space-3);
+  padding: var(--credence-space-4) var(--credence-space-5) var(--credence-space-5);
+  border-top: 1px solid var(--credence-border-default);
+  background: var(--credence-surface-card);
+  flex-shrink: 0;
+}
+
+/* ─── Entrance animation ───────────────────────────────────────────────────── */
+
+@keyframes shortcuts-dialog-fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+/* ─── Mobile: bottom sheet ─────────────────────────────────────────────────── */
+
+@media (max-width: 767px) {
+  .shortcuts-dialog__backdrop {
+    align-items: flex-end;
+    padding: 0;
+  }
+
+  .shortcuts-dialog {
+    max-width: none;
+    max-height: 92vh;
+    border-radius: var(--credence-radius-xl) var(--credence-radius-xl) 0 0;
+  }
+
+  .shortcuts-dialog__footer {
+    flex-direction: column;
+  }
+
+  .shortcuts-dialog__footer .credence-button {
+    width: 100%;
+  }
+}
+
+/* ─── Wider screens ────────────────────────────────────────────────────────── */
+
+@media (min-width: 1280px) {
+  .shortcuts-dialog {
+    max-width: 38rem;
+  }
+}

--- a/src/components/KeyboardShortcutsDialog.test.tsx
+++ b/src/components/KeyboardShortcutsDialog.test.tsx
@@ -1,0 +1,302 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import KeyboardShortcutsDialog from './KeyboardShortcutsDialog'
+import { KEYBOARD_SHORTCUTS } from '../data/keyboardShortcuts'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderDialog(overrides: Partial<Parameters<typeof KeyboardShortcutsDialog>[0]> = {}) {
+  const onClose = vi.fn()
+  const props = { open: true, onClose, ...overrides }
+  const result = render(<KeyboardShortcutsDialog {...props} />)
+  return { ...result, onClose }
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+    cb(0)
+    return 0
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  document.body.style.overflow = ''
+})
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+describe('KeyboardShortcutsDialog — rendering', () => {
+  it('renders nothing when open is false', () => {
+    renderDialog({ open: false })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders the dialog when open is true', () => {
+    renderDialog()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('has role="dialog"', () => {
+    renderDialog()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('has aria-modal="true"', () => {
+    renderDialog()
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true')
+  })
+
+  it('has an accessible title via aria-labelledby', () => {
+    renderDialog()
+    const dialog = screen.getByRole('dialog')
+    const labelledById = dialog.getAttribute('aria-labelledby')
+    expect(labelledById).toBeTruthy()
+    const titleEl = document.getElementById(labelledById!)
+    expect(titleEl).toHaveTextContent('Keyboard Shortcuts')
+  })
+
+  it('renders all shortcut labels from the KEYBOARD_SHORTCUTS array', () => {
+    renderDialog()
+    for (const shortcut of KEYBOARD_SHORTCUTS) {
+      expect(screen.getByText(shortcut.label)).toBeInTheDocument()
+    }
+  })
+
+  it('renders a close button with an accessible label', () => {
+    renderDialog()
+    expect(
+      screen.getByRole('button', { name: /close keyboard shortcuts/i })
+    ).toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Closing behaviour
+// ---------------------------------------------------------------------------
+
+describe('KeyboardShortcutsDialog — closing', () => {
+  it('calls onClose when the × close button is clicked', async () => {
+    const user = userEvent.setup()
+    const { onClose } = renderDialog()
+    await user.click(screen.getByRole('button', { name: /close keyboard shortcuts/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when the footer Close button is clicked', async () => {
+    const user = userEvent.setup()
+    const { onClose } = renderDialog()
+    await user.click(screen.getByRole('button', { name: /^close$/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when Escape is pressed', async () => {
+    const user = userEvent.setup()
+    const { onClose } = renderDialog()
+    await user.keyboard('{Escape}')
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when the backdrop is clicked', async () => {
+    const user = userEvent.setup()
+    const { onClose } = renderDialog()
+    const backdrop = screen.getByRole('dialog').parentElement!
+    await user.click(backdrop)
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('does NOT call onClose when clicking inside the dialog panel', async () => {
+    const user = userEvent.setup()
+    const { onClose } = renderDialog()
+    await user.click(screen.getByRole('dialog'))
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Scroll lock
+// ---------------------------------------------------------------------------
+
+describe('KeyboardShortcutsDialog — body scroll lock', () => {
+  it('sets document.body.style.overflow to "hidden" when open', () => {
+    renderDialog({ open: true })
+    expect(document.body.style.overflow).toBe('hidden')
+  })
+
+  it('restores document.body.style.overflow on unmount', () => {
+    document.body.style.overflow = 'auto'
+    const { unmount } = renderDialog({ open: true })
+    expect(document.body.style.overflow).toBe('hidden')
+    unmount()
+    expect(document.body.style.overflow).toBe('auto')
+  })
+
+  it('does not lock scroll when open is false', () => {
+    document.body.style.overflow = ''
+    renderDialog({ open: false })
+    expect(document.body.style.overflow).toBe('')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Focus management
+// ---------------------------------------------------------------------------
+
+describe('KeyboardShortcutsDialog — focus management', () => {
+  it('initially focuses the × close button when opened', () => {
+    renderDialog()
+    expect(document.activeElement).toBe(
+      screen.getByRole('button', { name: /close keyboard shortcuts/i })
+    )
+  })
+
+  it('returns focus to returnFocusRef element on close', () => {
+    const triggerEl = document.createElement('button')
+    triggerEl.type = 'button'
+    Object.defineProperty(triggerEl, 'offsetParent', {
+      get: () => document.body,
+      configurable: true,
+    })
+    document.body.appendChild(triggerEl)
+    triggerEl.focus()
+
+    const returnFocusRef = createRef<HTMLButtonElement>()
+    ;(returnFocusRef as React.MutableRefObject<HTMLButtonElement>).current = triggerEl
+
+    const onClose = vi.fn()
+    const { rerender } = render(
+      <KeyboardShortcutsDialog open={true} onClose={onClose} returnFocusRef={returnFocusRef} />
+    )
+
+    rerender(
+      <KeyboardShortcutsDialog open={false} onClose={onClose} returnFocusRef={returnFocusRef} />
+    )
+
+    expect(document.activeElement).toBe(triggerEl)
+
+    document.body.removeChild(triggerEl)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tab focus trapping
+// ---------------------------------------------------------------------------
+
+describe('KeyboardShortcutsDialog — tab focus trapping', () => {
+  it('keeps focus inside the dialog when Tab is pressed', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    const dialog = screen.getByRole('dialog')
+
+    // Tab through all focusable elements — focus should never leave the dialog
+    for (let i = 0; i < 5; i++) {
+      await user.tab()
+      expect(dialog.contains(document.activeElement)).toBe(true)
+    }
+  })
+
+  it('keeps focus inside the dialog when Shift+Tab is pressed', async () => {
+    const user = userEvent.setup()
+    renderDialog()
+
+    const dialog = screen.getByRole('dialog')
+
+    for (let i = 0; i < 5; i++) {
+      await user.tab({ shift: true })
+      expect(dialog.contains(document.activeElement)).toBe(true)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Global Shift+? listener (tested via Layout in integration, but also unit-
+// tested here with a thin wrapper to avoid a full router setup).
+// ---------------------------------------------------------------------------
+
+describe('KeyboardShortcutsDialog — global Shift+? shortcut guard', () => {
+  /**
+   * Helper that fires a keydown event on the window with key='?' and checks
+   * whether a state setter was called, simulating how Layout wires the handler.
+   */
+  function createHandler(setter: (v: boolean) => void) {
+    return (event: KeyboardEvent) => {
+      if (event.key !== '?') return
+      const target = event.target as HTMLElement
+      const tag = target.tagName
+      if (
+        tag === 'INPUT' ||
+        tag === 'TEXTAREA' ||
+        tag === 'SELECT' ||
+        target.isContentEditable
+      ) {
+        return
+      }
+      setter(true)
+    }
+  }
+
+  it('fires the setter when ? is pressed outside a text field', () => {
+    const setter = vi.fn()
+    const handler = createHandler(setter)
+    window.addEventListener('keydown', handler)
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: '?', bubbles: true }))
+    expect(setter).toHaveBeenCalledWith(true)
+
+    window.removeEventListener('keydown', handler)
+  })
+
+  it('does NOT fire the setter when ? is pressed inside an <input>', () => {
+    const setter = vi.fn()
+    const handler = createHandler(setter)
+    window.addEventListener('keydown', handler)
+
+    const input = document.createElement('input')
+    document.body.appendChild(input)
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: '?', bubbles: true }))
+    expect(setter).not.toHaveBeenCalled()
+
+    document.body.removeChild(input)
+    window.removeEventListener('keydown', handler)
+  })
+
+  it('does NOT fire the setter when ? is pressed inside a <textarea>', () => {
+    const setter = vi.fn()
+    const handler = createHandler(setter)
+    window.addEventListener('keydown', handler)
+
+    const ta = document.createElement('textarea')
+    document.body.appendChild(ta)
+    ta.dispatchEvent(new KeyboardEvent('keydown', { key: '?', bubbles: true }))
+    expect(setter).not.toHaveBeenCalled()
+
+    document.body.removeChild(ta)
+    window.removeEventListener('keydown', handler)
+  })
+
+  it('does NOT fire the setter when ? is pressed inside a contenteditable element', () => {
+    const setter = vi.fn()
+    const handler = createHandler(setter)
+    window.addEventListener('keydown', handler)
+
+    const div = document.createElement('div')
+    div.contentEditable = 'true'
+    document.body.appendChild(div)
+    div.dispatchEvent(new KeyboardEvent('keydown', { key: '?', bubbles: true }))
+    expect(setter).not.toHaveBeenCalled()
+
+    document.body.removeChild(div)
+    window.removeEventListener('keydown', handler)
+  })
+})

--- a/src/components/KeyboardShortcutsDialog.tsx
+++ b/src/components/KeyboardShortcutsDialog.tsx
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useId, useRef } from 'react'
+import { createPortal } from 'react-dom'
+import { useFocusTrap } from '../hooks/useFocusTrap'
+import { KEYBOARD_SHORTCUTS, type KeyboardShortcut } from '../data/keyboardShortcuts'
+import Button from './Button'
+import './KeyboardShortcutsDialog.css'
+
+export interface KeyboardShortcutsDialogProps {
+  open: boolean
+  onClose: () => void
+  /**
+   * Optional ref whose element will receive focus after the dialog closes.
+   * When omitted, focus returns to whichever element was active before opening.
+   */
+  returnFocusRef?: React.RefObject<HTMLElement | null>
+}
+
+/** Groups an array of shortcuts by their `group` field, preserving insertion order. */
+function groupShortcuts(shortcuts: KeyboardShortcut[]): Map<string, KeyboardShortcut[]> {
+  const map = new Map<string, KeyboardShortcut[]>()
+  for (const shortcut of shortcuts) {
+    const existing = map.get(shortcut.group)
+    if (existing) {
+      existing.push(shortcut)
+    } else {
+      map.set(shortcut.group, [shortcut])
+    }
+  }
+  return map
+}
+
+const GROUPED = groupShortcuts(KEYBOARD_SHORTCUTS)
+
+/**
+ * Modal dialog listing all global keyboard shortcuts.
+ *
+ * - Renders via a React portal into `document.body`.
+ * - Focus is trapped inside while open; restored on close.
+ * - Escape closes the dialog.
+ * - Backdrop click closes the dialog.
+ */
+export default function KeyboardShortcutsDialog({
+  open,
+  onClose,
+  returnFocusRef,
+}: KeyboardShortcutsDialogProps) {
+  const titleId = useId()
+  const descId = useId()
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+
+  const handleClose = useCallback(() => {
+    onClose()
+  }, [onClose])
+
+  useFocusTrap({
+    containerRef: dialogRef,
+    isActive: open,
+    initialFocusRef: closeButtonRef,
+    returnFocusRef,
+    onEscape: handleClose,
+  })
+
+  // Lock body scroll while dialog is open (mirrors ConfirmDialog pattern)
+  useEffect(() => {
+    if (!open) return
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = previousOverflow
+    }
+  }, [open])
+
+  const handleBackdropClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      handleClose()
+    }
+  }
+
+  if (!open) return null
+
+  return createPortal(
+    <div
+      className="shortcuts-dialog__backdrop"
+      onClick={handleBackdropClick}
+      aria-hidden={false}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descId}
+        className="shortcuts-dialog"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="shortcuts-dialog__header">
+          <h2 id={titleId} className="shortcuts-dialog__title">
+            Keyboard Shortcuts
+          </h2>
+          <Button
+            ref={closeButtonRef}
+            type="button"
+            variant="ghost"
+            className="shortcuts-dialog__close"
+            aria-label="Close keyboard shortcuts"
+            onClick={handleClose}
+          >
+            {/* × character */}
+            <span aria-hidden="true">&#x2715;</span>
+          </Button>
+        </header>
+
+        <div id={descId} className="shortcuts-dialog__body">
+          {Array.from(GROUPED.entries()).map(([group, shortcuts]) => (
+            <section key={group} className="shortcuts-dialog__group">
+              <h3 className="shortcuts-dialog__group-heading">{group}</h3>
+              <ul className="shortcuts-dialog__list" role="list">
+                {shortcuts.map((shortcut) => (
+                  <li key={shortcut.label} className="shortcuts-dialog__item">
+                    <span className="shortcuts-dialog__label">{shortcut.label}</span>
+                    <span className="shortcuts-dialog__keys" aria-label={shortcut.keys.join(' + ')}>
+                      {shortcut.keys.map((key, index) => (
+                        <span key={key} className="shortcuts-dialog__key-group">
+                          {index > 0 && (
+                            <span className="shortcuts-dialog__key-plus" aria-hidden="true">
+                              +
+                            </span>
+                          )}
+                          <kbd className="shortcuts-dialog__kbd">{key}</kbd>
+                        </span>
+                      ))}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+
+        <footer className="shortcuts-dialog__footer">
+          <Button type="button" variant="secondary" onClick={handleClose}>
+            Close
+          </Button>
+        </footer>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/src/components/Layout.css
+++ b/src/components/Layout.css
@@ -75,6 +75,45 @@
   margin-bottom: var(--credence-space-1);
 }
 
+/* ── Shortcuts help button ───────────────────────────────────────────────── */
+
+.appHeader-shortcuts-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: 1px solid var(--credence-border-default);
+  border-radius: var(--credence-radius-full);
+  background: transparent;
+  font-family: var(--credence-font-family-base);
+  font-size: var(--credence-font-size-sm);
+  font-weight: var(--credence-font-weight-bold);
+  color: var(--credence-text-secondary);
+  cursor: pointer;
+  transition:
+    background var(--credence-motion-duration-fast) var(--credence-motion-easing-standard),
+    color var(--credence-motion-duration-fast) var(--credence-motion-easing-standard),
+    border-color var(--credence-motion-duration-fast) var(--credence-motion-easing-standard);
+  flex-shrink: 0;
+}
+
+.appHeader-shortcuts-btn:hover {
+  background: var(--credence-color-slate-100);
+  color: var(--credence-text-primary);
+  border-color: var(--credence-color-slate-400);
+}
+
+.appHeader-shortcuts-btn:focus-visible {
+  outline: var(--credence-focus-ring);
+  outline-offset: 2px;
+}
+
+[data-theme='dark'] .appHeader-shortcuts-btn:hover {
+  background: var(--credence-color-slate-700);
+}
+
 /* Mobile: hide desktop nav, tighten header padding */
 @media (max-width: 639px) {
   .appNav {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,7 +1,9 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Outlet, NavLink } from 'react-router-dom'
 import ThemeToggle from './ThemeToggle'
 import MobileNav from './navigation/MobileNav'
 import RouteAnnouncer from './RouteAnnouncer'
+import KeyboardShortcutsDialog from './KeyboardShortcutsDialog'
 import LINKS from '../config/links'
 import './Layout.css'
 
@@ -21,6 +23,36 @@ function FooterLink({ label, href }: { label: string; href: string }) {
 }
 
 export default function Layout() {
+  const [shortcutsOpen, setShortcutsOpen] = useState(false)
+  // Ref on the header button so focus returns to it after the dialog closes
+  const shortcutsButtonRef = useRef<HTMLButtonElement>(null)
+
+  const openShortcuts = useCallback(() => setShortcutsOpen(true), [])
+  const closeShortcuts = useCallback(() => setShortcutsOpen(false), [])
+
+  // Global Shift+? listener — opens the shortcuts dialog from anywhere except
+  // text-entry contexts (input, textarea, contenteditable).
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== '?') return
+      // Ignore while typing inside editable elements
+      const target = event.target as HTMLElement
+      const tag = target.tagName
+      if (
+        tag === 'INPUT' ||
+        tag === 'TEXTAREA' ||
+        tag === 'SELECT' ||
+        target.isContentEditable
+      ) {
+        return
+      }
+      setShortcutsOpen(true)
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [])
+
   return (
     <div className="appShell">
       <a className="skip-link" href="#main-content">
@@ -55,6 +87,17 @@ export default function Layout() {
         </nav>
 
         <ThemeToggle />
+
+        {/* Keyboard shortcuts help button */}
+        <button
+          ref={shortcutsButtonRef}
+          type="button"
+          className="appHeader-shortcuts-btn"
+          aria-label="Open keyboard shortcuts (Shift+?)"
+          onClick={openShortcuts}
+        >
+          ?
+        </button>
       </header>
 
       <main id="main-content" className="appMain">
@@ -74,6 +117,12 @@ export default function Layout() {
           </div>
         </div>
       </footer>
+
+      <KeyboardShortcutsDialog
+        open={shortcutsOpen}
+        onClose={closeShortcuts}
+        returnFocusRef={shortcutsButtonRef}
+      />
     </div>
   )
 }

--- a/src/data/keyboardShortcuts.ts
+++ b/src/data/keyboardShortcuts.ts
@@ -1,0 +1,50 @@
+/**
+ * Central registry of all global keyboard shortcuts in the Credence app.
+ *
+ * ## Adding a new shortcut
+ * 1. Add a new entry to this array.
+ * 2. Wire up the actual listener in the appropriate component or hook.
+ * 3. The dialog will automatically reflect the new entry — no other change needed.
+ *
+ * @example
+ * ```ts
+ * {
+ *   group: 'Navigation',
+ *   label: 'Go to Dashboard',
+ *   keys: ['G', 'D'],
+ * }
+ * ```
+ */
+
+export interface KeyboardShortcut {
+  /** Logical grouping displayed as a section heading in the help dialog. */
+  group: string
+  /** Human-readable description of what the shortcut does. */
+  label: string
+  /**
+   * The key(s) the user presses, displayed as individual `<kbd>` elements.
+   * Use platform-agnostic labels (e.g. "Esc", "?", "Shift").
+   */
+  keys: string[]
+}
+
+/** All global keyboard shortcuts, ordered by group then action. */
+export const KEYBOARD_SHORTCUTS: KeyboardShortcut[] = [
+  // ── General ─────────────────────────────────────────────────────────────
+  {
+    group: 'General',
+    label: 'Open keyboard shortcuts help',
+    keys: ['Shift', '?'],
+  },
+  {
+    group: 'General',
+    label: 'Dismiss dialog / close overlay',
+    keys: ['Esc'],
+  },
+  // ── Theme ────────────────────────────────────────────────────────────────
+  {
+    group: 'Appearance',
+    label: 'Toggle light / dark theme',
+    keys: ['T'],
+  },
+]


### PR DESCRIPTION
Closes #306

---

- Add src/data/keyboardShortcuts.ts as single source of truth for all global shortcuts (TSDoc included for future contributors)
- Add KeyboardShortcutsDialog component rendered via portal, using useFocusTrap, role=dialog, aria-modal, aria-labelledby, scroll lock, backdrop click, and Escape to close — mirrors ConfirmDialog pattern
- Add KeyboardShortcutsDialog.css with token-driven styles, fade-in animation, mobile bottom-sheet at <=767px, dark mode support
- Add KeyboardShortcutsDialog.test.tsx covering: render, a11y attrs, Escape/backdrop/button close, scroll lock, focus trap (Tab+Shift+Tab), focus restoration, and Shift+? guard for input/textarea/contenteditable
- Update Layout: global keydown listener for Shift+?, circular ? button in header with accessible label, dialog wired with returnFocusRef