### PR TITLE
feat(wallet): auto-disconnect idle sessions via useIdleTimeout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,13 +42,15 @@ const ToastTest = import.meta.env.DEV ? lazy(() => import('./pages/ToastTest')) 
 /**
  * Provider order is load-bearing: SettingsProvider must be the outer ancestor
  * because ToastProvider reads toastsEnabled and autoDismiss via useSettings().
+ * ToastProvider sits above WalletProvider so WalletProvider can use useToast()
+ * for idle-disconnect notifications.
  */
 function App() {
   return (
     <BrowserRouter>
       <SettingsProvider>
-        <WalletProvider>
-          <ToastProvider>
+        <ToastProvider>
+          <WalletProvider>
             <ErrorBoundary>
               <Suspense fallback={<div>Loading...</div>}>
                 <Routes>
@@ -70,8 +72,8 @@ function App() {
                 </Routes>
               </Suspense>
             </ErrorBoundary>
-          </ToastProvider>
-        </WalletProvider>
+          </WalletProvider>
+        </ToastProvider>
       </SettingsProvider>
     </BrowserRouter>
   )

--- a/src/context/WalletContext.test.tsx
+++ b/src/context/WalletContext.test.tsx
@@ -14,6 +14,10 @@ vi.mock('../hooks/useWallet', () => ({
   }),
 }))
 
+vi.mock('../components/ToastProvider', () => ({
+  useToast: () => ({ addToast: vi.fn() }),
+}))
+
 function WalletConsumer() {
   const wallet = useWalletContext()
 

--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -1,6 +1,8 @@
 import React, { createContext, useContext } from 'react'
 import { useSettings } from './SettingsContext'
 import { useWallet as useWalletState, type UseWalletState } from '../hooks/useWallet'
+import { useIdleTimeout } from '../hooks/useIdleTimeout'
+import { useToast } from '../components/ToastProvider'
 
 export type WalletContextValue = UseWalletState & {
   connected: boolean
@@ -29,9 +31,21 @@ export function useWallet(): WalletContextValue {
   return useWalletContext()
 }
 
+const IDLE_TIMEOUT_MS = 15 * 60 * 1000
+
 export function WalletProvider({ children }: { children: React.ReactNode }) {
   const { network } = useSettings()
   const wallet = useWalletState(network)
+  const { addToast } = useToast()
+
+  useIdleTimeout({
+    timeoutMs: wallet.isConnected ? IDLE_TIMEOUT_MS : 0,
+    onIdle: () => {
+      wallet.disconnect()
+      addToast('warning', 'Disconnected after inactivity \u2014 reconnect to continue.')
+    },
+  })
+
   const value = {
     ...wallet,
     connected: wallet.isConnected,

--- a/src/hooks/useIdleTimeout.test.ts
+++ b/src/hooks/useIdleTimeout.test.ts
@@ -1,0 +1,173 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useIdleTimeout } from './useIdleTimeout'
+
+describe('useIdleTimeout', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('calls onIdle after timeoutMs of inactivity', () => {
+    const onIdle = vi.fn()
+    renderHook(() => useIdleTimeout({ timeoutMs: 1000, onIdle }))
+
+    expect(onIdle).not.toHaveBeenCalled()
+
+    act(() => { vi.advanceTimersByTime(1000) })
+
+    expect(onIdle).toHaveBeenCalledTimes(1)
+  })
+
+  it('resets timer on mousemove activity', () => {
+    const onIdle = vi.fn()
+    renderHook(() => useIdleTimeout({ timeoutMs: 1000, onIdle }))
+
+    act(() => { vi.advanceTimersByTime(500) })
+
+    window.dispatchEvent(new Event('mousemove'))
+
+    act(() => { vi.advanceTimersByTime(500) })
+
+    expect(onIdle).not.toHaveBeenCalled()
+
+    act(() => { vi.advanceTimersByTime(500) })
+
+    expect(onIdle).toHaveBeenCalledTimes(1)
+  })
+
+  it('resets timer on keydown activity', () => {
+    const onIdle = vi.fn()
+    renderHook(() => useIdleTimeout({ timeoutMs: 1000, onIdle }))
+
+    act(() => { vi.advanceTimersByTime(500) })
+
+    window.dispatchEvent(new Event('keydown'))
+
+    act(() => { vi.advanceTimersByTime(500) })
+
+    expect(onIdle).not.toHaveBeenCalled()
+
+    act(() => { vi.advanceTimersByTime(500) })
+
+    expect(onIdle).toHaveBeenCalledTimes(1)
+  })
+
+  it('resets timer when tab becomes visible after being hidden', () => {
+    const onIdle = vi.fn()
+    renderHook(() => useIdleTimeout({ timeoutMs: 1000, onIdle }))
+
+    act(() => { vi.advanceTimersByTime(500) })
+
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'visible',
+      configurable: true,
+    })
+    document.dispatchEvent(new Event('visibilitychange'))
+
+    act(() => { vi.advanceTimersByTime(500) })
+
+    expect(onIdle).not.toHaveBeenCalled()
+
+    act(() => { vi.advanceTimersByTime(500) })
+
+    expect(onIdle).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not start timer when timeoutMs is 0 (disconnected)', () => {
+    const onIdle = vi.fn()
+    renderHook(() => useIdleTimeout({ timeoutMs: 0, onIdle }))
+
+    act(() => { vi.advanceTimersByTime(10000) })
+
+    expect(onIdle).not.toHaveBeenCalled()
+  })
+
+  it('does not start timer when timeoutMs is negative', () => {
+    const onIdle = vi.fn()
+    renderHook(() => useIdleTimeout({ timeoutMs: -1, onIdle }))
+
+    act(() => { vi.advanceTimersByTime(10000) })
+
+    expect(onIdle).not.toHaveBeenCalled()
+  })
+
+  it('clears timer and removes listeners on unmount', () => {
+    const onIdle = vi.fn()
+    const { unmount } = renderHook(() => useIdleTimeout({ timeoutMs: 1000, onIdle }))
+
+    unmount()
+
+    act(() => { vi.advanceTimersByTime(1000) })
+
+    expect(onIdle).not.toHaveBeenCalled()
+  })
+
+  it('does not fire onIdle after unmount even with delayed activity', () => {
+    const onIdle = vi.fn()
+    const { unmount } = renderHook(() => useIdleTimeout({ timeoutMs: 1000, onIdle }))
+
+    act(() => { vi.advanceTimersByTime(500) })
+
+    unmount()
+
+    window.dispatchEvent(new Event('mousemove'))
+
+    act(() => { vi.advanceTimersByTime(1000) })
+
+    expect(onIdle).not.toHaveBeenCalled()
+  })
+
+  it('uses injectable setTimeout implementation', () => {
+    const onIdle = vi.fn()
+    const mockSetTimeout = vi.fn().mockReturnValue(123)
+    const mockClearTimeout = vi.fn()
+
+    renderHook(() => useIdleTimeout({
+      timeoutMs: 1000,
+      onIdle,
+      setTimeoutImpl: mockSetTimeout as unknown as typeof setTimeout,
+      clearTimeoutImpl: mockClearTimeout as unknown as typeof clearTimeout,
+    }))
+
+    expect(mockSetTimeout).toHaveBeenCalledTimes(1)
+    expect(mockSetTimeout).toHaveBeenCalledWith(expect.any(Function), 1000)
+  })
+
+  it('uses the latest onIdle callback without restarting the timer', () => {
+    const onIdle1 = vi.fn()
+    const onIdle2 = vi.fn()
+
+    const { rerender } = renderHook(
+      ({ onIdle }: { onIdle: () => void }) =>
+        useIdleTimeout({ timeoutMs: 1000, onIdle }),
+      { initialProps: { onIdle: onIdle1 } },
+    )
+
+    rerender({ onIdle: onIdle2 })
+
+    act(() => { vi.advanceTimersByTime(1000) })
+
+    expect(onIdle1).not.toHaveBeenCalled()
+    expect(onIdle2).toHaveBeenCalledTimes(1)
+  })
+
+  it('resets timer on repeated activity', () => {
+    const onIdle = vi.fn()
+    renderHook(() => useIdleTimeout({ timeoutMs: 1000, onIdle }))
+
+    for (let i = 0; i < 5; i++) {
+      act(() => { vi.advanceTimersByTime(500) })
+      window.dispatchEvent(new Event('mousemove'))
+    }
+
+    expect(onIdle).not.toHaveBeenCalled()
+
+    act(() => { vi.advanceTimersByTime(1000) })
+
+    expect(onIdle).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/hooks/useIdleTimeout.ts
+++ b/src/hooks/useIdleTimeout.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react'
+
+export interface UseIdleTimeoutOptions {
+  timeoutMs: number
+  onIdle: () => void
+  setTimeoutImpl?: typeof setTimeout
+  clearTimeoutImpl?: typeof clearTimeout
+}
+
+export function useIdleTimeout({
+  timeoutMs,
+  onIdle,
+  setTimeoutImpl = setTimeout,
+  clearTimeoutImpl = clearTimeout,
+}: UseIdleTimeoutOptions): void {
+  const onIdleRef = useRef(onIdle)
+  onIdleRef.current = onIdle
+
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || timeoutMs <= 0) return
+
+    const clearTimer = () => {
+      if (timerRef.current !== null) {
+        clearTimeoutImpl(timerRef.current)
+        timerRef.current = null
+      }
+    }
+
+    const startTimer = () => {
+      clearTimer()
+      timerRef.current = setTimeoutImpl(() => {
+        onIdleRef.current()
+      }, timeoutMs)
+    }
+
+    const handleActivity = () => {
+      startTimer()
+    }
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        startTimer()
+      }
+    }
+
+    startTimer()
+
+    window.addEventListener('mousemove', handleActivity, { passive: true })
+    window.addEventListener('keydown', handleActivity, { passive: true })
+    document.addEventListener('visibilitychange', handleVisibilityChange)
+
+    return () => {
+      clearTimer()
+      window.removeEventListener('mousemove', handleActivity)
+      window.removeEventListener('keydown', handleActivity)
+      document.removeEventListener('visibilitychange', handleVisibilityChange)
+    }
+  }, [timeoutMs, setTimeoutImpl, clearTimeoutImpl])
+}


### PR DESCRIPTION
Tracks activity, fires onIdle after inactivity to disconnect, and announces a polite reconnect toast. No timer while disconnected; listeners cleaned on unmount.

closes: #310 