### PR TITLE
feat(address-input): detect and label the connected wallet's own address

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1721,7 +1721,6 @@
       "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }

--- a/src/components/AddressInput.css
+++ b/src/components/AddressInput.css
@@ -152,6 +152,12 @@
   word-break: break-all;
 }
 
+.address-input-echo-self {
+  margin-left: var(--credence-space-2);
+  color: var(--credence-text-secondary);
+  font-size: var(--credence-font-size-sm);
+}
+
 /**
  * Copy button: appears inside echo bar, copies full address to clipboard
  */

--- a/src/components/AddressInput.tsx
+++ b/src/components/AddressInput.tsx
@@ -14,6 +14,8 @@ export interface AddressInputProps {
   className?: string
   /** Parent-provided validation error message. */
   error?: string
+  /** Optional connected wallet address to detect "self" lookups (case-insensitive). */
+  selfAddress?: string
 }
 
 
@@ -108,6 +110,7 @@ export default function AddressInput({
   disabled = false,
   className = '',
   error: externalError,
+  selfAddress,
 }: AddressInputProps) {
   const inputRef = useRef<HTMLInputElement>(null)
 
@@ -176,6 +179,13 @@ export default function AddressInput({
 
   const error = externalError || (showError ? 'Invalid address. Stellar public keys are 56 characters starting with G.' : undefined)
   const hint = 'Stellar public key format (56 characters, starts with G)'
+
+  // Detect whether the entered (validated) value matches the connected wallet's address.
+  const isSelf =
+    !!selfAddress &&
+    !!debouncedValue &&
+    isValid &&
+    selfAddress.trim().toLowerCase() === debouncedValue.trim().toLowerCase()
 
   return (
     <div className={`address-input-wrapper ${className}`}>
@@ -251,6 +261,11 @@ export default function AddressInput({
             )}
             {copied && <span className="address-input-copy-feedback">Copied</span>}
           </button>
+          {isSelf && (
+            <span className="address-input-echo-self" aria-hidden="false">
+              This is your connected wallet
+            </span>
+          )}
         </div>
       )}
 

--- a/src/pages/TrustScore.tsx
+++ b/src/pages/TrustScore.tsx
@@ -199,6 +199,7 @@ export default function TrustScore() {
             value={address}
             onChange={handleAddressChange}
             onValidationChange={setIsAddressValid}
+            selfAddress={walletAddress}
           />
           {isConnected && walletAddress && (
             <Button
@@ -208,7 +209,7 @@ export default function TrustScore() {
               fullWidth
               className="trustScore__buttonRow"
             >
-              Use connected wallet
+              Use my address
             </Button>
           )}
           <Button


### PR DESCRIPTION
Adds an optional `selfAddress` prop to `AddressInput`, renders an informational "This is your connected wallet" note when the entered address matches the connected wallet (case-insensitive), and adds a "Use my address" shortcut on the Trust Score page.

Closes #308
