### PR TITLE
feat(hooks): add useAsync hook with cancel-on-unmount safety (#407)

### DIFF
--- a/src/hooks/useAsync.test.ts
+++ b/src/hooks/useAsync.test.ts
@@ -1,0 +1,65 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import useAsync from './useAsync'
+
+describe('useAsync', () => {
+  it('starts in loading state when immediate=true', () => {
+    const { result } = renderHook(() =>
+      useAsync(() => Promise.resolve(42)),
+    )
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.data).toBeUndefined()
+    expect(result.current.error).toBeNull()
+  })
+
+  it('does not start loading when immediate=false', () => {
+    const { result } = renderHook(() =>
+      useAsync(() => Promise.resolve(42), { immediate: false }),
+    )
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.data).toBeUndefined()
+  })
+
+  it('resolves data after async function completes', async () => {
+    const { result } = renderHook(() =>
+      useAsync(() => Promise.resolve('hello')),
+    )
+
+    // Flush all pending microtasks
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 0))
+    })
+
+    expect(result.current.data).toBe('hello')
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.error).toBeNull()
+  })
+
+  it('captures errors', async () => {
+    const { result } = renderHook(() =>
+      useAsync<string>(() => Promise.reject(new Error('fail'))),
+    )
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 0))
+    })
+
+    expect(result.current.error).toBeInstanceOf(Error)
+    expect(result.current.error?.message).toBe('fail')
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it('run() re-triggers the async function when immediate=false', async () => {
+    const fn = vi.fn().mockResolvedValue('data')
+    const { result } = renderHook(() => useAsync(fn, { immediate: false }))
+
+    expect(fn).not.toHaveBeenCalled()
+
+    await act(async () => {
+      await result.current.run()
+    })
+
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(result.current.data).toBe('data')
+  })
+})

--- a/src/hooks/useAsync.ts
+++ b/src/hooks/useAsync.ts
@@ -1,0 +1,72 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+export interface UseAsyncState<T> {
+  data: T | undefined
+  error: Error | null
+  isLoading: boolean
+}
+
+export interface UseAsyncOptions {
+  immediate?: boolean
+}
+
+/**
+ * A reusable hook for async operations with cancel-on-unmount safety.
+ * Prevents React "setState on unmounted component" warnings.
+ */
+export default function useAsync<T>(
+  asyncFn: () => Promise<T>,
+  options: UseAsyncOptions = {},
+): UseAsyncState<T> & { run: () => Promise<void> } {
+  const { immediate = true } = options
+
+  const [data, setData] = useState<T | undefined>(undefined)
+  const [error, setError] = useState<Error | null>(null)
+  const [isLoading, setIsLoading] = useState<boolean>(immediate)
+
+  const mountedRef = useRef(true)
+  const runIdRef = useRef(0)
+  const fnRef = useRef(asyncFn)
+
+  // Keep the function ref fresh without causing re-renders
+  useEffect(() => {
+    fnRef.current = asyncFn
+  })
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  const run = useCallback(async () => {
+    const currentRunId = ++runIdRef.current
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      const result = await fnRef.current()
+      if (mountedRef.current && currentRunId === runIdRef.current) {
+        setData(result)
+        setError(null)
+      }
+    } catch (err) {
+      if (mountedRef.current && currentRunId === runIdRef.current) {
+        setError(err instanceof Error ? err : new Error(String(err)))
+      }
+    } finally {
+      if (mountedRef.current && currentRunId === runIdRef.current) {
+        setIsLoading(false)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (immediate) {
+      run()
+    }
+  }, [immediate, run])
+
+  return { data, error, isLoading, run }
+}


### PR DESCRIPTION
## Summary
Adds a reusable useAsync hook that prevents setState warnings on unmounted components.

## Changes
- `src/hooks/useAsync.ts` — Hook with loading/error/data state + run callback
- `src/hooks/useAsync.test.ts` — 5 tests covering immediate, deferred, error, and run behaviors
- Uses ref-based pattern for mount safety and stale-run cancellation

## Testing
- All 5 unit tests pass
- Handles mount/unmount race conditions
- Cancels stale runs on re-invocation

Closes #407