### PR TITLE
Add tests for toast queue ordering

### DIFF
--- a/src/components/ToastProvider.test.tsx
+++ b/src/components/ToastProvider.test.tsx
@@ -18,6 +18,10 @@ function TestComponent() {
     <div>
       <button onClick={() => addToast('info', 'Info Message')}>Add Info</button>
       <button onClick={() => addToast('danger', 'Danger Message')}>Add Danger</button>
+      <button onClick={() => addToast('info', 'Toast One')}>Add Toast One</button>
+      <button onClick={() => addToast('success', 'Toast Two')}>Add Toast Two</button>
+      <button onClick={() => addToast('warning', 'Toast Three')}>Add Toast Three</button>
+      <button onClick={() => addToast('info', 'Toast Four')}>Add Toast Four</button>
       <button onClick={removeAllToasts}>Remove All</button>
     </div>
   )
@@ -159,6 +163,35 @@ describe('ToastProvider', () => {
 
     expect(screen.getAllByText('Danger Message').length).toBe(2)
     expect(screen.getAllByText('Info Message').length).toBe(1)
+  })
+
+  it('dismisses the oldest toast first when the queue exceeds 3 items', () => {
+    render(
+      <ToastProvider>
+        <TestComponent />
+      </ToastProvider>
+    )
+
+    vi.mocked(SettingsContextModule.useSettings).mockReturnValue({
+      toastsEnabled: true,
+      autoDismiss: 'off',
+    } as ReturnType<typeof SettingsContextModule.useSettings>)
+
+    fireEvent.click(screen.getByText('Add Toast One'))
+    fireEvent.click(screen.getByText('Add Toast Two'))
+    fireEvent.click(screen.getByText('Add Toast Three'))
+
+    expect(screen.getByText('Toast One')).toBeInTheDocument()
+    expect(screen.getByText('Toast Two')).toBeInTheDocument()
+    expect(screen.getByText('Toast Three')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText('Add Toast Four'))
+
+    expect(screen.queryByText('Toast One')).not.toBeInTheDocument()
+    expect(screen.getByText('Toast Two')).toBeInTheDocument()
+    expect(screen.getByText('Toast Three')).toBeInTheDocument()
+    expect(screen.getByText('Toast Four')).toBeInTheDocument()
+    expect(screen.getAllByRole('status')).toHaveLength(3)
   })
 
   it('clears timeouts when removed early', () => {

--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -13,7 +13,11 @@ const TIMEOUTS: Record<ToastSeverity, number> = {
 }
 
 interface ToastContextValue {
-  addToast: (severity: ToastSeverity, message: string, options?: { txHash?: string; network?: string }) => void
+  addToast: (
+    severity: ToastSeverity,
+    message: string,
+    options?: { txHash?: string; network?: string }
+  ) => void
   removeToast: (id: string) => void
   removeAllToasts: () => void
 }
@@ -61,6 +65,7 @@ export default function ToastProvider({ children }: { children: ReactNode }) {
 
       // respect global toast enable setting
       if (!toastsEnabled) return
+      const id = String(++idCounter.current)
 
       // compute timeout: settings `autoDismiss` can override default TIMEOUTS
       let timeout = TIMEOUTS[severity]
@@ -81,6 +86,21 @@ export default function ToastProvider({ children }: { children: ReactNode }) {
         const timerId = setTimeout(() => removeToast(id), timeout)
         timeoutsMap.current.set(id, timerId)
       }
+
+      setToasts((prev: ToastData[]) => {
+        const next = [...prev, { id, severity, message, durationMs: timeout }]
+        const overflow = next.length - MAX_TOASTS
+        if (overflow <= 0) return next
+
+        for (const toast of next.slice(0, overflow)) {
+          const timerId = timeoutsMap.current.get(toast.id)
+          if (timerId) {
+            clearTimeout(timerId)
+            timeoutsMap.current.delete(toast.id)
+          }
+        }
+        return next.slice(overflow)
+      })
     },
     [removeToast, toastsEnabled, autoDismiss]
   )


### PR DESCRIPTION
## Summary
- Enforce toast queue appends through ToastProvider state and remove the oldest toast when exceeding the 3-toast limit.
- Add coverage that confirms the oldest toast is dismissed first and only three toast status items remain.

Closes #388

## Tests
- `npm test -- --run src/components/ToastProvider.test.tsx`
- `npx prettier --check src/components/ToastProvider.tsx src/components/ToastProvider.test.tsx`