### PR TITLE
Persist theme before first render

### DIFF
--- a/docs/STATE_MANAGEMENT.md
+++ b/docs/STATE_MANAGEMENT.md
@@ -90,6 +90,9 @@ const { themeMode, network, addressDisplay, toastsEnabled, autoDismiss, hasUnsav
 
 The `themeMode` value is applied to the document root as `data-theme`:
 
+- Before React renders, `index.html` runs a tiny `theme-preference-bootstrap`
+  script that reads `credence:settings` and applies the persisted or
+  system-resolved theme to avoid a first-paint flash
 - When `themeMode === 'system'`: reads OS preference via `matchMedia('(prefers-color-scheme: dark)')` and sets `data-theme` to `'light'` or `'dark'`
 - When `themeMode === 'light'` or `'dark'`: sets `data-theme` directly
 - On OS preference change (only when `themeMode === 'system'`), re-evaluates and updates the DOM

--- a/docs/dark-mode.md
+++ b/docs/dark-mode.md
@@ -61,8 +61,10 @@ The theme has exactly **one** owner: `SettingsContext` (`src/context/SettingsCon
   `SettingsContext` and is persisted under the single `credence:settings`
   localStorage key. There is no separate `'theme'` key.
 - **Document attribute**: `SettingsContext` is the _only_ writer of
-  `document.documentElement[data-theme]`. Its effect resolves `'system'` via
-  `matchMedia('(prefers-color-scheme: dark)')` and re-applies on OS changes.
+  `document.documentElement[data-theme]` after React mounts. The small
+  `theme-preference-bootstrap` script in `index.html` applies the same
+  persisted or system-resolved value before React renders, preventing a
+  light/dark flash on first paint.
 - **`ThemeToggle`** (`src/components/ThemeToggle.tsx`) is a pure consumer of
   `useSettings()`. It owns no theme state and writes to no storage key. It:
   - _derives_ the displayed light/dark from `themeMode` (resolving `'system'`

--- a/index.html
+++ b/index.html
@@ -1,9 +1,42 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Credence — on-chain economic identity on Stellar. Stake USDC as a programmable reputation bond." />
+    <meta
+      name="description"
+      content="Credence — on-chain economic identity on Stellar. Stake USDC as a programmable reputation bond."
+    />
+    <script id="theme-preference-bootstrap">
+      ;(() => {
+        const validThemes = ['light', 'dark', 'system']
+        let themeMode = 'system'
+
+        try {
+          const stored = window.localStorage.getItem('credence:settings')
+          if (stored !== null) {
+            const parsed = JSON.parse(stored)
+            if (validThemes.includes(parsed?.themeMode)) {
+              themeMode = parsed.themeMode
+            }
+          } else {
+            const legacyTheme = window.localStorage.getItem('theme')
+            if (validThemes.includes(legacyTheme)) {
+              themeMode = legacyTheme
+            }
+          }
+        } catch {
+          themeMode = 'system'
+        }
+
+        const prefersDark =
+          themeMode === 'system' && window.matchMedia?.('(prefers-color-scheme: dark)').matches
+        document.documentElement.setAttribute(
+          'data-theme',
+          themeMode === 'system' ? (prefersDark ? 'dark' : 'light') : themeMode
+        )
+      })()
+    </script>
     <title>Credence — Economic Trust</title>
   </head>
   <body>

--- a/src/context/SettingsContext.test.tsx
+++ b/src/context/SettingsContext.test.tsx
@@ -369,6 +369,26 @@ describe('SettingsProvider', () => {
       })
     })
 
+    it('persists an explicit saveSettings payload without waiting for state setters', () => {
+      render(
+        <SettingsProvider>
+          <ExplicitSaveProbe />
+        </SettingsProvider>
+      )
+
+      fireEvent.click(screen.getByRole('button', { name: 'save explicit dark' }))
+
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')
+      expect(stored).toEqual({
+        themeMode: 'dark',
+        network: 'test',
+        addressDisplay: 'full',
+        toastsEnabled: false,
+        autoDismiss: 'off',
+      })
+      expect(screen.getByTestId('unsaved').textContent).toBe('false')
+    })
+
     it('persists toastsEnabled=false', async () => {
       const user = userEvent.setup()
       renderWithProvider()
@@ -538,6 +558,28 @@ function UnsavedProbe() {
     <div>
       <span data-testid="theme">{s.themeMode}</span>
       <span data-testid="unsaved">{String(s.hasUnsavedChanges)}</span>
+    </div>
+  )
+}
+
+function ExplicitSaveProbe() {
+  const s = useSettings()
+  return (
+    <div>
+      <span data-testid="unsaved">{String(s.hasUnsavedChanges)}</span>
+      <button
+        onClick={() =>
+          s.saveSettings({
+            themeMode: 'dark',
+            network: 'test',
+            addressDisplay: 'full',
+            toastsEnabled: false,
+            autoDismiss: 'off',
+          })
+        }
+      >
+        save explicit dark
+      </button>
     </div>
   )
 }

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -1,16 +1,14 @@
-import React, { createContext, useContext, useEffect, useState } from 'react'
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react'
 import { useLocalStorage } from '../hooks/useLocalStorage'
-
-type ThemeMode = 'light' | 'dark' | 'system'
+import {
+  defaultSettings,
+  validateAndNormalize,
+  type SettingsBlob,
+  type ThemeMode,
+} from '../lib/settingsSchema'
 
 /** The persisted settings payload (the subset of state written to localStorage). */
-interface SettingsPayload {
-  themeMode: ThemeMode
-  network: string
-  addressDisplay: string
-  toastsEnabled: boolean
-  autoDismiss: string
-}
+type SettingsPayload = SettingsBlob
 
 interface SettingsState {
   themeMode: ThemeMode
@@ -33,28 +31,14 @@ interface SettingsState {
   hasUnsavedChanges: boolean
 }
 
-type PersistedSettings = {
-  themeMode: ThemeMode
-  network: string
-  addressDisplay: string
-  toastsEnabled: boolean
-  autoDismiss: string
-}
+type PersistedSettings = SettingsBlob
 
 const STORAGE_KEY = 'credence:settings'
 const LEGACY_THEME_KEY = 'theme'
 
-
-
 const VALID_THEMES: ThemeMode[] = ['light', 'dark', 'system']
 
-const defaultPersistedSettings: PersistedSettings = {
-  themeMode: 'system',
-  network: 'public',
-  addressDisplay: 'short',
-  toastsEnabled: true,
-  autoDismiss: '5s',
-}
+const defaultPersistedSettings: PersistedSettings = defaultSettings()
 
 const defaultState: SettingsState = {
   ...defaultPersistedSettings,
@@ -70,10 +54,13 @@ const defaultState: SettingsState = {
 
 const SettingsContext = createContext<SettingsState>(defaultState)
 
-
-
 export function useSettings() {
   return useContext(SettingsContext)
+}
+
+function normalizeStoredSettings(raw: unknown): PersistedSettings {
+  const result = validateAndNormalize(raw)
+  return result.ok ? result.data : defaultPersistedSettings
 }
 
 /**
@@ -88,11 +75,11 @@ function useMigrateLegacyTheme(): void {
   useState<null>(() => {
     if (typeof window === 'undefined') return null
 
-    const legacyTheme = localStorage.getItem('theme')
+    const legacyTheme = localStorage.getItem(LEGACY_THEME_KEY)
     if (!legacyTheme) return null
 
     // Always clean up the orphaned key regardless of whether we use its value.
-    localStorage.removeItem('theme')
+    localStorage.removeItem(LEGACY_THEME_KEY)
 
     if (!VALID_THEMES.includes(legacyTheme as ThemeMode)) return null
 
@@ -102,7 +89,7 @@ function useMigrateLegacyTheme(): void {
     // Bootstrap credence:settings so useLocalStorage reads the migrated theme.
     localStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify({ ...defaultPersistedSettings, themeMode: legacyTheme as ThemeMode }),
+      JSON.stringify({ ...defaultPersistedSettings, themeMode: legacyTheme as ThemeMode })
     )
 
     return null
@@ -114,10 +101,15 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
   useMigrateLegacyTheme()
 
   // Single localStorage read — replaces five individual JSON.parse calls on every mount.
-  const [persistedSettings, setPersistedSettings] = useLocalStorage<PersistedSettings>(
+  const [storedSettings, setStoredSettings] = useLocalStorage<unknown>(
     STORAGE_KEY,
-    defaultPersistedSettings,
+    defaultPersistedSettings
   )
+  const setPersistedSettings = useCallback(
+    (next: PersistedSettings) => setStoredSettings(next),
+    [setStoredSettings]
+  )
+  const persistedSettings = normalizeStoredSettings(storedSettings)
 
   const [themeMode, setThemeMode] = useState<ThemeMode>(persistedSettings.themeMode)
   const [network, setNetwork] = useState<string>(persistedSettings.network)
@@ -140,8 +132,15 @@ export function SettingsProvider({ children }: { children: React.ReactNode }) {
     setPersistedSettings({ themeMode, network, addressDisplay, toastsEnabled, autoDismiss })
   }, [themeMode, network, addressDisplay, toastsEnabled, autoDismiss, setPersistedSettings])
 
-  const saveSettings = () => {
-    const payload = { themeMode, network, addressDisplay, toastsEnabled, autoDismiss }
+  const saveSettings = (next?: SettingsPayload) => {
+    const payload = next ?? { themeMode, network, addressDisplay, toastsEnabled, autoDismiss }
+    if (next) {
+      setThemeMode(payload.themeMode)
+      setNetwork(payload.network)
+      setAddressDisplay(payload.addressDisplay)
+      setToastsEnabled(payload.toastsEnabled)
+      setAutoDismiss(payload.autoDismiss)
+    }
     setPersistedSettings(payload)
     setOriginalSettings(payload)
   }

--- a/src/themeBootstrap.test.ts
+++ b/src/themeBootstrap.test.ts
@@ -1,0 +1,67 @@
+import { readFileSync } from 'node:fs'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+function runBootstrap() {
+  const html = readFileSync('index.html', 'utf8')
+  const script = html.match(/<script id="theme-preference-bootstrap">([\s\S]*?)<\/script>/)?.[1]
+
+  if (!script) {
+    throw new Error('theme-preference-bootstrap script not found')
+  }
+  Function(script)()
+}
+
+function mockSystemTheme(prefersDark: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation(() => ({
+      matches: prefersDark,
+      media: '(prefers-color-scheme: dark)',
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+}
+
+describe('theme preference bootstrap', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
+    mockSystemTheme(false)
+  })
+
+  it('applies a persisted explicit dark theme before React renders', () => {
+    localStorage.setItem('credence:settings', JSON.stringify({ themeMode: 'dark' }))
+
+    runBootstrap()
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+  })
+
+  it('resolves a persisted system theme from matchMedia', () => {
+    mockSystemTheme(true)
+    localStorage.setItem('credence:settings', JSON.stringify({ themeMode: 'system' }))
+
+    runBootstrap()
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+  })
+
+  it('uses the legacy theme key only when the settings payload is absent', () => {
+    localStorage.setItem('theme', 'light')
+
+    runBootstrap()
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('light')
+  })
+
+  it('falls back to the system preference when stored settings are corrupt', () => {
+    mockSystemTheme(true)
+    localStorage.setItem('credence:settings', 'not-json')
+
+    runBootstrap()
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+  })
+})


### PR DESCRIPTION
## Summary
- Add a first-paint `theme-preference-bootstrap` script in `index.html` so persisted/system theme is applied before React renders.
- Route SettingsContext hydration through the existing settings schema and make `saveSettings(payload)` update state and persistence together.
- Add regression coverage for the bootstrap path and explicit settings payload persistence.
- Document the pre-render theme bootstrap in the dark mode and state management docs.

Closes #380

## Tests
- `npm test -- --run src/themeBootstrap.test.ts src/context/SettingsContext.test.tsx src/components/ThemeToggle.test.tsx`
- `npx prettier --check index.html src/themeBootstrap.test.ts src/context/SettingsContext.tsx src/context/SettingsContext.test.tsx docs/dark-mode.md docs/STATE_MANAGEMENT.md`
- `npx eslint src/themeBootstrap.test.ts src/context/SettingsContext.tsx src/context/SettingsContext.test.tsx`

## Existing base-branch failures observed locally
- `npm run build` still fails on pre-existing files outside this PR, including `src/components/ToastProvider.tsx`, `src/components/TrustGauge.tsx`, `src/pages/Bond.tsx`, `src/components/AddressInput.tsx`, `src/App.tsx`, and several existing test files.
- `npm run lint -- --max-warnings=0` still fails on pre-existing issues in `RouteAnnouncer.test.tsx`, `ToastProvider.tsx`, `TrustGauge.test.tsx`, `useCopyToClipboard.ts`, and `TrustScore.tsx`.