### PR TITLE
Fix lazy route load failure recovery

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react'
+import { lazy, Suspense } from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
-import App from './App'
+import App, { LazyRouteBoundary } from './App'
 
 beforeAll(() => {
   Object.defineProperty(window, 'matchMedia', {
@@ -45,5 +47,48 @@ describe('App routing', () => {
 
     expect(await screen.findByRole('heading', { name: /^Create Bond$/i })).toBeInTheDocument()
     expect(await screen.findByText(/Step 1: Enter Bond Amount/i)).toBeInTheDocument()
+  })
+})
+
+describe('lazy route error handling', () => {
+  it('renders a retry UI for a failed lazy route and retries with a fresh import', async () => {
+    let attempts = 0
+
+    function RetryableLazyRoute({ retryKey }: { retryKey: number }) {
+      const Page = lazy(async () => {
+        attempts += 1
+
+        if (attempts === 1) {
+          throw new Error('Failed to fetch dynamically imported module')
+        }
+
+        return { default: () => <h1>Recovered route</h1> }
+      })
+
+      return (
+        <Suspense fallback={<div>Loading route...</div>}>
+          <Page key={retryKey} />
+        </Suspense>
+      )
+    }
+
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <LazyRouteBoundary>
+          {(retryKey) => <RetryableLazyRoute retryKey={retryKey} />}
+        </LazyRouteBoundary>
+      </MemoryRouter>
+    )
+
+    expect(await screen.findByRole('heading', { name: /page failed to load/i })).toBeInTheDocument()
+    expect(screen.getByText(/page bundle could not be loaded/i)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }))
+
+    expect(await screen.findByRole('heading', { name: /recovered route/i })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: /page failed to load/i })).not.toBeInTheDocument()
+    expect(attempts).toBe(2)
   })
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,44 +1,124 @@
-import { lazy, Suspense } from 'react'
-import { BrowserRouter, Routes, Route, useRouteError } from 'react-router-dom'
+import { lazy, ReactNode, Suspense, useMemo, useState } from 'react'
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom'
 import { SettingsProvider } from './context/SettingsContext'
 import { WalletProvider } from './context/WalletContext'
 import ToastProvider from './components/ToastProvider'
 import ErrorBoundary from './components/ErrorBoundary'
 import Layout from './components/Layout'
+import ErrorState from './components/states/ErrorState'
 import RouteErrorPage from './pages/RouteErrorPage'
 
-function RouteErrorPage() {
-  const error = useRouteError()
-  const message = error instanceof Error ? error.message : 'An unexpected error occurred.'
+function createLazyPages() {
+  return {
+    Home: lazy(() => import('./pages/Home')),
+    Dashboard: lazy(() => import('./pages/Dashboard')),
+    Bond: lazy(() => import('./pages/Bond')),
+    CreateBondPage: lazy(() => import('./pages/CreateBondPage')),
+    BondDetail: lazy(() => import('./pages/BondDetail')),
+    TrustScore: lazy(() => import('./pages/TrustScore')),
+    Attestations: lazy(() => import('./pages/Attestations')),
+    Transactions: lazy(() => import('./pages/Transactions')),
+    Settings: lazy(() => import('./pages/Settings')),
+    AmountInputTestPage: lazy(() => import('./pages/AmountInputTestPage')),
+    NotFound: lazy(() => import('./pages/NotFound')),
+    // import.meta.env.DEV is replaced with `false` at build time by Vite/Rollup,
+    // so the dynamic import('./pages/ToastTest') reference is dead-code eliminated
+    // from the production bundle.
+    ToastTest: import.meta.env.DEV ? lazy(() => import('./pages/ToastTest')) : null,
+  }
+}
+
+function isLazyRouteLoadError(error: Error) {
   return (
-    <div style={{ padding: 'var(--credence-space-8)', textAlign: 'center' }}>
-      <h1>Something went wrong</h1>
-      <p style={{ color: 'var(--credence-text-secondary)', marginTop: 'var(--credence-space-3)' }}>
-        {message}
-      </p>
-      <a href="/" style={{ marginTop: 'var(--credence-space-6)', display: 'inline-block' }}>
-        Go home
+    error.name === 'ChunkLoadError' ||
+    /chunkloaderror|loading chunk \d+ failed|failed to fetch dynamically imported module|importing a module script failed|error loading dynamically imported module/i.test(
+      error.message
+    )
+  )
+}
+
+function RouteLoadFallback({ error, onRetry }: { error: Error; onRetry: () => void }) {
+  const lazyLoadError = isLazyRouteLoadError(error)
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '50vh',
+        padding: 'var(--credence-space-6)',
+      }}
+    >
+      <ErrorState
+        type={lazyLoadError ? 'network' : 'generic'}
+        title="Page failed to load"
+        message={
+          lazyLoadError
+            ? 'The page bundle could not be loaded. This can happen after an app update or a temporary network interruption.'
+            : 'This route failed to render. Try again to reload the page content.'
+        }
+        action={{ label: 'Try again', onClick: onRetry }}
+      />
+      <a
+        href="/"
+        style={{
+          marginTop: 'var(--credence-space-4)',
+          fontSize: 'var(--credence-font-size-sm)',
+          color: 'var(--credence-text-secondary)',
+          textDecoration: 'underline',
+        }}
+      >
+        Go to home page
       </a>
     </div>
   )
 }
 
-const Home = lazy(() => import('./pages/Home'))
-const Dashboard = lazy(() => import('./pages/Dashboard'))
-const Bond = lazy(() => import('./pages/Bond'))
-const CreateBondPage = lazy(() => import('./pages/CreateBondPage'))
-const BondDetail = lazy(() => import('./pages/BondDetail'))
-const TrustScore = lazy(() => import('./pages/TrustScore'))
-const Attestations = lazy(() => import('./pages/Attestations'))
-const Transactions = lazy(() => import('./pages/Transactions'))
-const Settings = lazy(() => import('./pages/Settings'))
-const AmountInputTestPage = lazy(() => import('./pages/AmountInputTestPage'))
-const NotFound = lazy(() => import('./pages/NotFound'))
+export function LazyRouteBoundary({ children }: { children: (retryKey: number) => ReactNode }) {
+  const location = useLocation()
+  const [retryKey, setRetryKey] = useState(0)
+  const boundaryKey = `${location.pathname}${location.search}${location.hash}:${retryKey}`
 
-// import.meta.env.DEV is replaced with `false` at build time by Vite/Rollup,
-// so the dynamic import('./pages/ToastTest') reference is dead-code eliminated
-// from the production bundle.
-const ToastTest = import.meta.env.DEV ? lazy(() => import('./pages/ToastTest')) : null
+  return (
+    <ErrorBoundary
+      key={boundaryKey}
+      fallback={(error) => (
+        <RouteLoadFallback error={error} onRetry={() => setRetryKey((key) => key + 1)} />
+      )}
+    >
+      {children(retryKey)}
+    </ErrorBoundary>
+  )
+}
+
+function LazyRoutes({ retryKey }: { retryKey: number }) {
+  const pages = useMemo(() => createLazyPages(), [retryKey])
+
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <Routes>
+        <Route path="/" element={<Layout />} errorElement={<RouteErrorPage />}>
+          <Route index element={<pages.Home />} />
+          <Route path="dashboard" element={<pages.Dashboard />} />
+          <Route path="bond" element={<pages.Bond />} />
+          <Route path="bond/new" element={<pages.CreateBondPage />} />
+          <Route path="bond/:id" element={<pages.BondDetail />} />
+          <Route path="trust" element={<pages.TrustScore />} />
+          <Route path="attestations" element={<pages.Attestations />} />
+          <Route path="transactions" element={<pages.Transactions />} />
+          <Route path="settings" element={<pages.Settings />} />
+          <Route path="test-amount-input" element={<pages.AmountInputTestPage />} />
+          {import.meta.env.DEV && pages.ToastTest && (
+            <Route path="dev/toasts" element={<pages.ToastTest />} />
+          )}
+          <Route path="*" element={<pages.NotFound />} />
+        </Route>
+      </Routes>
+    </Suspense>
+  )
+}
 
 /**
  * Provider order is load-bearing: SettingsProvider must be the outer ancestor
@@ -52,28 +132,9 @@ function App() {
       <SettingsProvider>
         <ToastProvider>
           <WalletProvider>
-            <ErrorBoundary>
-              <Suspense fallback={<div>Loading...</div>}>
-                <Routes>
-                  <Route path="/" element={<Layout />} errorElement={<RouteErrorPage />}>
-                    <Route index element={<Home />} />
-                    <Route path="dashboard" element={<Dashboard />} />
-                    <Route path="bond" element={<Bond />} />
-                    <Route path="bond/new" element={<CreateBondPage />} />
-                    <Route path="bond/:id" element={<BondDetail />} />
-                    <Route path="trust" element={<TrustScore />} />
-                    <Route path="attestations" element={<Attestations />} />
-                    <Route path="transactions" element={<Transactions />} />
-                    <Route path="settings" element={<Settings />} />
-                    <Route path="test-amount-input" element={<AmountInputTestPage />} />
-                    {import.meta.env.DEV && ToastTest && (
-                      <Route path="dev/toasts" element={<ToastTest />} />
-                    )}
-                    <Route path="*" element={<NotFound />} />
-                  </Route>
-                </Routes>
-              </Suspense>
-            </ErrorBoundary>
+            <LazyRouteBoundary>
+              {(retryKey) => <LazyRoutes retryKey={retryKey} />}
+            </LazyRouteBoundary>
           </WalletProvider>
         </ToastProvider>
       </SettingsProvider>


### PR DESCRIPTION
Closes #382

## Summary
- Add a route-level error boundary around the lazy route tree so chunk-load/render failures show a branded recovery UI instead of a blank screen.
- Recreate the lazy route component map on retry so a failed `React.lazy` import is not permanently cached after the first rejected dynamic import.
- Add a regression test that simulates a failed dynamically imported route, verifies the retry UI, then verifies the route recovers on retry.

## User-visible impact
Users who hit a stale or temporarily unavailable route bundle after a deploy/network interruption now see a clear "Page failed to load" message with a retry action. Before this, the practical mitigation was a manual hard refresh or navigating away from the broken page.

## Validation
- `npm test -- --run src/App.test.tsx src/components/ErrorBoundary.test.tsx` ✅ 15 tests passed
- `npx eslint src/App.tsx src/App.test.tsx src/components/ErrorBoundary.tsx src/components/ErrorBoundary.test.tsx` ✅
- `npx prettier --check src/App.tsx src/App.test.tsx` ✅
- `npm run lint` currently fails on pre-existing files outside this PR: `RouteAnnouncer.test.tsx`, `ToastProvider.tsx`, `TrustGauge.test.tsx`, `SettingsContext.tsx`, `useCopyToClipboard.ts`, `TrustScore.tsx`.
- `npm run build` currently fails on pre-existing TypeScript errors outside this PR, including `ToastProvider.tsx`, `AddressInput.tsx`, `TrustGauge.tsx`, `Bond.tsx`, `RouteAnnouncer.test.tsx`, and `Select.test.tsx` matcher typings.
- `npm test -- --run` currently fails on pre-existing unrelated suites such as `AddressInput`, `ToastProvider`, `KeyboardShortcutsDialog`, `useWallet`, and `Select`.