### PR TITLE
Add screen-reader labels to focus trap test inputs

### DIFF
--- a/src/pages/FocusTrapTestPage.test.tsx
+++ b/src/pages/FocusTrapTestPage.test.tsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import FocusTrapTestPage from './FocusTrapTestPage'
+
+describe('FocusTrapTestPage accessibility', () => {
+  it('gives placeholder-only trap inputs programmatic labels', () => {
+    render(<FocusTrapTestPage />)
+
+    const firstInput = screen.getByRole('textbox', { name: 'Focus trap input 1' })
+    const secondInput = screen.getByRole('textbox', { name: 'Focus trap input 2' })
+
+    expect(firstInput).toHaveAttribute('placeholder', 'Input 1')
+    expect(secondInput).toHaveAttribute('placeholder', 'Input 2')
+
+    expect(screen.queryByRole('textbox', { name: 'Input 1' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('textbox', { name: 'Input 2' })).not.toBeInTheDocument()
+  })
+})

--- a/src/pages/FocusTrapTestPage.tsx
+++ b/src/pages/FocusTrapTestPage.tsx
@@ -136,7 +136,11 @@ export default function FocusTrapTestPage() {
           <button onFocus={() => handleTrapElementFocus('Button 2')} style={{ margin: '0.5rem' }}>
             Button 2
           </button>
+          <label htmlFor="focus-trap-input-1" className="sr-only">
+            Focus trap input 1
+          </label>
           <input
+            id="focus-trap-input-1"
             type="text"
             placeholder="Input 1"
             onFocus={() => handleTrapElementFocus('Input 1')}
@@ -153,7 +157,11 @@ export default function FocusTrapTestPage() {
           >
             Link 1
           </a>
+          <label htmlFor="focus-trap-input-2" className="sr-only">
+            Focus trap input 2
+          </label>
           <input
+            id="focus-trap-input-2"
             type="text"
             placeholder="Input 2"
             onFocus={() => handleTrapElementFocus('Input 2')}

--- a/test-focus-trap.html
+++ b/test-focus-trap.html
@@ -87,6 +87,17 @@
     .external-button {
       margin: 1rem 0;
     }
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
     code {
       background: #f4f4f4;
       padding: 0.2rem 0.4rem;
@@ -133,9 +144,11 @@
       <h3>Inside Focus Trap</h3>
       <button id="trap-btn-1">Button 1</button>
       <button id="trap-btn-2">Button 2</button>
+      <label for="trap-input-1" class="sr-only">Focus trap input 1</label>
       <input type="text" id="trap-input-1" placeholder="Input 1" />
       <button id="trap-btn-3">Button 3</button>
       <a href="#" id="trap-link-1" onclick="return false;">Link 1</a>
+      <label for="trap-input-2" class="sr-only">Focus trap input 2</label>
       <input type="text" id="trap-input-2" placeholder="Input 2" />
       <button id="trap-btn-4">Button 4</button>
     </div>


### PR DESCRIPTION
Closes #381.

## Summary
- Add screen-reader-only labels for the two focus-trap test inputs that previously relied on placeholders.
- Mirror the same labels in the standalone `test-focus-trap.html` harness.
- Add a regression test that queries both inputs by their programmatic accessible names.

## Accessibility notes
- Placeholders remain visible hints only; accessible names now come from hidden `<label>` elements linked with `htmlFor`/`id`.
- Keyboard flow is unchanged because labels are not focusable and inputs keep their existing order.

## Verification
- `npx vitest run src/pages/FocusTrapTestPage.test.tsx` passes.
- `npx eslint src/pages/FocusTrapTestPage.tsx src/pages/FocusTrapTestPage.test.tsx` passes.
- Full `npm test`, `npm run lint`, and `npm run build` are currently blocked by existing base-branch failures unrelated to this change, including `useDebouncedValue is not defined` in `AddressInput`, `ToastProvider` referencing undefined `id`, and TypeScript errors in `RouteAnnouncer.test.tsx` / `TrustGauge.test.tsx`.
- Axe was not run locally because the repo does not currently include `axe-core`, `@axe-core/playwright`, or `jest-axe` dependencies.

## Keyboard walkthrough
- Tab order in the focus trap remains Button 1 -> Button 2 -> Input 1 -> Button 3 -> Link 1 -> Input 2 -> Button 4.
- Shift+Tab follows the same sequence in reverse.
- The labels are visually hidden and do not add extra stops.