### PR TITLE
feat(hooks): add SSR-safe useMediaQuery + breakpoint helpers (#437)

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -23,6 +23,7 @@ behavior notes, and a minimal usage example linking to source.
 - [Hooks (`src/hooks/`)](#hooks-srchooks)
   - [`useFocusTrap`](#usefocustrap)
   - [`useDocumentTitle`](#usedocumenttitle)
+  - [`useMediaQuery`](#usemediaquery)
   - [`useReducedMotion`](#usereducedmotion)
   - [`useTrustScore`](#usetrustscore)
   - [`useUsdcBalance`](#useusdcbalance)
@@ -148,6 +149,49 @@ import { useDocumentTitle } from '../hooks/useDocumentTitle'
 function Bond() {
   useDocumentTitle('Bond') // document.title === 'Bond · Credence'
   return <main>…</main>
+}
+```
+
+---
+
+### `useMediaQuery`
+
+Source: [`src/hooks/useMediaQuery.ts`](../src/hooks/useMediaQuery.ts)
+
+```ts
+function useMediaQuery(query: string): boolean
+function useIsMobile(): boolean  // shorthand: (max-width: 767px)
+```
+
+Subscribes to a CSS media query and returns whether it currently matches. The exported
+breakpoint helper `useIsMobile` wraps the 768 px mobile threshold used throughout the app.
+
+**Parameters**
+
+| Parameter | Required | Description                                         |
+| --------- | :------: | --------------------------------------------------- |
+| `query`   |    ✓     | A valid CSS media query string, e.g. `'(max-width: 767px)'`. |
+
+**Behavior notes**
+
+- Returns `false` during SSR or when `window.matchMedia` is unavailable — no crash.
+- Uses a lazy `useState` initializer to read the initial match synchronously on first render,
+  eliminating any flash of wrong state.
+- Subscribes via `addEventListener('change', …)` with optional chaining, mirroring the
+  pattern in `SettingsContext`.
+- **SSR-safe / cleanup:** all DOM work is guarded; the `change` listener is removed on unmount
+  or when the query string changes.
+
+```tsx
+import { useMediaQuery, useIsMobile } from '../hooks/useMediaQuery'
+
+// Generic usage
+const isWide = useMediaQuery('(min-width: 1024px)')
+
+// Breakpoint helper
+function ActivityCard() {
+  const isMobile = useIsMobile()
+  return <h2>{isMobile ? 'Recent Activity' : 'Recent Activity Timeline'}</h2>
 }
 ```
 

--- a/src/hooks/useMediaQuery.test.ts
+++ b/src/hooks/useMediaQuery.test.ts
@@ -1,0 +1,139 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import { useMediaQuery, useIsMobile } from './useMediaQuery'
+
+const QUERY = '(max-width: 767px)'
+
+function makeMql(matches: boolean) {
+  let changeHandler: ((e: MediaQueryListEvent) => void) | null = null
+  const mql = {
+    matches,
+    media: QUERY,
+    onchange: null,
+    addEventListener: vi.fn((event: string, handler: (e: MediaQueryListEvent) => void) => {
+      if (event === 'change') changeHandler = handler
+    }),
+    removeEventListener: vi.fn((event: string, handler: (e: MediaQueryListEvent) => void) => {
+      if (event === 'change' && changeHandler === handler) changeHandler = null
+    }),
+    dispatchEvent: vi.fn(),
+    /** Test helper: fire a change event */
+    _fire: (nextMatches: boolean) => changeHandler?.({ matches: nextMatches } as MediaQueryListEvent),
+    _handler: () => changeHandler,
+  }
+  return mql
+}
+
+describe('useMediaQuery', () => {
+  const originalMatchMedia = window.matchMedia
+
+  afterEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      value: originalMatchMedia,
+      writable: true,
+      configurable: true,
+    })
+    vi.restoreAllMocks()
+  })
+
+  it('returns false when window.matchMedia is undefined', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    })
+    const { result } = renderHook(() => useMediaQuery(QUERY))
+    expect(result.current).toBe(false)
+  })
+
+  it('returns initial match value (false)', () => {
+    const mql = makeMql(false)
+    window.matchMedia = vi.fn().mockReturnValue(mql)
+
+    const { result } = renderHook(() => useMediaQuery(QUERY))
+    expect(result.current).toBe(false)
+  })
+
+  it('returns initial match value (true)', () => {
+    const mql = makeMql(true)
+    window.matchMedia = vi.fn().mockReturnValue(mql)
+
+    const { result } = renderHook(() => useMediaQuery(QUERY))
+    expect(result.current).toBe(true)
+  })
+
+  it('updates when the media query fires a change event', () => {
+    const mql = makeMql(false)
+    window.matchMedia = vi.fn().mockReturnValue(mql)
+
+    const { result } = renderHook(() => useMediaQuery(QUERY))
+    expect(result.current).toBe(false)
+
+    act(() => { mql._fire(true) })
+    expect(result.current).toBe(true)
+
+    act(() => { mql._fire(false) })
+    expect(result.current).toBe(false)
+  })
+
+  it('removes the listener on unmount', () => {
+    const mql = makeMql(false)
+    window.matchMedia = vi.fn().mockReturnValue(mql)
+
+    const { unmount } = renderHook(() => useMediaQuery(QUERY))
+    expect(mql._handler()).not.toBeNull()
+
+    unmount()
+    expect(mql._handler()).toBeNull()
+  })
+
+  it('re-subscribes when the query string changes', () => {
+    const mql1 = makeMql(false)
+    const mql2 = makeMql(true)
+    const matchMediaMock = vi.fn()
+      .mockReturnValueOnce(mql1) // initial render (lazy init) or first effect call
+      .mockReturnValue(mql2)
+
+    window.matchMedia = matchMediaMock
+
+    const { result, rerender } = renderHook(({ q }) => useMediaQuery(q), {
+      initialProps: { q: QUERY },
+    })
+
+    expect(result.current).toBe(false)
+
+    act(() => { rerender({ q: '(min-width: 1024px)' }) })
+    expect(result.current).toBe(true)
+  })
+})
+
+describe('useIsMobile', () => {
+  const originalMatchMedia = window.matchMedia
+
+  afterEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      value: originalMatchMedia,
+      writable: true,
+      configurable: true,
+    })
+    vi.restoreAllMocks()
+  })
+
+  it('returns true when viewport is below 768px', () => {
+    window.matchMedia = vi.fn().mockReturnValue(makeMql(true))
+    const { result } = renderHook(() => useIsMobile())
+    expect(result.current).toBe(true)
+  })
+
+  it('returns false when viewport is 768px or above', () => {
+    window.matchMedia = vi.fn().mockReturnValue(makeMql(false))
+    const { result } = renderHook(() => useIsMobile())
+    expect(result.current).toBe(false)
+  })
+
+  it('uses the (max-width: 767px) query', () => {
+    window.matchMedia = vi.fn().mockReturnValue(makeMql(false))
+    renderHook(() => useIsMobile())
+    expect(window.matchMedia).toHaveBeenCalledWith('(max-width: 767px)')
+  })
+})

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * SSR-safe hook that subscribes to a CSS media query and returns whether it
+ * currently matches. The listener is cleaned up on unmount.
+ *
+ * @param query - A valid CSS media query string, e.g. `'(max-width: 767px)'`.
+ * @returns `true` while the query matches, `false` otherwise. Returns `false`
+ *   in environments without `window.matchMedia` (SSR, Node test runners).
+ *
+ * @example
+ * ```tsx
+ * const isNarrow = useMediaQuery('(max-width: 767px)')
+ * return <span>{isNarrow ? 'Mobile' : 'Desktop'}</span>
+ * ```
+ */
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState<boolean>(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return false
+    }
+    return window.matchMedia(query).matches
+  })
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return
+    }
+
+    const mql = window.matchMedia(query)
+    setMatches(mql.matches)
+
+    const handler = (event: MediaQueryListEvent) => setMatches(event.matches)
+    mql.addEventListener?.('change', handler)
+    return () => mql.removeEventListener?.('change', handler)
+  }, [query])
+
+  return matches
+}
+
+/**
+ * Returns `true` when the viewport is at the mobile breakpoint (< 768 px).
+ *
+ * @example
+ * ```tsx
+ * const isMobile = useIsMobile()
+ * return <h2>{isMobile ? 'Recent Activity' : 'Recent Activity Timeline'}</h2>
+ * ```
+ */
+export function useIsMobile(): boolean {
+  return useMediaQuery('(max-width: 767px)')
+}

--- a/src/pages/TrustScore.tsx
+++ b/src/pages/TrustScore.tsx
@@ -15,6 +15,7 @@ import { useSettings } from '../context/SettingsContext'
 import { useWallet } from '../context/WalletContext'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useNetworkMismatch } from '../hooks/useNetworkMismatch'
+import { useIsMobile } from '../hooks/useMediaQuery'
 import { useTrustScore } from '../hooks/useTrustScore'
 import { ApiError } from '../api/client'
 import { isValidStellarAddress } from '@/lib/stellar'
@@ -36,6 +37,7 @@ function trustScoreErrorType(error: ApiError): 'network' | 'backend' | 'validati
 export default function TrustScore() {
   useDocumentTitle('Trust Score')
 
+  const isMobile = useIsMobile()
   const { isConnected, address: walletAddress, connect, network: walletNetwork } = useWallet()
   const { setNetwork } = useSettings()
   const networkMismatch = useNetworkMismatch()
@@ -223,6 +225,9 @@ export default function TrustScore() {
         </div>
 
         <div className="trustScore__card">
+          <h2 className="trustScore__cardTitle">
+            {isMobile ? 'Recent Activity' : 'Recent Activity Timeline'}
+          </h2>
           <ActivityTimeline compact items={activity} />
         </div>
       </div>


### PR DESCRIPTION
closes #437
## Summary

Implements #437.

Adds a typed, SSR-safe `useMediaQuery` hook that centralizes `matchMedia` subscriptions, removes the need for scattered inline calls, and enables JS-driven responsive component behavior alongside the existing CSS reflow.

## Changes

### `src/hooks/useMediaQuery.ts` (new)
- `useMediaQuery(query: string): boolean` — subscribes to any CSS media query, cleans up the listener on unmount, returns `false` when `window` / `matchMedia` is unavailable (SSR-safe).
- `useIsMobile(): boolean` — named breakpoint helper at the repo-documented 768 px threshold (`(max-width: 767px)`).
- Mirrors the `addEventListener` / `removeEventListener` pattern from `SettingsContext`.
- Lazy `useState` initializer reads the initial match synchronously — no flash of wrong state.

### `src/pages/TrustScore.tsx`
- Imports and calls `useIsMobile`.
- Drives the "Recent Activity" card heading: mobile → `Recent Activity`, desktop → `Recent Activity Timeline`.

### `src/hooks/useMediaQuery.test.ts` (new)
Vitest tests covering:
- No-window / no-matchMedia guard (returns `false`, no crash)
- Initial match `false` / `true`
- Change-event-driven re-render
- Listener cleanup on unmount
- Re-subscription when query string changes
- `useIsMobile` breakpoint value and query string assertion

### `docs/HOOKS.md`
- Added `useMediaQuery` / `useIsMobile` to the Contents list.
- Full section (signature, params, behavior notes, usage example) inserted before `useReducedMotion`.

## Acceptance criteria

| Requirement | Status |
|---|---|
| `useMediaQuery` + breakpoint helpers implemented | ✅ |
| Listener cleanup + no-window guard | ✅ |
| Used in at least one real surface (TrustScore activity panel heading) | ✅ |
| Vitest coverage: initial value, change events, cleanup, re-subscription | ✅ |
| Follows existing matchMedia listener pattern (SettingsContext) | ✅ |
| TypeScript strict | ✅ |
| HOOKS.md updated | ✅ |
