### PR TITLE
feat(layout): add active-network indicator pill to the header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -113,7 +113,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -470,7 +469,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -494,7 +492,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2494,7 +2491,6 @@
       "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -2512,7 +2508,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2524,7 +2519,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2588,7 +2582,6 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -2960,7 +2953,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3175,7 +3167,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3693,7 +3684,6 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4627,7 +4617,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -5135,7 +5124,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5274,7 +5262,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5332,7 +5319,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6020,7 +6006,6 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6150,7 +6135,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -6234,7 +6218,6 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Outlet, NavLink } from 'react-router-dom'
 import ThemeToggle from './ThemeToggle'
+import NetworkIndicator from './NetworkIndicator'
 import MobileNav from './navigation/MobileNav'
 import RouteAnnouncer from './RouteAnnouncer'
 import KeyboardShortcutsDialog from './KeyboardShortcutsDialog'
@@ -89,6 +90,7 @@ export default function Layout() {
         </nav>
 
         <ThemeToggle />
+        <NetworkIndicator />
 
         {/* Keyboard shortcuts help button */}
         <button

--- a/src/components/NetworkIndicator.css
+++ b/src/components/NetworkIndicator.css
@@ -1,0 +1,12 @@
+.networkIndicator {
+  display: flex;
+  align-items: center;
+  margin-right: 1rem;
+}
+
+/* Ensure it doesn't overflow or crowd other elements at small viewports */
+@media (max-width: 360px) {
+  .networkIndicator {
+    margin-right: 0.5rem;
+  }
+}

--- a/src/components/NetworkIndicator.test.tsx
+++ b/src/components/NetworkIndicator.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import NetworkIndicator from './NetworkIndicator'
+import { useSettings, type SettingsState } from '../context/SettingsContext'
+
+vi.mock('../context/SettingsContext', () => ({
+  useSettings: vi.fn(),
+}))
+
+describe('NetworkIndicator', () => {
+  it('renders "Mainnet" pill for public network', () => {
+    vi.mocked(useSettings).mockReturnValue({ network: 'public' } as Partial<SettingsState> as SettingsState)
+    render(<NetworkIndicator />)
+    expect(screen.getByText('Mainnet')).toBeInTheDocument()
+    expect(screen.getByLabelText('Active network: Mainnet')).toBeInTheDocument()
+  })
+
+  it('renders "Testnet" pill for test network', () => {
+    vi.mocked(useSettings).mockReturnValue({ network: 'test' } as Partial<SettingsState> as SettingsState)
+    render(<NetworkIndicator />)
+    expect(screen.getByText('Testnet')).toBeInTheDocument()
+    expect(screen.getByLabelText('Active network: Testnet')).toBeInTheDocument()
+  })
+
+  it('renders "Unknown" pill for unknown network', () => {
+    vi.mocked(useSettings).mockReturnValue({ network: 'other' } as Partial<SettingsState> as SettingsState)
+    render(<NetworkIndicator />)
+    expect(screen.getByText('Unknown')).toBeInTheDocument()
+    expect(screen.getByLabelText('Active network: Unknown')).toBeInTheDocument()
+  })
+})

--- a/src/components/NetworkIndicator.tsx
+++ b/src/components/NetworkIndicator.tsx
@@ -1,0 +1,27 @@
+import { useSettings } from '../context/SettingsContext'
+import Badge from './Badge'
+import './NetworkIndicator.css'
+
+export default function NetworkIndicator() {
+  const { network } = useSettings()
+
+  let variant: string
+  let label: string
+
+  if (network === 'public') {
+    variant = 'active'
+    label = 'Mainnet'
+  } else if (network === 'test') {
+    variant = 'slashed' // Using 'slashed' as a high-visibility warning style for Testnet
+    label = 'Testnet'
+  } else {
+    variant = 'unknown'
+    label = 'Unknown'
+  }
+
+  return (
+    <div className="networkIndicator" aria-label={`Active network: ${label}`}>
+      <Badge variant={variant} label={label} />
+    </div>
+  )
+}

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -12,7 +12,7 @@ export interface SettingsPayload {
   autoDismiss: string
 }
 
-interface SettingsState {
+export interface SettingsState {
   themeMode: ThemeMode
   network: string
   addressDisplay: string


### PR DESCRIPTION
Description
  This PR implements a persistent network indicator pill in the application header. This safety affordance
  explicitly displays the currently active Stellar network (Mainnet vs. Testnet) to prevent users from
  unknowingly transacting on the wrong network.

Closes #441 

  Implementation Details
   * Created NetworkIndicator Component:
       * Reads the active network from SettingsContext.
       * Renders a styled pill:
           * "Mainnet": Uses the active variant (subtle).
           * "Testnet": Uses the slashed variant (high-visibility warning color).
           * "Unknown": Uses the unknown variant as a fallback.
       * Includes an accessible aria-label (e.g., "Active network: Testnet").
   * Integration:
       * Added the NetworkIndicator to the Layout header component, positioned next to the ThemeToggle.
       * Styled with NetworkIndicator.css to ensure responsiveness and prevent header overflow at small
         viewports (min 360px).
   * Context Update:
       * Exported SettingsState from SettingsContext.tsx to allow proper type-checking in component tests.
  Acceptance Criteria Checklist
   - [x] NetworkIndicator reflects active network
   - [x] Testnet pill is high-visibility + accessible name
   - [x] Responsive at 360px, contrast-passing in both themes
   - [x] RTL coverage including unknown-network fallback
   - [x] npm run lint + npm run build + npm run test all pass