### PR TITLE
feat: add deep-link support to dashboard widgets via query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ See the [docs/](docs/) directory for detailed project documentation, including:
 
 | Route       | Component            | Description                                                                                                               |
 | ----------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `/dashboard`| `Dashboard.tsx`      | Overview of user activity. Supports `?widget=<slug>` (e.g., `trust-score`, `active-bonds`) for deep-linking exact views.  |
 | `/bond`     | `Bond.tsx`           | Overview page — lists active bonds and provides an entry into the creation wizard                                         |
 | `/bond/new` | `CreateBondPage.tsx` | Four-step bond-creation wizard (amount → duration → review → confirm). Navigates back to `/bond` on completion or cancel. |
 

--- a/src/pages/Dashboard.test.tsx
+++ b/src/pages/Dashboard.test.tsx
@@ -21,9 +21,9 @@ vi.mock('../context/WalletContext', () => ({
   }),
 }))
 
-function renderDashboard() {
+function renderDashboard(initialEntries = ['/']) {
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={initialEntries}>
       <Dashboard />
     </MemoryRouter>
   )
@@ -59,6 +59,15 @@ describe('Dashboard', () => {
     expect(screen.getByText('4,250 USDC')).toBeInTheDocument()
     expect(screen.getByRole('heading', { name: /recent activity/i })).toBeInTheDocument()
     expect(screen.getByText(/Attestation submitted/i)).toBeInTheDocument()
+  })
+
+  it('renders only the specified widget when ?widget= parameter is provided', () => {
+    renderDashboard(['/dashboard?widget=active-bonds'])
+
+    expect(screen.getByRole('heading', { name: /active bonds/i })).toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Trust Score' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: /recent activity/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('heading', { name: 'Shortcuts' })).not.toBeInTheDocument()
   })
 
   it('exposes primary shortcut links', () => {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom'
+import { Link, useSearchParams } from 'react-router-dom'
 import ActionCard from '../components/ActionCard'
 import ActivityTimeline from '../components/ActivityTimeline'
 import Badge from '../components/Badge'
@@ -37,7 +37,14 @@ export default function Dashboard() {
   useDocumentTitle('Dashboard')
 
   const { address, connected, connect, isConnecting } = useWallet()
+  const [searchParams] = useSearchParams()
+  const widgetParam = searchParams.get('widget')
   const totalBonded = activeBonds.reduce((total, bond) => total + bond.amountUsdc, 0)
+
+  const showTrustScore = !widgetParam || widgetParam === 'trust-score'
+  const showActiveBonds = !widgetParam || widgetParam === 'active-bonds'
+  const showRecentActivity = !widgetParam || widgetParam === 'recent-activity'
+  const showShortcuts = !widgetParam || widgetParam === 'shortcuts'
 
   return (
     <div className="dashboard">
@@ -81,62 +88,70 @@ export default function Dashboard() {
       {connected && !isConnecting && (
         <>
           <div className="dashboard__grid">
-            <ActionCard title="Trust Score">
-              <div className="dashboard__cardHeader">
-                <div>
-                  <p className="dashboard__metric">{TRUST_SCORE}</p>
-                  <p className="dashboard__metricLabel">Current score</p>
+            {showTrustScore && (
+              <ActionCard title="Trust Score">
+                <div className="dashboard__cardHeader">
+                  <div>
+                    <p className="dashboard__metric">{TRUST_SCORE}</p>
+                    <p className="dashboard__metricLabel">Current score</p>
+                  </div>
+                  <Badge variant={TRUST_TIER} label="Gold Tier" />
                 </div>
-                <Badge variant={TRUST_TIER} label="Gold Tier" />
-              </div>
-              <TrustGauge
-                score={TRUST_SCORE}
-                tier={TRUST_TIER}
-                className="dashboard__trustGauge"
-                id="dashboard-trust-gauge"
-              />
-            </ActionCard>
+                <TrustGauge
+                  score={TRUST_SCORE}
+                  tier={TRUST_TIER}
+                  className="dashboard__trustGauge"
+                  id="dashboard-trust-gauge"
+                />
+              </ActionCard>
+            )}
 
-            <ActionCard title="Active Bonds">
-              <div className="dashboard__cardHeader">
-                <div>
-                  <p className="dashboard__metric">{formatUsdc(totalBonded)}</p>
-                  <p className="dashboard__metricLabel">{activeBonds.length} active bonds</p>
+            {showActiveBonds && (
+              <ActionCard title="Active Bonds">
+                <div className="dashboard__cardHeader">
+                  <div>
+                    <p className="dashboard__metric">{formatUsdc(totalBonded)}</p>
+                    <p className="dashboard__metricLabel">{activeBonds.length} active bonds</p>
+                  </div>
+                  <Badge variant="active" />
                 </div>
-                <Badge variant="active" />
-              </div>
-              <ul className="dashboard__bondList" aria-label="Active bond summary">
-                {activeBonds.map((bond) => (
-                  <li className="dashboard__bondRow" key={bond.id}>
-                    <div>
-                      <p className="dashboard__bondAmount">{formatUsdc(bond.amountUsdc)}</p>
-                      <p className="dashboard__bondMeta">Unlocks {bond.unlockLabel}</p>
-                    </div>
-                    <Badge variant={bond.status} />
-                  </li>
-                ))}
-              </ul>
-            </ActionCard>
+                <ul className="dashboard__bondList" aria-label="Active bond summary">
+                  {activeBonds.map((bond) => (
+                    <li className="dashboard__bondRow" key={bond.id}>
+                      <div>
+                        <p className="dashboard__bondAmount">{formatUsdc(bond.amountUsdc)}</p>
+                        <p className="dashboard__bondMeta">Unlocks {bond.unlockLabel}</p>
+                      </div>
+                      <Badge variant={bond.status} />
+                    </li>
+                  ))}
+                </ul>
+              </ActionCard>
+            )}
           </div>
 
           <div className="dashboard__grid dashboard__grid--activity">
-            <ActionCard title="Recent Activity">
-              <ActivityTimeline compact />
-            </ActionCard>
+            {showRecentActivity && (
+              <ActionCard title="Recent Activity">
+                <ActivityTimeline compact />
+              </ActionCard>
+            )}
 
-            <ActionCard title="Shortcuts">
-              <div className="dashboard__shortcutList">
-                {shortcuts.map((shortcut) => (
-                  <Link className="dashboard__shortcut" key={shortcut.to} to={shortcut.to}>
-                    <span className="dashboard__shortcutLabel">{shortcut.label}</span>
-                    <span className="dashboard__shortcutDescription">{shortcut.description}</span>
-                  </Link>
-                ))}
-              </div>
-              <Button type="button" variant="secondary" onClick={() => window.scrollTo({ top: 0 })}>
-                Back to summary
-              </Button>
-            </ActionCard>
+            {showShortcuts && (
+              <ActionCard title="Shortcuts">
+                <div className="dashboard__shortcutList">
+                  {shortcuts.map((shortcut) => (
+                    <Link className="dashboard__shortcut" key={shortcut.to} to={shortcut.to}>
+                      <span className="dashboard__shortcutLabel">{shortcut.label}</span>
+                      <span className="dashboard__shortcutDescription">{shortcut.description}</span>
+                    </Link>
+                  ))}
+                </div>
+                <Button type="button" variant="secondary" onClick={() => window.scrollTo({ top: 0 })}>
+                  Back to summary
+                </Button>
+              </ActionCard>
+            )}
           </div>
         </>
       )}


### PR DESCRIPTION
## Closes #386                                                                                                                                                                                                         
                                                                                                                                                                                                                        
   ### Summary                                                                                                                                                                                                         
   Added deep-link support to the Dashboard widgets so that support agents and frontend engineers can share isolated exact views of specific components.                                                               
                                                                                                                                                                                                                        
   ### What changed                                                                                                                                                                                                    
   - `Dashboard.tsx`: Added `useSearchParams` to read the `?widget=` URL parameter. When present, the page will only render the `<ActionCard>` that matches the query param (e.g., `trust-score`, `active-bonds`, `recent-activity`, `shortcuts`), hiding the rest. If omitted, all widgets render as normal.                                                                                                                           
   - `Dashboard.test.tsx`: Seeded the `MemoryRouter` mock to accept `initialEntries` and added a regression test verifying that passing `?widget=active-bonds` correctly filters out all other widgets.                
   - `README.md`: Documented the new deep-link query parameter under the routing index.                                                                                                                                
                                                                                                                                                                                                                        
   *(Note regarding layout: When isolating a widget via the query param, it inherits the full width of its `dashboard__grid` container. This is a standard CSS Grid behavior and is generally acceptable for isolated debugging/support views without requiring a heavier layout refactor).*                                                                                                                                                
                                                                                                                                                                                                                        
   ### Acceptance Criteria Checklist                                                                                                                                                                                   
   - [x] The change matches the summary above.                                                                                                                                                                         
   - [x] No regression in the existing test suite (added test to lock in new behavior).                                                                                                                                
   - [x] The change is documented where it is observable (README).                                                                                                                                                     
   - [x] Lint, type-check, and tests all pass locally.                                                                                                                                                                 
   - [x] PR description references this issue with Closes #.  