### PR TITLE
feat: add standardized useActionToast hook for irreversible actions

### DIFF
--- a/docs/STATE_MANAGEMENT.md
+++ b/docs/STATE_MANAGEMENT.md
@@ -333,9 +333,26 @@ Use this checklist to decide where new state should live:
 
 **✅ Use useToast() for:**
 
-- Confirmation messages after an action
-- Error messages that should not block the UI
-- Non-critical alerts
+- Transient success/failure confirmations
+- Irreversible action feedback (use `useActionToast()` for `sign`, `send`, `approve`, and `delete` actions)
+- Non-critical background events
+
+**🚀 Standardized Action Toasts:**
+
+For irreversible actions, we standardise messages using the `useActionToast()` hook instead of `useToast()`. This hook takes an action type (`'sign'`, `'send'`, `'approve'`, `'delete'`) and a promise, and handles the success/failure toasts for you:
+
+```tsx
+import { useActionToast } from '../hooks/useActionToast'
+
+function ActionComponent() {
+  const { withToast } = useActionToast()
+
+  const handleDelete = async () => {
+    // Automatically shows a success toast if resolved, or a danger toast if rejected (and rethrows)
+    await withToast('delete', apiFetch('/resource/123', { method: 'DELETE' }))
+  }
+}
+```
 
 **❌ Don't add to SettingsContext:**
 

--- a/src/config/toastMessages.ts
+++ b/src/config/toastMessages.ts
@@ -1,0 +1,20 @@
+export const ACTION_TOASTS = {
+  sign: {
+    success: 'Signed successfully.',
+    error: 'Failed to sign.',
+  },
+  send: {
+    success: 'Sent successfully.',
+    error: 'Failed to send.',
+  },
+  approve: {
+    success: 'Approved successfully.',
+    error: 'Failed to approve.',
+  },
+  delete: {
+    success: 'Deleted successfully.',
+    error: 'Failed to delete.',
+  },
+} as const
+
+export type ToastAction = keyof typeof ACTION_TOASTS

--- a/src/hooks/useActionToast.test.ts
+++ b/src/hooks/useActionToast.test.ts
@@ -1,0 +1,65 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useActionToast } from './useActionToast'
+import { ACTION_TOASTS } from '../config/toastMessages'
+
+const mockAddToast = vi.fn()
+
+vi.mock('../components/ToastProvider', () => ({
+  useToast: () => ({
+    addToast: mockAddToast,
+  }),
+}))
+
+describe('useActionToast', () => {
+  beforeEach(() => {
+    mockAddToast.mockClear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('adds a success toast and returns the result when the promise resolves', async () => {
+    const { result } = renderHook(() => useActionToast())
+
+    const promise = Promise.resolve('Success Data')
+
+    let value
+    await act(async () => {
+      value = await result.current.withToast('sign', promise)
+    })
+
+    expect(value).toBe('Success Data')
+    expect(mockAddToast).toHaveBeenCalledWith('success', ACTION_TOASTS['sign'].success)
+    expect(mockAddToast).toHaveBeenCalledTimes(1)
+  })
+
+  it('adds a danger toast and rethrows when the promise rejects', async () => {
+    const { result } = renderHook(() => useActionToast())
+
+    const error = new Error('Test Error')
+    const promise = Promise.reject(error)
+
+    await act(async () => {
+      await expect(result.current.withToast('delete', promise)).rejects.toThrow('Test Error')
+    })
+
+    expect(mockAddToast).toHaveBeenCalledWith('danger', ACTION_TOASTS['delete'].error)
+    expect(mockAddToast).toHaveBeenCalledTimes(1)
+  })
+
+  it('works identically with an async thunk', async () => {
+    const { result } = renderHook(() => useActionToast())
+
+    const thunk = async () => 'Thunk Result'
+
+    let value
+    await act(async () => {
+      value = await result.current.withToast('approve', thunk)
+    })
+
+    expect(value).toBe('Thunk Result')
+    expect(mockAddToast).toHaveBeenCalledWith('success', ACTION_TOASTS['approve'].success)
+  })
+})

--- a/src/hooks/useActionToast.ts
+++ b/src/hooks/useActionToast.ts
@@ -1,0 +1,31 @@
+import { useCallback } from 'react'
+import { useToast } from '../components/ToastProvider'
+import { ACTION_TOASTS, type ToastAction } from '../config/toastMessages'
+
+/**
+ * A specialized hook for wrapping irreversible actions (sign, send, approve, delete)
+ * with standardized success and failure toasts.
+ */
+export function useActionToast() {
+  const { addToast } = useToast()
+
+  const withToast = useCallback(
+    async <T>(
+      action: ToastAction,
+      promise: Promise<T> | (() => Promise<T>)
+    ): Promise<T> => {
+      try {
+        const result = typeof promise === 'function' ? await promise() : await promise
+        addToast('success', ACTION_TOASTS[action].success)
+        return result
+      } catch (err) {
+        // We do not swallow the error; we rethrow so the component can manage its own loading/error state
+        addToast('danger', ACTION_TOASTS[action].error)
+        throw err
+      }
+    },
+    [addToast]
+  )
+
+  return { withToast }
+}


### PR DESCRIPTION
## Closes #379                                                                                                                                                                                                                      
   ### Summary                                                                                                                                                                                                         
   Added a centralized standard for displaying success and failure toasts during irreversible actions (`sign`, `send`, `approve`, and `delete`).                                                                       
                                                                                                                                                                                                                        
   ### What changed                                                                                                                                                                                                    
   - **`src/config/toastMessages.ts`**: Landed the notification string constants in a single place to ensure consistency across the application.                                                                       
   - **`src/hooks/useActionToast.ts`**: Added a new hook that wraps promises for these specific actions. It automatically unwraps the success result to fire a success toast, or catches failures to fire a danger  toast before re-throwing the error so local UI state can be managed correctly.                                                                                                                                        
   - **`docs/STATE_MANAGEMENT.md`**: Updated the Toast behavior guide to direct developers to use this hook instead of manual `addToast` calls for irreversible actions.                                               
                                                                                                                                                                                                                        
   *(Note: Because the UI features for these specific actions haven't been implemented yet, this PR focuses on fulfilling the issue's requirements at the infrastructure level so that they can be reused everywhere once those features land without enforcing manual `try/catch` workarounds.)*                                                                                                                                          
                                                                                                                                                                                                                        
   ### Acceptance Criteria Checklist                                                                                                                                                                                   
   - [x] The change matches the summary above.                                                                                                                                                                         
   - [x] No regression in the existing test suite (added dedicated test suite for the new hook).                                                                                                                       
   - [x] The change is documented where it is observable (`docs/STATE_MANAGEMENT.md`).                                                                                                                                 
   - [x] Lint, type-check, and tests all pass locally.                                                                                                                                                                 
   - [x] PR description references this issue with Closes #.                                                                                                                                                           
                                                                  