### PR TITLE
feat(seo): add useSeo hook for per-route title and meta description

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -23,6 +23,7 @@ behavior notes, and a minimal usage example linking to source.
 - [Hooks (`src/hooks/`)](#hooks-srchooks)
   - [`useFocusTrap`](#usefocustrap)
   - [`useDocumentTitle`](#usedocumenttitle)
+  - [`useSeo`](#useseo)
   - [`useReducedMotion`](#usereducedmotion)
   - [`useTrustScore`](#usetrustscore)
   - [`useUsdcBalance`](#useusdcbalance)
@@ -147,6 +148,49 @@ import { useDocumentTitle } from '../hooks/useDocumentTitle'
 
 function Bond() {
   useDocumentTitle('Bond') // document.title === 'Bond · Credence'
+  return <main>…</main>
+}
+```
+
+---
+
+### `useSeo`
+
+Source: [`src/hooks/useSeo.ts`](../src/hooks/useSeo.ts)
+
+```ts
+function useSeo(options: UseSeoOptions): void
+
+interface UseSeoOptions {
+  title: string
+  description?: string
+  brandSuffix?: boolean      // default: true — append ` · Credence`
+  restoreOnUnmount?: boolean // default: true — restore prior values on unmount
+}
+```
+
+Sets both `document.title` and the `<meta name="description">` tag for the calling
+component's lifetime, restoring the previous values on unmount. This is the preferred
+hook for route-level SEO metadata — a drop-in superset of `useDocumentTitle` that adds
+per-route description control so search engines and social-card scrapers receive page-specific
+descriptions rather than the static fallback in `index.html`.
+
+**Behavior notes**
+
+- Creates the `<meta name="description">` element if one is absent; updates `content` if it
+  already exists; restores or removes it on unmount (governed by `restoreOnUnmount`).
+- Title semantics are identical to `useDocumentTitle` (no double-suffix, empty → `Credence`).
+- **SSR-safe / cleanup:** all DOM access is guarded by `typeof document === 'undefined'` and
+  deferred to effects; both effects clean up their mutations on unmount.
+
+```tsx
+import { useSeo } from '../hooks/useSeo'
+
+function Bond() {
+  useSeo({
+    title: 'Bond',
+    description: 'Lock USDC into the Credence contract to build your on-chain economic reputation.',
+  })
   return <main>…</main>
 }
 ```

--- a/docs/components.md
+++ b/docs/components.md
@@ -4,6 +4,8 @@ This catalog is the source-facing reference for shared UI under `src/components/
 
 Related focused docs: [button system](./button-system.md), [notifications](./notifications.md), [design tokens](./DESIGN_TOKENS.md), [dark mode](./dark-mode.md), [focus patterns](./focus-patterns.md), [UI states](./UI_STATES_GUIDE.md), [TrustGauge quick reference](./TRUST_GAUGE_QUICK_REFERENCE.md), and [tier thresholds](./tier-thresholds.md).
 
+> **Per-route SEO metadata** — Use the [`useSeo`](../src/hooks/useSeo.ts) hook (documented in [HOOKS.md](./HOOKS.md#useseo)) to set `document.title` and `<meta name="description">` on a per-route basis. Every route-level page component should call `useSeo` with a descriptive `description` so search engines and social-card scrapers receive page-specific context rather than the static fallback in `index.html`.
+
 ## Styling ownership snapshot
 
 | Component              | Styling owner                                                                       | Inline-style migration note                                                                                               |

--- a/src/hooks/useSeo.test.ts
+++ b/src/hooks/useSeo.test.ts
@@ -1,0 +1,130 @@
+import { renderHook, cleanup } from '@testing-library/react'
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { useSeo } from './useSeo'
+import { BRAND_SUFFIX } from './useDocumentTitle'
+
+const INITIAL_TITLE = 'Test Page'
+
+function getMetaDescription(): HTMLMetaElement | null {
+  return document.querySelector<HTMLMetaElement>('meta[name="description"]')
+}
+
+beforeEach(() => {
+  document.title = INITIAL_TITLE
+  getMetaDescription()?.remove()
+})
+
+afterEach(() => {
+  cleanup()
+  document.title = INITIAL_TITLE
+  getMetaDescription()?.remove()
+})
+
+describe('useSeo', () => {
+  describe('title management', () => {
+    it('sets document.title with the brand suffix by default', () => {
+      renderHook(() => useSeo({ title: 'Bond' }))
+      expect(document.title).toBe(`Bond ${BRAND_SUFFIX}`)
+    })
+
+    it('omits the brand suffix when brandSuffix=false', () => {
+      renderHook(() => useSeo({ title: 'Bond', brandSuffix: false }))
+      expect(document.title).toBe('Bond')
+    })
+
+    it('does not double-suffix an already-branded title', () => {
+      renderHook(() => useSeo({ title: `Bond ${BRAND_SUFFIX}` }))
+      expect(document.title).toBe(`Bond ${BRAND_SUFFIX}`)
+    })
+
+    it('restores the previous title on unmount', () => {
+      document.title = 'Previous Page'
+      const { unmount } = renderHook(() => useSeo({ title: 'Bond' }))
+      unmount()
+      expect(document.title).toBe('Previous Page')
+    })
+
+    it('leaves the title in place when restoreOnUnmount=false', () => {
+      document.title = 'Previous Page'
+      const { unmount } = renderHook(() => useSeo({ title: 'Bond', restoreOnUnmount: false }))
+      unmount()
+      expect(document.title).toBe(`Bond ${BRAND_SUFFIX}`)
+    })
+
+    it('updates document.title when the title prop changes', () => {
+      const { rerender } = renderHook(({ title }: { title: string }) => useSeo({ title }), {
+        initialProps: { title: 'Bond' },
+      })
+      expect(document.title).toBe(`Bond ${BRAND_SUFFIX}`)
+      rerender({ title: 'Dashboard' })
+      expect(document.title).toBe(`Dashboard ${BRAND_SUFFIX}`)
+    })
+  })
+
+  describe('meta description management', () => {
+    it('creates a <meta name="description"> element when none exists', () => {
+      renderHook(() => useSeo({ title: 'Bond', description: 'Lock USDC on Stellar.' }))
+      const meta = getMetaDescription()
+      expect(meta).not.toBeNull()
+      expect(meta!.getAttribute('content')).toBe('Lock USDC on Stellar.')
+    })
+
+    it('updates an existing meta description without creating a duplicate', () => {
+      const existing = document.createElement('meta')
+      existing.setAttribute('name', 'description')
+      existing.setAttribute('content', 'Old description')
+      document.head.appendChild(existing)
+
+      renderHook(() => useSeo({ title: 'Bond', description: 'New description.' }))
+
+      const metas = document.querySelectorAll('meta[name="description"]')
+      expect(metas).toHaveLength(1)
+      expect(metas[0].getAttribute('content')).toBe('New description.')
+    })
+
+    it('restores a pre-existing description on unmount', () => {
+      const existing = document.createElement('meta')
+      existing.setAttribute('name', 'description')
+      existing.setAttribute('content', 'Original description')
+      document.head.appendChild(existing)
+
+      const { unmount } = renderHook(() =>
+        useSeo({ title: 'Bond', description: 'Temporary description' })
+      )
+      unmount()
+
+      expect(getMetaDescription()!.getAttribute('content')).toBe('Original description')
+    })
+
+    it('removes a created meta description on unmount', () => {
+      const { unmount } = renderHook(() =>
+        useSeo({ title: 'Bond', description: 'Ephemeral description' })
+      )
+      unmount()
+      expect(getMetaDescription()).toBeNull()
+    })
+
+    it('does not create a meta description when description is undefined', () => {
+      renderHook(() => useSeo({ title: 'Bond' }))
+      expect(getMetaDescription()).toBeNull()
+    })
+
+    it('leaves the description in place when restoreOnUnmount=false', () => {
+      const { unmount } = renderHook(() =>
+        useSeo({ title: 'Bond', description: 'Permanent desc', restoreOnUnmount: false })
+      )
+      unmount()
+      expect(getMetaDescription()!.getAttribute('content')).toBe('Permanent desc')
+    })
+
+    it('updates the description when the prop changes', () => {
+      const { rerender } = renderHook(
+        ({ description }: { description: string }) => useSeo({ title: 'Bond', description }),
+        { initialProps: { description: 'First' } }
+      )
+      expect(getMetaDescription()!.getAttribute('content')).toBe('First')
+      rerender({ description: 'Second' })
+      expect(getMetaDescription()!.getAttribute('content')).toBe('Second')
+    })
+  })
+})

--- a/src/hooks/useSeo.ts
+++ b/src/hooks/useSeo.ts
@@ -1,0 +1,87 @@
+import { useEffect } from 'react'
+import { formatDocumentTitle } from './useDocumentTitle'
+
+export interface UseSeoOptions {
+  /** The page-specific title (e.g. 'Bond') — branded to 'Bond · Credence'. */
+  title: string
+  /** Per-route meta description surfaced by search engines and social card scrapers. */
+  description?: string
+  /**
+   * Append the '· Credence' brand suffix to the title.
+   * @defaultValue true
+   */
+  brandSuffix?: boolean
+  /**
+   * Restore the prior document title and meta description on unmount.
+   * @defaultValue true
+   */
+  restoreOnUnmount?: boolean
+}
+
+/**
+ * Sets `document.title` and the `<meta name="description">` tag for the lifetime
+ * of the calling component, restoring the previous values on unmount.
+ *
+ * This is a drop-in superset of `useDocumentTitle` — it forwards the title /
+ * brandSuffix / restoreOnUnmount semantics while additionally managing the
+ * description meta tag so every route can own its own SEO metadata without a
+ * central registry.
+ *
+ * SSR-safe: all DOM access is deferred to effects and guarded by a
+ * `typeof document === 'undefined'` check.
+ *
+ * @example
+ * ```tsx
+ * function Bond() {
+ *   useSeo({
+ *     title: 'Bond',
+ *     description: 'Lock USDC into the Credence contract to build your on-chain reputation.',
+ *   })
+ *   return <main>…</main>
+ * }
+ * ```
+ */
+export function useSeo({
+  title,
+  description,
+  brandSuffix = true,
+  restoreOnUnmount = true,
+}: UseSeoOptions): void {
+  // ── Title ──────────────────────────────────────────────────────────────────
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+
+    const previousTitle = document.title
+    document.title = formatDocumentTitle(title, brandSuffix)
+
+    return () => {
+      if (restoreOnUnmount) document.title = previousTitle
+    }
+  }, [title, brandSuffix, restoreOnUnmount])
+
+  // ── Meta description ───────────────────────────────────────────────────────
+  useEffect(() => {
+    if (typeof document === 'undefined' || description === undefined) return
+
+    let metaEl = document.querySelector<HTMLMetaElement>('meta[name="description"]')
+    const previousContent = metaEl?.getAttribute('content') ?? null
+    const wasCreated = metaEl === null
+
+    if (wasCreated) {
+      metaEl = document.createElement('meta')
+      metaEl.setAttribute('name', 'description')
+      document.head.appendChild(metaEl)
+    }
+
+    metaEl!.setAttribute('content', description)
+
+    return () => {
+      if (!restoreOnUnmount) return
+      if (wasCreated) {
+        metaEl?.parentNode?.removeChild(metaEl)
+      } else if (previousContent !== null && metaEl) {
+        metaEl.setAttribute('content', previousContent)
+      }
+    }
+  }, [description, restoreOnUnmount])
+}

--- a/src/pages/Bond.tsx
+++ b/src/pages/Bond.tsx
@@ -12,7 +12,7 @@ import AmountInput from '../components/AmountInput'
 import { FormField } from '../components/forms/FormField'
 import { useSettings } from '../context/SettingsContext'
 import { useWallet } from '../context/WalletContext'
-import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { useSeo } from '../hooks/useSeo'
 import { useNetworkMismatch } from '../hooks/useNetworkMismatch'
 import { formatUsdc } from '../lib/format'
 import {
@@ -119,7 +119,11 @@ function BondRow({ bond, isConnected, onWithdraw, onConnect }: BondRowProps) {
 }
 
 export default function Bond() {
-  useDocumentTitle('Bond')
+  useSeo({
+    title: 'Bond',
+    description:
+      'Lock USDC into the Credence contract to build your on-chain economic reputation. Create bonds, track penalties, and manage withdrawals.',
+  })
 
   const navigate = useNavigate()
   const { addToast } = useToast()

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -7,7 +7,7 @@ import Button from '../components/Button'
 import TrustGauge from '../components/TrustGauge'
 import { EmptyState, LoadingSkeleton } from '../components/states'
 import { useWallet } from '../context/WalletContext'
-import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { useSeo } from '../hooks/useSeo'
 import { formatUsdc } from '../lib/format'
 import './Dashboard.css'
 
@@ -34,7 +34,11 @@ const shortcuts = [
 ]
 
 export default function Dashboard() {
-  useDocumentTitle('Dashboard')
+  useSeo({
+    title: 'Dashboard',
+    description:
+      'Monitor your Credence trust score, active USDC bonds, and recent protocol activity from one place.',
+  })
 
   const { address, connected, connect, isConnecting } = useWallet()
   const totalBonded = activeBonds.reduce((total, bond) => total + bond.amountUsdc, 0)

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,9 +1,13 @@
 import { Link } from 'react-router-dom'
-import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { useSeo } from '../hooks/useSeo'
 import './Home.css'
 
 export default function Home() {
-  useDocumentTitle('Home')
+  useSeo({
+    title: 'Home',
+    description:
+      'Credence — on-chain economic identity on Stellar. Stake USDC as a programmable reputation bond and build verifiable trust.',
+  })
 
   return (
     <div className="home">

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -7,7 +7,7 @@ import Toggle from '../components/controls/Toggle'
 import Select from '../components/controls/Select'
 import ConfirmDialog from '../components/ConfirmDialog'
 import { ErrorState } from '../components/states'
-import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { useSeo } from '../hooks/useSeo'
 import { validateAndNormalize, type SettingsBlob } from '../lib/settingsSchema'
 import './Settings.css'
 
@@ -46,7 +46,10 @@ export default function Settings() {
   } = useSettings()
   const { addToast } = useToast()
 
-  useDocumentTitle('Settings')
+  useSeo({
+    title: 'Settings',
+    description: 'Configure your Credence app preferences: theme, network, address display, and toast notifications.',
+  })
 
   const [draft, setDraft] = useState({
     themeMode: themeMode as 'light' | 'dark' | 'system',

--- a/src/pages/TrustScore.tsx
+++ b/src/pages/TrustScore.tsx
@@ -13,7 +13,7 @@ import { TIERS } from '../lib/tiers'
 import { EmptyState, ErrorState, LoadingSkeleton } from '../components/states'
 import { useSettings } from '../context/SettingsContext'
 import { useWallet } from '../context/WalletContext'
-import { useDocumentTitle } from '../hooks/useDocumentTitle'
+import { useSeo } from '../hooks/useSeo'
 import { useNetworkMismatch } from '../hooks/useNetworkMismatch'
 import { useTrustScore } from '../hooks/useTrustScore'
 import { ApiError } from '../api/client'
@@ -34,7 +34,11 @@ function trustScoreErrorType(error: ApiError): 'network' | 'backend' | 'validati
 }
 
 export default function TrustScore() {
-  useDocumentTitle('Trust Score')
+  useSeo({
+    title: 'Trust Score',
+    description:
+      'Look up on-chain Credence trust scores for any Stellar address. View tier, bond history, and attestation evidence.',
+  })
 
   const { isConnected, address: walletAddress, connect, network: walletNetwork } = useWallet()
   const { setNetwork } = useSettings()


### PR DESCRIPTION
Closes #398

## Summary

Introduces `src/hooks/useSeo.ts` -- a drop-in superset of `useDocumentTitle` that also manages `<meta name="description">` on a per-route basis. Every route-level page component can now own its SEO metadata inline rather than relying on the static fallback in `index.html`.

### Changes

- **`src/hooks/useSeo.ts`** -- new `useSeo({ title, description, brandSuffix?, restoreOnUnmount? })` hook that sets `document.title` (via `formatDocumentTitle`) and creates/updates/restores `<meta name="description">` with full lifecycle management
- **`src/hooks/useSeo.test.ts`** -- comprehensive RTL test suite covering title management (brand suffix, double-suffix guard, restore on unmount) and meta description management (create, update existing, restore, remove on unmount)
- **Pages migrated:** `Bond`, `Home`, `Dashboard`, `TrustScore`, `Settings` -- all now call `useSeo` with a descriptive per-route description
- **`docs/HOOKS.md`** -- added `useSeo` entry under hooks catalog
- **`docs/COMPONENTS.md`** -- added cross-reference note directing consumers to `useSeo` for per-route SEO

### Backwards compatibility

`useDocumentTitle` is unchanged and still exported. `useSeo` is purely additive.

## Test plan

- [ ] `npm run lint` passes
- [ ] `npm run build` passes
- [ ] `npm run test` passes