### PR TITLE
feat(bond): add transaction-pending UX to create and withdraw actions

### DIFF
--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -49,6 +49,12 @@ export interface ConfirmDialogProps {
    * Defaults to the wallet/funds hint used for bond withdrawals.
    */
   confirmHint?: string
+  /**
+   * When `true`, the dialog is mid-submission: the confirm button enters its
+   * loading state, the cancel button is disabled, and backdrop-click is ignored.
+   * Reset to `false` once the async operation settles (success or error).
+   */
+  isSubmitting?: boolean
 }
 
 export default function ConfirmDialog({
@@ -67,6 +73,7 @@ export default function ConfirmDialog({
   variant = 'danger',
   confirmPhrase = DEFAULT_CONFIRM_PHRASE,
   confirmHint = DEFAULT_CONFIRM_HINT,
+  isSubmitting = false,
 }: ConfirmDialogProps) {
   const titleId = useId()
   const descId = useId()
@@ -132,6 +139,7 @@ export default function ConfirmDialog({
   }
 
   const handleBackdropClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (isSubmitting) return
     if (event.target === event.currentTarget) {
       handleCancel()
     }
@@ -209,16 +217,23 @@ export default function ConfirmDialog({
         </div>
 
         <footer className="confirm-dialog__footer">
-          <Button ref={cancelRef} type="button" variant="secondary" onClick={handleCancel}>
+          <Button
+            ref={cancelRef}
+            type="button"
+            variant="secondary"
+            onClick={handleCancel}
+            disabled={isSubmitting}
+          >
             Cancel
           </Button>
           <Button
             ref={confirmRef}
             type="button"
             variant={variant === 'danger' ? 'danger' : 'primary'}
-            disabled={!isConfirmEnabled}
+            disabled={!isConfirmEnabled || isSubmitting}
+            isLoading={isSubmitting}
             onClick={handleConfirm}
-            aria-disabled={!isConfirmEnabled}
+            aria-disabled={!isConfirmEnabled || isSubmitting}
           >
             {confirmLabel}
           </Button>

--- a/src/pages/Bond.test.tsx
+++ b/src/pages/Bond.test.tsx
@@ -207,4 +207,98 @@ describe('Bond Page', () => {
     await user.click(screen.getByRole('button', { name: /switch app to test \(testnet\)/i }))
     expect(mockSetNetwork).toHaveBeenCalledWith('test')
   })
+
+  describe('transaction pending states', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.runAllTimers()
+      vi.useRealTimers()
+    })
+
+    it('create bond button enters aria-busy while transaction is in flight', async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+      render(<Bond />)
+
+      const createBtn = screen.getByRole('button', { name: /^Create bond$/i })
+      expect(createBtn).not.toHaveAttribute('aria-busy', 'true')
+
+      // start the click but do not advance the timer yet
+      const clickPromise = user.click(createBtn)
+      // while the mock delay is pending, the button should be busy
+      expect(screen.getByRole('button', { name: /^Create bond$/i })).toHaveAttribute(
+        'aria-busy',
+        'true'
+      )
+
+      // complete the timer so the promise resolves
+      vi.runAllTimers()
+      await clickPromise
+    })
+
+    it('aria-live region announces "Submitting transaction…" while in flight', async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+      render(<Bond />)
+
+      const clickPromise = user.click(screen.getByRole('button', { name: /^Create bond$/i }))
+      expect(screen.getByRole('status')).toHaveTextContent('Submitting transaction…')
+
+      vi.runAllTimers()
+      await clickPromise
+    })
+
+    it('aria-live region is cleared after transaction completes', async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+      render(<Bond />)
+
+      const clickPromise = user.click(screen.getByRole('button', { name: /^Create bond$/i }))
+      vi.runAllTimers()
+      await clickPromise
+
+      expect(screen.getByRole('status')).toHaveTextContent('')
+    })
+
+    it('navigates to /bond/new after create transaction completes', async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+      render(<Bond />)
+
+      const clickPromise = user.click(screen.getByRole('button', { name: /^Create bond$/i }))
+      vi.runAllTimers()
+      await clickPromise
+
+      expect(mockNavigate).toHaveBeenCalledWith('/bond/new')
+    })
+
+    it('prevents double-submit: second click while pending is a no-op', async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+      render(<Bond />)
+
+      const createBtn = screen.getByRole('button', { name: /^Create bond$/i })
+      const firstClick = user.click(createBtn)
+
+      // Button is now disabled (aria-busy + disabled), second click should not fire
+      await user.click(createBtn)
+
+      vi.runAllTimers()
+      await firstClick
+
+      // navigate should only have been called once despite two clicks
+      expect(mockNavigate).toHaveBeenCalledTimes(1)
+    })
+
+    it('create bond button resets to non-loading after transaction completes', async () => {
+      const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+      render(<Bond />)
+
+      const clickPromise = user.click(screen.getByRole('button', { name: /^Create bond$/i }))
+      vi.runAllTimers()
+      await clickPromise
+
+      const btn = screen.getByRole('button', { name: /^Create bond$/i })
+      expect(btn).not.toHaveAttribute('aria-busy', 'true')
+      expect(btn).not.toBeDisabled()
+    })
+  })
 })

--- a/src/pages/Bond.tsx
+++ b/src/pages/Bond.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useMemo, useRef, useState } from 'react'
+import { lazy, Suspense, useCallback, useMemo, useRef, useState, useId } from 'react'
 import { useNavigate } from 'react-router-dom'
 import './Bond.css'
 import Banner from '../components/Banner'
@@ -22,6 +22,11 @@ import {
 } from '../lib/bondPenalty'
 
 const ConfirmDialog = lazy(() => import('../components/ConfirmDialog'))
+
+/** Simulates the async round-trip of signing and submitting a Stellar transaction. */
+function submitTransaction(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 1500))
+}
 
 export interface MockBond {
   id: number
@@ -132,16 +137,32 @@ export default function Bond() {
 
   const [bondAmount, setBondAmount] = useState('')
   const [bondAmountError, setBondAmountError] = useState('')
+  const [isPendingCreate, setIsPendingCreate] = useState(false)
+  const [isPendingWithdraw, setIsPendingWithdraw] = useState(false)
+  const [txStatus, setTxStatus] = useState('')
+  const txStatusId = useId()
 
   const bonds = initialBonds
 
-  const handleCreateBond = useCallback(() => {
+  const handleCreateBond = useCallback(async () => {
     if (!isConnected) {
       connect()
       return
     }
-    navigate('/bond/new')
-  }, [isConnected, connect, navigate])
+    if (isPendingCreate) return
+    setIsPendingCreate(true)
+    setTxStatus('Submitting transaction…')
+    try {
+      await submitTransaction()
+      setTxStatus('')
+      navigate('/bond/new')
+    } catch {
+      setTxStatus('')
+      addToast('danger', 'Transaction failed. Please try again.')
+    } finally {
+      setIsPendingCreate(false)
+    }
+  }, [isConnected, connect, navigate, isPendingCreate, addToast])
 
   const withdrawBreakdown = useMemo(
     () => (withdrawTarget ? computeWithdrawBreakdown(withdrawTarget) : null),
@@ -165,22 +186,36 @@ export default function Bond() {
     setWithdrawTarget(null)
   }, [])
 
-  const confirmWithdraw = useCallback(() => {
+  const confirmWithdraw = useCallback(async () => {
     if (!withdrawTarget || !withdrawBreakdown) return
+    if (isPendingWithdraw) return
+
+    setIsPendingWithdraw(true)
+    setTxStatus('Submitting transaction…')
 
     const { penaltyUsdc } = withdrawBreakdown
     const mockHash = 'b6d396a84d41bf162d05f32a51f8a846b0a6fb2abccedb441f71f11e9f1a2380'
-    if (penaltyUsdc > 0) {
-      addToast(
-        'warning',
-        `Bond withdrawn. ${formatUsdc(penaltyUsdc)} was slashed per early withdrawal policy.`,
-        { txHash: mockHash }
-      )
-    } else {
-      addToast('success', 'Bond withdrawn successfully.', { txHash: mockHash })
+
+    try {
+      await submitTransaction()
+      setTxStatus('')
+      if (penaltyUsdc > 0) {
+        addToast(
+          'warning',
+          `Bond withdrawn. ${formatUsdc(penaltyUsdc)} was slashed per early withdrawal policy.`,
+          { txHash: mockHash }
+        )
+      } else {
+        addToast('success', 'Bond withdrawn successfully.', { txHash: mockHash })
+      }
+      setWithdrawTarget(null)
+    } catch {
+      setTxStatus('')
+      addToast('danger', 'Withdrawal failed. Please try again.')
+    } finally {
+      setIsPendingWithdraw(false)
     }
-    setWithdrawTarget(null)
-  }, [withdrawTarget, withdrawBreakdown, addToast])
+  }, [withdrawTarget, withdrawBreakdown, addToast, isPendingWithdraw])
 
   const slashExposureBond = useMemo(() => bonds.find((b) => getPenaltyRate(b.status) > 0), [bonds])
 
@@ -191,6 +226,17 @@ export default function Bond() {
 
   return (
     <div className="bond__container">
+      {/* aria-live region announces async transaction progress to assistive tech */}
+      <div
+        id={txStatusId}
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {txStatus}
+      </div>
+
       <div className="bond__headerSection">
         <h1 className="bond__title">Bond USDC</h1>
         <p id="bond-desc" className="bond__description">
@@ -271,7 +317,8 @@ export default function Bond() {
             type="button"
             onClick={handleCreateBond}
             fullWidth
-            disabled={networkMismatch.mismatch}
+            disabled={networkMismatch.mismatch || isPendingCreate}
+            isLoading={isPendingCreate}
             aria-describedby={networkMismatch.mismatch ? mismatchBannerId : undefined}
           >
             {isConnected ? 'Create bond' : 'Connect wallet to continue'}
@@ -315,6 +362,7 @@ export default function Bond() {
             onConfirm={confirmWithdraw}
             onCancel={cancelWithdraw}
             returnFocusRef={withdrawTriggerRef}
+            isSubmitting={isPendingWithdraw}
           />
         </Suspense>
       )}


### PR DESCRIPTION
Closes #443

## Summary

Buttons enter `aria-busy` loading, the confirm dialog locks during submit, and an `aria-live` region announces progress - preventing duplicate submissions and giving screen-reader users real-time feedback during the async Stellar transaction window.

### Changes

**`src/pages/Bond.tsx`**
- Added `isPendingCreate` and `isPendingWithdraw` local state
- `submitTransaction()` helper models the async gap (mock delay) until the real Stellar API lands
- Create Bond `Button` wires `isLoading={isPendingCreate}`; button disabled during flight
- `handleCreateBond` and `confirmWithdraw` are now async; both guard against double-submit via `isPending` flag checks
- `aria-live="polite"` `sr-only` region announces `"Submitting transaction."` on start and clears on success/failure
- Error path shows a danger toast and resets pending state

**`src/components/ConfirmDialog.tsx`**
- Added `isSubmitting?: boolean` prop
- When `isSubmitting`: confirm button enters `isLoading` state, cancel button disabled, backdrop-click blocked to prevent inconsistent mid-submit dismissal

**`src/pages/Bond.test.tsx`**
- RTL tests for pending-state aria-busy, aria-live region text, double-submit prevention, post-completion reset, and navigate-on-success
- Uses `vi.useFakeTimers()` + `advanceTimers` to synchronously drive the mock delay

## Test plan

- [ ] `npm run lint` passes
- [ ] `npm run build` passes
- [ ] `npm run test` passes (new Bond.test.tsx pending-state coverage)