### PR TITLE
feat(a11y): fix focus trap in connect-wallet modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ See the [docs/](docs/) directory for detailed project documentation, including:
 ## Project layout
 
 - `src/pages/` — Home, Bond, Trust Score
-- `src/components/` — Layout, shared UI; see the [shared components catalog](docs/COMPONENTS.md) for props, accessibility notes, styling ownership, and token usage
+- `src/components/` — Layout, shared UI; see the [shared components catalog](docs/COMPONENTS.md) for props, Storybook stories, accessibility notes, styling ownership, and token usage
 - `src/App.tsx` — Router and routes
 
 ### Bond flow routes

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -4,6 +4,8 @@ This catalog is the source-facing reference for shared UI under `src/components/
 
 Related focused docs: [button system](./button-system.md), [notifications](./notifications.md), [design tokens](./DESIGN_TOKENS.md), [dark mode](./dark-mode.md), [focus patterns](./focus-patterns.md), [UI states](./UI_STATES_GUIDE.md), [TrustGauge quick reference](./TRUST_GAUGE_QUICK_REFERENCE.md), and [tier thresholds](./tier-thresholds.md).
 
+**Storybook**: Components that have stories are listed with their Storybook path and variant names. Run `npm run storybook` (defaults to port 6006) to browse and interact with them. Components without a Storybook entry have no story file yet.
+
 ## Styling ownership snapshot
 
 | Component              | Styling owner                                                                       | Inline-style migration note                                                                                               |
@@ -25,6 +27,13 @@ Related focused docs: [button system](./button-system.md), [notifications](./not
 | states/ErrorState      | Inline styles in `src/components/states/ErrorState.tsx`                             | Owns inline styles and should be migrated to CSS.                                                                         |
 | states/LoadingSkeleton | Inline styles in `src/components/states/LoadingSkeleton.tsx`                        | Owns inline styles and should be migrated to CSS.                                                                         |
 | SessionTimeoutModal    | Inline styles in `src/components/SessionTimeoutModal.tsx`                           | Uses `ConfirmDialog` primitive with internal warning styles.                                                              |
+| ActionCard             | Inline styles in `src/components/ActionCard.tsx`                                    | Owns all inline styles; migrate to a CSS file when a module is added.                                                    |
+| Disclaimer             | `src/components/Disclaimer.css`                                                     | None.                                                                                                                     |
+| ThemeToggle            | `src/components/ThemeToggle.css`                                                    | None.                                                                                                                     |
+| KeyboardShortcutsDialog | `src/components/KeyboardShortcutsDialog.css`                                       | None.                                                                                                                     |
+| AttestationForm        | Delegates to `AddressInput`, `Select`, `FormField`, `Button`                        | No dedicated CSS file; inherits from composing components.                                                                |
+| CreateBondFlow         | `src/components/CreateBondFlow.css`                                                 | None.                                                                                                                     |
+| ErrorBoundary          | Delegates to `states/ErrorState`                                                    | No dedicated CSS file.                                                                                                    |
 
 ## Shared vocabularies
 
@@ -163,18 +172,27 @@ function SaveButton() {
 
 Source: [`src/components/ConfirmDialog.tsx`](../src/components/ConfirmDialog.tsx). Focused docs: [focus patterns](./focus-patterns.md).
 
-| Prop             | Type                                                                                              | Default           |
-| ---------------- | ------------------------------------------------------------------------------------------------- | ----------------- |
-| `open`           | `boolean`                                                                                         | Required          |
-| `title`          | `string`                                                                                          | Required          |
-| `subtitle`       | `string`                                                                                          | `undefined`       |
-| `breakdown`      | `{ bondAmount: string; penaltyAmount: string; penaltyPercent: number; resultingBalance: string }` | Required          |
-| `onConfirm`      | `() => void`                                                                                      | Required          |
-| `onCancel`       | `() => void`                                                                                      | Required          |
-| `returnFocusRef` | `RefObject<HTMLElement \| null>`                                                                  | `undefined`       |
-| `confirmLabel`   | `string`                                                                                          | `'Withdraw bond'` |
+| Prop                | Type                              | Default                          |
+| ------------------- | --------------------------------- | -------------------------------- |
+| `open`              | `boolean`                         | Required                         |
+| `title`             | `string`                          | Required                         |
+| `subtitle`          | `string`                          | `undefined`                      |
+| `breakdown`         | `ConfirmDialogPenaltyBreakdown`   | `undefined`                      |
+| `description`       | `React.ReactNode`                 | `undefined`                      |
+| `children`          | `React.ReactNode`                 | `undefined`                      |
+| `onConfirm`         | `() => void`                      | Required                         |
+| `onCancel`          | `() => void`                      | Required                         |
+| `returnFocusRef`    | `RefObject<HTMLElement \| null>`  | `undefined`                      |
+| `confirmLabel`      | `string`                          | `'Withdraw bond'`                |
+| `confirmInputLabel` | `React.ReactNode`                 | `undefined`                      |
+| `confirmInputHint`  | `React.ReactNode`                 | `undefined`                      |
+| `variant`           | `'danger' \| 'info'`              | `'danger'`                       |
+| `confirmPhrase`     | `string`                          | `'CONFIRM'`                      |
+| `confirmHint`       | `string`                          | Wallet/funds irreversibility hint |
 
-Accessibility: renders in a portal with `role="dialog"`, `aria-modal="true"`, generated `aria-labelledby`/`aria-describedby`, focus trap, initial focus on Cancel, Escape and backdrop cancellation, body scroll lock, and optional focus restoration. The destructive action is disabled until the user types `CONFIRM`; assertive sr-only announcements describe state changes.
+`ConfirmDialogPenaltyBreakdown` is `{ bondAmount: string; penaltyAmount: string; penaltyPercent: number; resultingBalance: string }`. When `breakdown` is omitted, the `description` prop or `children` slot is rendered in its place.
+
+Accessibility: renders in a portal with `role="dialog"`, `aria-modal="true"`, generated `aria-labelledby`/`aria-describedby`, focus trap, initial focus on Cancel, Escape and backdrop cancellation, body scroll lock, and optional focus restoration. The confirm button is disabled until the user types the value of `confirmPhrase` (default: `CONFIRM`); assertive sr-only announcements describe state changes.
 
 Tokens: danger color tokens, font family/size/weight, line-height, motion, radius, spacing, surface, and text tokens.
 
@@ -220,6 +238,8 @@ Tokens: border, danger, primary, slate, success, focus, font, line-height, motio
 />
 ```
 
+Storybook: `Components/Forms/AddressInput` — **Default** · **Filled** · **Invalid** · **Disabled** · **Loading**.
+
 ## AmountInput
 
 Source: [`src/components/AmountInput.tsx`](../src/components/AmountInput.tsx). Focused docs: [USDC amount input](./uiux/usdc-amount-input.md).
@@ -241,6 +261,8 @@ Tokens: border, danger-border, slate, focus, font, motion, radius, spacing, surf
 ```tsx
 <AmountInput value={amount} onChange={setAmount} balance={availableUsdc} error={amountError} />
 ```
+
+Storybook: `Components/Forms/AmountInput` — **Default** · **Filled** · **OverBalance** · **Error** · **Disabled** · **Loading**.
 
 ## TrustGauge
 
@@ -319,6 +341,8 @@ Tokens: `--credence-color-danger-text`, `--credence-font-size-sm`, `--credence-f
 </FormField>
 ```
 
+Storybook: `Components/Forms/FormField` — **Default** · **WithHint** · **WithError** · **WithHintAndError**.
+
 ## controls/Select
 
 Source: [`src/components/controls/Select.tsx`](../src/components/controls/Select.tsx).
@@ -345,6 +369,8 @@ Tokens: shared control CSS consumes border, primary, white, focus, font, line-he
 />
 ```
 
+Storybook: `Components/Controls/Select` — **Default** · **Error** · **Disabled** · **Loading**.
+
 ## controls/Toggle
 
 Source: [`src/components/controls/Toggle.tsx`](../src/components/controls/Toggle.tsx).
@@ -363,6 +389,8 @@ Tokens: shared control CSS consumes border, primary, white, focus, font, line-he
 ```tsx
 <Toggle checked={toastsEnabled} onChange={setToastsEnabled} ariaLabel="Enable notifications" />
 ```
+
+Storybook: `Components/Controls/Toggle` — **Off** · **On** · **Error** · **Disabled** · **Loading**.
 
 ## states/EmptyState
 
@@ -449,4 +477,142 @@ Tokens: warning color tokens, spacing, radius.
   onStayLoggedIn={stay}
   onLogout={logout}
 />
+```
+
+## ActionCard
+
+Source: [`src/components/ActionCard.tsx`](../src/components/ActionCard.tsx).
+
+| Prop       | Type        | Default  |
+| ---------- | ----------- | -------- |
+| `title`    | `string`    | Required |
+| `children` | `ReactNode` | Required |
+
+Accessibility: renders as a semantic `<article>` with the title in an `<h2>`. No additional ARIA attributes are needed; place inside a `<main>` or named landmark so context is clear.
+
+Tokens: `--credence-border-default`, `--credence-radius-xl`, `--credence-space-4`, `--credence-space-6`, `--credence-surface-card`, `--credence-text-primary`, `--credence-font-size-xl`, `--credence-line-height-tight`.
+
+```tsx
+<ActionCard title="Create bond">
+  <AmountInput value={amount} onChange={setAmount} balance={balance} />
+  <Button onClick={submit}>Submit</Button>
+</ActionCard>
+```
+
+## Disclaimer
+
+Source: [`src/components/Disclaimer.tsx`](../src/components/Disclaimer.tsx).
+
+| Prop        | Type     | Default        |
+| ----------- | -------- | -------------- |
+| `context`   | `string` | `undefined`    |
+| `termsHref` | `string` | `LINKS.terms`  |
+
+Accessibility: renders as `<aside aria-label="Risk disclaimer">`. The terms link has an explicit `aria-label="Read full terms and conditions"`. When `termsHref` resolves to a placeholder (`'#'` or empty), a `<span aria-disabled="true">` is rendered instead of an anchor so the element is inert for keyboard and AT users.
+
+Tokens: secondary text and spacing tokens via `Disclaimer.css`.
+
+```tsx
+<Disclaimer context="Early withdrawal forfeits accrued rewards." />
+```
+
+## ThemeToggle
+
+Source: [`src/components/ThemeToggle.tsx`](../src/components/ThemeToggle.tsx). Focused docs: [dark mode](./dark-mode.md).
+
+No external props. Reads `themeMode` from `SettingsContext` and writes the explicit opposite on click; never exposes a prop API.
+
+Accessibility: native `<button>` with `aria-label="Switch to {nextTheme} mode"` and `aria-pressed` reflecting whether the resolved theme is dark. Both icons are `aria-hidden`. Tracks the OS `prefers-color-scheme` media query while `themeMode` is `'system'` so `aria-pressed` and `aria-label` stay in sync with the document's `data-theme`.
+
+Tokens: `--credence-focus-ring`, spacing, and icon sizing via `ThemeToggle.css`.
+
+```tsx
+<ThemeToggle />
+```
+
+## KeyboardShortcutsDialog
+
+Source: [`src/components/KeyboardShortcutsDialog.tsx`](../src/components/KeyboardShortcutsDialog.tsx). Focused docs: [keyboard interactions](./keyboard-interactions.md).
+
+| Prop             | Type                              | Default     |
+| ---------------- | --------------------------------- | ----------- |
+| `open`           | `boolean`                         | Required    |
+| `onClose`        | `() => void`                      | Required    |
+| `returnFocusRef` | `React.RefObject<HTMLElement \| null>` | `undefined` |
+
+Accessibility: portal-rendered modal with `role="dialog"`, `aria-modal="true"`, and a generated `aria-labelledby`. Focus is trapped while open. Escape and backdrop click both call `onClose`. Focus is restored to `returnFocusRef` on close, or to the previously active element when `returnFocusRef` is omitted. Shortcuts are grouped by category with visible section headings.
+
+Tokens: border, surface, text, font, spacing, radius, and focus tokens via `KeyboardShortcutsDialog.css`.
+
+```tsx
+const triggerRef = useRef<HTMLButtonElement>(null)
+
+<button ref={triggerRef} onClick={() => setOpen(true)}>Keyboard shortcuts</button>
+<KeyboardShortcutsDialog open={open} onClose={() => setOpen(false)} returnFocusRef={triggerRef} />
+```
+
+## AttestationForm
+
+Source: [`src/components/AttestationForm.tsx`](../src/components/AttestationForm.tsx).
+
+| Prop              | Type                                                                   | Default     |
+| ----------------- | ---------------------------------------------------------------------- | ----------- |
+| `onSubmitSuccess` | `(payload: { subject: string; type: string; evidence: string }) => void` | `undefined` |
+| `disabled`        | `boolean`                                                              | `false`     |
+
+Accessibility: all form fields are wrapped in `FormField` so each has a `<label>`, hint, and error wired through `aria-describedby` and `aria-invalid`. The type selector uses `controls/Select` (native `<select>`). The evidence textarea has a live character counter associated via `aria-describedby`. Submission is confirmed via `ConfirmDialog` before calling `onSubmitSuccess`; success is announced via a toast.
+
+Tokens: inherits tokens from `AddressInput`, `Select`, `FormField`, and `Button`.
+
+```tsx
+<AttestationForm
+  onSubmitSuccess={({ subject, type, evidence }) => recordAttestation(subject, type, evidence)}
+/>
+```
+
+## CreateBondFlow
+
+Source: [`src/components/CreateBondFlow.tsx`](../src/components/CreateBondFlow.tsx).
+
+| Prop         | Type         | Default     |
+| ------------ | ------------ | ----------- |
+| `onComplete` | `() => void` | `undefined` |
+| `onCancel`   | `() => void` | `undefined` |
+
+A four-step wizard: **amount → duration → review → confirm**. Fetches the connected wallet's USDC balance and calculates early-withdrawal penalty in-flight. The final step uses `ConfirmDialog` for confirmation.
+
+Accessibility: each step manages focus on mount so keyboard users advance through the wizard without losing context. Reduced motion is respected via `useReducedMotion`. Success is announced via a toast; `onComplete` is called after the toast fires.
+
+Tokens: `CreateBondFlow.css` consumes border, radius, spacing, surface, text, font, and motion tokens.
+
+```tsx
+<CreateBondFlow onComplete={() => navigate('/bond')} onCancel={() => navigate('/bond')} />
+```
+
+## ErrorBoundary
+
+Source: [`src/components/ErrorBoundary.tsx`](../src/components/ErrorBoundary.tsx).
+
+| Prop       | Type                                         | Default                        |
+| ---------- | -------------------------------------------- | ------------------------------ |
+| `children` | `ReactNode`                                  | Required                       |
+| `fallback` | `(error: Error, reset: () => void) => ReactNode` | `undefined` (uses `ErrorState`) |
+
+Class component that catches render and lifecycle errors in its subtree. The default fallback renders a branded `ErrorState` with a "Retry" action (re-mounts the subtree without a full reload) and a "Go home" link. Supply `fallback` to override with custom error UI.
+
+Wire telemetry in `componentDidCatch` (currently logs to console) before shipping to production.
+
+Accessibility: no additional ARIA attributes; inherits accessibility from `ErrorState` or the custom `fallback` render.
+
+Tokens: none directly; delegates to `ErrorState`.
+
+```tsx
+<ErrorBoundary>
+  <BondPage />
+</ErrorBoundary>
+
+{/* Custom fallback */}
+<ErrorBoundary fallback={(err, reset) => <button onClick={reset}>Retry: {err.message}</button>}>
+  <TrustScorePage />
+</ErrorBoundary>
 ```

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -30,6 +30,7 @@ Related focused docs: [button system](./button-system.md), [notifications](./not
 | ActionCard             | Inline styles in `src/components/ActionCard.tsx`                                    | Owns all inline styles; migrate to a CSS file when a module is added.                                                    |
 | Disclaimer             | `src/components/Disclaimer.css`                                                     | None.                                                                                                                     |
 | ThemeToggle            | `src/components/ThemeToggle.css`                                                    | None.                                                                                                                     |
+| ConnectWalletModal     | `src/components/ConnectWalletModal.css`                                             | None.                                                                                                                     |
 | KeyboardShortcutsDialog | `src/components/KeyboardShortcutsDialog.css`                                       | None.                                                                                                                     |
 | AttestationForm        | Delegates to `AddressInput`, `Select`, `FormField`, `Button`                        | No dedicated CSS file; inherits from composing components.                                                                |
 | CreateBondFlow         | `src/components/CreateBondFlow.css`                                                 | None.                                                                                                                     |
@@ -476,6 +477,45 @@ Tokens: warning color tokens, spacing, radius.
   timeLeftSeconds={60}
   onStayLoggedIn={stay}
   onLogout={logout}
+/>
+```
+
+## ConnectWalletModal
+
+Source: [`src/components/ConnectWalletModal.tsx`](../src/components/ConnectWalletModal.tsx). Focused docs: [focus patterns](./focus-patterns.md).
+
+| Prop             | Type                                    | Default     |
+| ---------------- | --------------------------------------- | ----------- |
+| `open`           | `boolean`                               | Required    |
+| `onClose`        | `() => void`                            | Required    |
+| `returnFocusRef` | `React.RefObject<HTMLElement \| null>`  | `undefined` |
+
+Accessibility: portal-rendered modal with `role="dialog"`, `aria-modal="true"`, generated `aria-labelledby` and `aria-describedby`. Focus is trapped while open, with initial focus placed on the **Cancel** button (the safe/destructure-free action) so the first Tab press is deliberate. Escape and backdrop click both call `onClose`. Focus is restored to `returnFocusRef` on close, or to the previously active element when `returnFocusRef` is omitted. Trigger buttons that open the modal should carry `aria-haspopup="dialog"`.
+
+Tokens: `--credence-surface-card`, `--credence-border-default`, `--credence-radius-xl`, `--credence-text-primary/secondary`, `--credence-color-danger-*`, `--credence-space-*`, `--credence-font-size-*`, `--credence-motion-duration-*`, `--credence-motion-easing-decelerate`.
+
+Reduced motion: entrance animations (backdrop fade-in, panel slide-up) are disabled when `prefers-reduced-motion: reduce` is active.
+
+Error states: displays a `role="alert"` message for `not_installed` (Freighter extension missing), `rejected` (user declined in Freighter), or any generic error from `useWallet()`.
+
+```tsx
+const triggerRef = useRef<HTMLButtonElement>(null)
+
+<button
+  ref={triggerRef}
+  aria-haspopup="dialog"
+  onClick={(e) => {
+    connectTriggerRef.current = e.currentTarget
+    setConnectModalOpen(true)
+  }}
+>
+  Connect wallet
+</button>
+
+<ConnectWalletModal
+  open={connectModalOpen}
+  onClose={() => setConnectModalOpen(false)}
+  returnFocusRef={triggerRef}
 />
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,7 +34,7 @@ This directory contains comprehensive design specifications and implementation g
    ```
 
 4. **[Shared Components Catalog](./COMPONENTS.md)**
-   - Consolidated props, accessibility notes, usage snippets, styling ownership, and `--credence-*` token references for shared UI components
+   - Consolidated props, Storybook story paths and variants, accessibility notes, usage snippets, styling ownership, and `--credence-*` token references for all public shared UI components
    - Documents severity/variant vocabularies and cross-links focused component docs
 
 5. **[UI States Guide](./UI_STATES_GUIDE.md)**

--- a/src/components/ConnectWalletModal.css
+++ b/src/components/ConnectWalletModal.css
@@ -1,0 +1,142 @@
+/* ─── Backdrop ─────────────────────────────────────────────────────────────── */
+
+.connect-wallet-modal__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--credence-space-4);
+  background: rgba(15, 23, 42, 0.55);
+  animation: connect-wallet-fade-in var(--credence-motion-duration-fast)
+    var(--credence-motion-easing-decelerate);
+}
+
+[data-theme='dark'] .connect-wallet-modal__backdrop {
+  background: rgba(0, 0, 0, 0.65);
+}
+
+/* ─── Dialog panel ─────────────────────────────────────────────────────────── */
+
+.connect-wallet-modal {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 24rem;
+  border: 1px solid var(--credence-border-default);
+  border-radius: var(--credence-radius-xl);
+  background: var(--credence-surface-card);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.2);
+  color: var(--credence-text-primary);
+  animation: connect-wallet-slide-up var(--credence-motion-duration-base)
+    var(--credence-motion-easing-decelerate);
+}
+
+[data-theme='dark'] .connect-wallet-modal {
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
+}
+
+/* ─── Header ───────────────────────────────────────────────────────────────── */
+
+.connect-wallet-modal__header {
+  padding: var(--credence-space-5) var(--credence-space-5) var(--credence-space-4);
+  border-bottom: 1px solid var(--credence-border-default);
+}
+
+.connect-wallet-modal__title {
+  margin: 0;
+  font-size: var(--credence-font-size-lg);
+  font-weight: var(--credence-font-weight-bold);
+  line-height: var(--credence-line-height-tight);
+  color: var(--credence-text-primary);
+}
+
+/* ─── Body ─────────────────────────────────────────────────────────────────── */
+
+.connect-wallet-modal__body {
+  padding: var(--credence-space-5);
+  display: grid;
+  gap: var(--credence-space-4);
+}
+
+.connect-wallet-modal__description {
+  margin: 0;
+  font-size: var(--credence-font-size-sm);
+  line-height: var(--credence-line-height-base);
+  color: var(--credence-text-secondary);
+}
+
+.connect-wallet-modal__error {
+  padding: var(--credence-space-3) var(--credence-space-4);
+  border: 1px solid var(--credence-color-danger-border);
+  border-radius: var(--credence-radius-md);
+  background: var(--credence-color-danger-surface);
+  font-size: var(--credence-font-size-sm);
+  line-height: var(--credence-line-height-base);
+  color: var(--credence-color-danger-text);
+}
+
+/* ─── Footer ───────────────────────────────────────────────────────────────── */
+
+.connect-wallet-modal__footer {
+  display: flex;
+  gap: var(--credence-space-3);
+  padding: var(--credence-space-4) var(--credence-space-5) var(--credence-space-5);
+  border-top: 1px solid var(--credence-border-default);
+}
+
+.connect-wallet-modal__footer .credence-button {
+  flex: 1;
+}
+
+/* ─── Entrance animations ──────────────────────────────────────────────────── */
+
+@keyframes connect-wallet-fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes connect-wallet-slide-up {
+  from {
+    opacity: 0;
+    transform: translateY(var(--credence-space-4));
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* ─── Reduced motion ───────────────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .connect-wallet-modal__backdrop,
+  .connect-wallet-modal {
+    animation: none;
+  }
+}
+
+/* ─── Mobile: bottom sheet ─────────────────────────────────────────────────── */
+
+@media (max-width: 767px) {
+  .connect-wallet-modal__backdrop {
+    align-items: flex-end;
+    padding: 0;
+  }
+
+  .connect-wallet-modal {
+    max-width: none;
+    border-radius: var(--credence-radius-xl) var(--credence-radius-xl) 0 0;
+  }
+
+  .connect-wallet-modal__footer {
+    flex-direction: column-reverse;
+  }
+}

--- a/src/components/ConnectWalletModal.test.tsx
+++ b/src/components/ConnectWalletModal.test.tsx
@@ -1,0 +1,291 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createRef } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import ConnectWalletModal from './ConnectWalletModal'
+
+// ---------------------------------------------------------------------------
+// Wallet context mock — mutated per test
+// ---------------------------------------------------------------------------
+
+const mockConnect = vi.fn()
+let mockIsConnected = false
+let mockIsConnecting = false
+let mockError: { code: string; message: string } | null = null
+
+vi.mock('../context/WalletContext', () => ({
+  useWallet: () => ({
+    connect: mockConnect,
+    isConnected: mockIsConnected,
+    isConnecting: mockIsConnecting,
+    error: mockError,
+    disconnect: vi.fn(),
+    address: '',
+    network: null,
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderModal(
+  overrides: Partial<Parameters<typeof ConnectWalletModal>[0]> = {}
+) {
+  const onClose = vi.fn()
+  const props = { open: true, onClose, ...overrides }
+  const result = render(<ConnectWalletModal {...props} />)
+  return { ...result, onClose }
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  mockConnect.mockClear()
+  mockIsConnected = false
+  mockIsConnecting = false
+  mockError = null
+
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+    cb(0)
+    return 0
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  document.body.style.overflow = ''
+})
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+describe('ConnectWalletModal — rendering', () => {
+  it('renders nothing when open is false', () => {
+    renderModal({ open: false })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders the dialog when open is true', () => {
+    renderModal()
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('has aria-modal="true"', () => {
+    renderModal()
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true')
+  })
+
+  it('has an accessible title via aria-labelledby', () => {
+    renderModal()
+    const dialog = screen.getByRole('dialog')
+    const labelId = dialog.getAttribute('aria-labelledby')
+    expect(labelId).toBeTruthy()
+    const titleEl = document.getElementById(labelId!)
+    expect(titleEl).toHaveTextContent('Connect Freighter Wallet')
+  })
+
+  it('has an accessible description via aria-describedby', () => {
+    renderModal()
+    const dialog = screen.getByRole('dialog')
+    const descId = dialog.getAttribute('aria-describedby')
+    expect(descId).toBeTruthy()
+    const descEl = document.getElementById(descId!)
+    expect(descEl).toHaveTextContent(/Freighter/i)
+  })
+
+  it('renders Cancel and Connect buttons', () => {
+    renderModal()
+    expect(screen.getByRole('button', { name: /^cancel$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^connect$/i })).toBeInTheDocument()
+  })
+
+  it('does not render an error alert by default', () => {
+    renderModal()
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Error states
+// ---------------------------------------------------------------------------
+
+describe('ConnectWalletModal — error display', () => {
+  it('renders a not-installed error message', () => {
+    mockError = { code: 'not_installed', message: 'Not installed' }
+    renderModal()
+    expect(screen.getByRole('alert')).toHaveTextContent(/Freighter is not installed/i)
+  })
+
+  it('renders a rejected error message', () => {
+    mockError = { code: 'rejected', message: 'User declined' }
+    renderModal()
+    expect(screen.getByRole('alert')).toHaveTextContent(/declined/i)
+  })
+
+  it('falls back to error.message for unknown error codes', () => {
+    mockError = { code: 'unknown', message: 'Something went wrong' }
+    renderModal()
+    expect(screen.getByRole('alert')).toHaveTextContent('Something went wrong')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Connecting state
+// ---------------------------------------------------------------------------
+
+describe('ConnectWalletModal — connecting state', () => {
+  it('disables Cancel while connecting', () => {
+    mockIsConnecting = true
+    renderModal()
+    expect(screen.getByRole('button', { name: /^cancel$/i })).toBeDisabled()
+  })
+
+  it('shows loading state on Connect button while connecting', () => {
+    mockIsConnecting = true
+    renderModal()
+    const connectBtn = screen.getByRole('button', { name: /^connect$/i })
+    expect(connectBtn).toHaveAttribute('aria-busy', 'true')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Closing
+// ---------------------------------------------------------------------------
+
+describe('ConnectWalletModal — closing', () => {
+  it('calls onClose when Cancel is clicked', async () => {
+    const user = userEvent.setup()
+    const { onClose } = renderModal()
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when the backdrop is clicked', async () => {
+    const user = userEvent.setup()
+    const { onClose } = renderModal()
+    const backdrop = screen.getByRole('dialog').parentElement!
+    await user.click(backdrop)
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when Escape is pressed', async () => {
+    const user = userEvent.setup()
+    const { onClose } = renderModal()
+    await user.keyboard('{Escape}')
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('does NOT call onClose when clicking inside the dialog panel', async () => {
+    const user = userEvent.setup()
+    const { onClose } = renderModal()
+    await user.click(screen.getByRole('dialog'))
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Connect action
+// ---------------------------------------------------------------------------
+
+describe('ConnectWalletModal — connect action', () => {
+  it('calls connect() when Connect button is clicked', async () => {
+    const user = userEvent.setup()
+    renderModal()
+    await user.click(screen.getByRole('button', { name: /^connect$/i }))
+    expect(mockConnect).toHaveBeenCalledOnce()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Auto-close on wallet connect
+// ---------------------------------------------------------------------------
+
+describe('ConnectWalletModal — auto-close on wallet connect', () => {
+  it('calls onClose when isConnected becomes true while open', () => {
+    const onClose = vi.fn()
+    mockIsConnected = false
+    const { rerender } = render(<ConnectWalletModal open={true} onClose={onClose} />)
+
+    expect(onClose).not.toHaveBeenCalled()
+
+    mockIsConnected = true
+    rerender(<ConnectWalletModal open={true} onClose={onClose} />)
+
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('does NOT call onClose when already closed', () => {
+    const onClose = vi.fn()
+    mockIsConnected = true
+    render(<ConnectWalletModal open={false} onClose={onClose} />)
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Body scroll lock
+// ---------------------------------------------------------------------------
+
+describe('ConnectWalletModal — body scroll lock', () => {
+  it('sets overflow to hidden when open', () => {
+    renderModal({ open: true })
+    expect(document.body.style.overflow).toBe('hidden')
+  })
+
+  it('restores overflow on unmount', () => {
+    document.body.style.overflow = 'auto'
+    const { unmount } = renderModal({ open: true })
+    expect(document.body.style.overflow).toBe('hidden')
+    unmount()
+    expect(document.body.style.overflow).toBe('auto')
+  })
+
+  it('does not lock scroll when open is false', () => {
+    renderModal({ open: false })
+    expect(document.body.style.overflow).toBe('')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Focus management
+// ---------------------------------------------------------------------------
+
+describe('ConnectWalletModal — focus management', () => {
+  it('initially focuses the Cancel button when opened', () => {
+    renderModal()
+    expect(document.activeElement).toBe(
+      screen.getByRole('button', { name: /^cancel$/i })
+    )
+  })
+
+  it('returns focus to returnFocusRef element on close', () => {
+    const triggerEl = document.createElement('button')
+    triggerEl.type = 'button'
+    Object.defineProperty(triggerEl, 'offsetParent', {
+      get: () => document.body,
+      configurable: true,
+    })
+    document.body.appendChild(triggerEl)
+    triggerEl.focus()
+
+    const returnFocusRef = createRef<HTMLButtonElement>()
+    ;(returnFocusRef as React.MutableRefObject<HTMLButtonElement>).current = triggerEl
+
+    const onClose = vi.fn()
+    const { rerender } = render(
+      <ConnectWalletModal open={true} onClose={onClose} returnFocusRef={returnFocusRef} />
+    )
+
+    rerender(
+      <ConnectWalletModal open={false} onClose={onClose} returnFocusRef={returnFocusRef} />
+    )
+
+    expect(document.activeElement).toBe(triggerEl)
+    document.body.removeChild(triggerEl)
+  })
+})
+

--- a/src/components/ConnectWalletModal.tsx
+++ b/src/components/ConnectWalletModal.tsx
@@ -1,0 +1,147 @@
+import { useCallback, useEffect, useId, useRef } from 'react'
+import { createPortal } from 'react-dom'
+import { useFocusTrap } from '../hooks/useFocusTrap'
+import { useWallet } from '../context/WalletContext'
+import Button from './Button'
+import './ConnectWalletModal.css'
+
+export interface ConnectWalletModalProps {
+  open: boolean
+  onClose: () => void
+  /**
+   * Element to return focus to when the modal closes.
+   * When omitted, focus returns to the element that was active before the modal opened.
+   */
+  returnFocusRef?: React.RefObject<HTMLElement | null>
+}
+
+/**
+ * Modal dialog that explains the wallet connection step and surfaces
+ * connection status (connecting, error) without losing the user's focus context.
+ *
+ * - Portal-rendered into document.body.
+ * - Focus is trapped inside while open; returned to returnFocusRef on close.
+ * - Escape and backdrop click close the modal.
+ * - Body scroll is locked while open.
+ * - Entrance animation is suppressed when prefers-reduced-motion: reduce is set.
+ * - Auto-closes when the wallet connects successfully.
+ */
+export default function ConnectWalletModal({
+  open,
+  onClose,
+  returnFocusRef,
+}: ConnectWalletModalProps) {
+  const { connect, isConnecting, error, isConnected } = useWallet()
+
+  const titleId = useId()
+  const descId = useId()
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const cancelRef = useRef<HTMLButtonElement>(null)
+
+  // Auto-close when wallet connects successfully
+  useEffect(() => {
+    if (isConnected && open) {
+      onClose()
+    }
+  }, [isConnected, open, onClose])
+
+  useFocusTrap({
+    containerRef: dialogRef,
+    isActive: open,
+    initialFocusRef: cancelRef,
+    returnFocusRef,
+    onEscape: onClose,
+  })
+
+  // Lock body scroll while open
+  useEffect(() => {
+    if (!open) return
+    const previous = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = previous
+    }
+  }, [open])
+
+  const handleBackdropClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) {
+      onClose()
+    }
+  }
+
+  const handleConnect = useCallback(() => {
+    void connect()
+  }, [connect])
+
+  if (!open) return null
+
+  let errorMessage: string | null = null
+  if (error) {
+    if (error.code === 'not_installed') {
+      errorMessage =
+        'Freighter is not installed. Add the Freighter extension to your browser and try again.'
+    } else if (error.code === 'rejected') {
+      errorMessage = 'Connection request was declined in Freighter. Click Connect to try again.'
+    } else {
+      errorMessage = error.message
+    }
+  }
+
+  return createPortal(
+    <div
+      className="connect-wallet-modal__backdrop"
+      onClick={handleBackdropClick}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descId}
+        className="connect-wallet-modal"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="connect-wallet-modal__header">
+          <h2 id={titleId} className="connect-wallet-modal__title">
+            Connect Freighter Wallet
+          </h2>
+        </header>
+
+        <div className="connect-wallet-modal__body">
+          <p id={descId} className="connect-wallet-modal__description">
+            Freighter is a Stellar wallet browser extension. Clicking{' '}
+            <strong>Connect</strong> will open the Freighter extension and ask
+            you to approve access for this session.
+          </p>
+
+          {errorMessage && (
+            <div role="alert" className="connect-wallet-modal__error">
+              {errorMessage}
+            </div>
+          )}
+        </div>
+
+        <footer className="connect-wallet-modal__footer">
+          <Button
+            ref={cancelRef}
+            type="button"
+            variant="secondary"
+            onClick={onClose}
+            disabled={isConnecting}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="primary"
+            onClick={handleConnect}
+            isLoading={isConnecting}
+          >
+            Connect
+          </Button>
+        </footer>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/src/pages/Bond.tsx
+++ b/src/pages/Bond.tsx
@@ -10,6 +10,7 @@ import Button from '../components/Button'
 import EmptyState from '../components/states/EmptyState'
 import AmountInput from '../components/AmountInput'
 import { FormField } from '../components/forms/FormField'
+import ConnectWalletModal from '../components/ConnectWalletModal'
 import { useSettings } from '../context/SettingsContext'
 import { useWallet } from '../context/WalletContext'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
@@ -47,7 +48,7 @@ interface BondRowProps {
   bond: MockBond
   isConnected: boolean
   onWithdraw: (bond: MockBond, event: React.MouseEvent<HTMLButtonElement>) => void
-  onConnect: () => void
+  onConnect: (event: React.MouseEvent<HTMLButtonElement>) => void
 }
 
 function BondRow({ bond, isConnected, onWithdraw, onConnect }: BondRowProps) {
@@ -80,7 +81,7 @@ function BondRow({ bond, isConnected, onWithdraw, onConnect }: BondRowProps) {
             type="button"
             variant={hasPenalty ? 'danger' : 'secondary'}
             onClick={isConnected ? (event) => onWithdraw(bond, event) : onConnect}
-            aria-haspopup={isConnected ? 'dialog' : undefined}
+            aria-haspopup="dialog"
           >
             {isConnected ? 'Withdraw' : 'Connect wallet to withdraw'}
           </Button>
@@ -123,11 +124,13 @@ export default function Bond() {
 
   const navigate = useNavigate()
   const { addToast } = useToast()
-  const { isConnected, connect, network: walletNetwork } = useWallet()
+  const { isConnected, network: walletNetwork } = useWallet()
   const { setNetwork } = useSettings()
   const networkMismatch = useNetworkMismatch()
   const [withdrawTarget, setWithdrawTarget] = useState<MockBond | null>(null)
   const withdrawTriggerRef = useRef<HTMLElement | null>(null)
+  const [connectModalOpen, setConnectModalOpen] = useState(false)
+  const connectTriggerRef = useRef<HTMLElement | null>(null)
   const mismatchBannerId = 'bond-network-mismatch'
 
   const [bondAmount, setBondAmount] = useState('')
@@ -135,13 +138,22 @@ export default function Bond() {
 
   const bonds = initialBonds
 
-  const handleCreateBond = useCallback(() => {
-    if (!isConnected) {
-      connect()
-      return
-    }
-    navigate('/bond/new')
-  }, [isConnected, connect, navigate])
+  const openConnectModal = useCallback((event: React.MouseEvent<HTMLElement>) => {
+    connectTriggerRef.current = event.currentTarget
+    setConnectModalOpen(true)
+  }, [])
+
+  const handleCreateBond = useCallback(
+    (event?: React.MouseEvent<HTMLElement>) => {
+      if (!isConnected) {
+        if (event) openConnectModal(event)
+        else setConnectModalOpen(true)
+        return
+      }
+      navigate('/bond/new')
+    },
+    [isConnected, openConnectModal, navigate]
+  )
 
   const withdrawBreakdown = useMemo(
     () => (withdrawTarget ? computeWithdrawBreakdown(withdrawTarget) : null),
@@ -150,15 +162,10 @@ export default function Bond() {
 
   const requestWithdraw = useCallback(
     (bond: MockBond, event: React.MouseEvent<HTMLButtonElement>) => {
-      if (!isConnected) {
-        connect()
-        return
-      }
-
       withdrawTriggerRef.current = event.currentTarget
       setWithdrawTarget(bond)
     },
-    [isConnected, connect]
+    []
   )
 
   const cancelWithdraw = useCallback(() => {
@@ -206,7 +213,7 @@ export default function Bond() {
         <Banner
           severity="warning"
           title="Connect wallet required"
-          action={{ label: 'Connect wallet', onClick: connect }}
+          action={{ label: 'Connect wallet', onClick: () => setConnectModalOpen(true) }}
         >
           Create bond and withdraw actions require a connected Stellar wallet.
         </Banner>
@@ -269,10 +276,11 @@ export default function Bond() {
 
           <Button
             type="button"
-            onClick={handleCreateBond}
+            onClick={(e) => handleCreateBond(e)}
             fullWidth
             disabled={networkMismatch.mismatch}
             aria-describedby={networkMismatch.mismatch ? mismatchBannerId : undefined}
+            aria-haspopup={!isConnected ? 'dialog' : undefined}
           >
             {isConnected ? 'Create bond' : 'Connect wallet to continue'}
           </Button>
@@ -297,7 +305,7 @@ export default function Bond() {
                   bond={bond}
                   isConnected={isConnected}
                   onWithdraw={requestWithdraw}
-                  onConnect={connect}
+                  onConnect={openConnectModal}
                 />
               ))}
             </ul>
@@ -318,6 +326,12 @@ export default function Bond() {
           />
         </Suspense>
       )}
+
+      <ConnectWalletModal
+        open={connectModalOpen}
+        onClose={() => setConnectModalOpen(false)}
+        returnFocusRef={connectTriggerRef}
+      />
 
       <Disclaimer
         context="Bonding USDC locks funds in a non-custodial smart contract. Slashing conditions apply."

--- a/src/pages/BondDetail.test.tsx
+++ b/src/pages/BondDetail.test.tsx
@@ -27,6 +27,26 @@ vi.mock('../context/WalletContext', () => ({
   }),
 }))
 
+vi.mock('../components/ConnectWalletModal', () => ({
+  __esModule: true,
+  default: ({
+    open,
+    onClose,
+  }: {
+    open: boolean
+    onClose: () => void
+  }) => {
+    if (!open) return null
+    return (
+      <div role="dialog" aria-label="Connect Freighter Wallet">
+        <h2>Connect Freighter Wallet</h2>
+        <button onClick={onClose}>Cancel</button>
+        <button>Connect</button>
+      </div>
+    )
+  },
+}))
+
 vi.mock('../components/ConfirmDialog', () => ({
   __esModule: true,
   default: ({ open, title, onConfirm, onCancel }: { open: boolean; title: string; onConfirm: () => void; onCancel: () => void }) => {
@@ -169,7 +189,7 @@ describe('BondDetail Page', () => {
     expect(screen.getByRole('heading', { name: /Confirm bond withdrawal/i })).toBeInTheDocument()
   })
 
-  it('calls connect when withdraw button is clicked while disconnected', () => {
+  it('opens the ConnectWalletModal when withdraw is clicked while disconnected', () => {
     mockConnected = false
 
     render(
@@ -181,8 +201,8 @@ describe('BondDetail Page', () => {
     const withdrawBtn = screen.getByRole('button', { name: /connect wallet to withdraw/i })
     fireEvent.click(withdrawBtn)
 
-    expect(mockConnect).toHaveBeenCalledTimes(1)
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+    expect(mockConnect).not.toHaveBeenCalled()
+    expect(screen.getByRole('dialog', { name: /connect freighter wallet/i })).toBeInTheDocument()
   })
 
   it('confirm dialog allows cancellation', () => {

--- a/src/pages/BondDetail.tsx
+++ b/src/pages/BondDetail.tsx
@@ -9,6 +9,7 @@ import { useWallet } from '../context/WalletContext'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { formatUsdc } from '../lib/format'
 import ConfirmDialog from '../components/ConfirmDialog'
+import ConnectWalletModal from '../components/ConnectWalletModal'
 import {
   computeWithdrawBreakdown,
   calcUnlockDate,
@@ -26,8 +27,10 @@ export default function BondDetail() {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
   const { addToast } = useToast()
-  const { isConnected, connect } = useWallet()
+  const { isConnected } = useWallet()
   const withdrawTriggerRef = useRef<HTMLButtonElement | null>(null)
+  const [connectModalOpen, setConnectModalOpen] = useState(false)
+  const connectTriggerRef = useRef<HTMLButtonElement | null>(null)
 
   const bondId = Number(id)
   useDocumentTitle(`Bond #${bondId || 'Detail'}`)
@@ -81,7 +84,8 @@ export default function BondDetail() {
 
   const handleWithdrawClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     if (!isConnected) {
-      connect()
+      connectTriggerRef.current = event.currentTarget
+      setConnectModalOpen(true)
       return
     }
     withdrawTriggerRef.current = event.currentTarget
@@ -117,7 +121,7 @@ export default function BondDetail() {
         <Banner
           severity="warning"
           title="Connect wallet required"
-          action={{ label: 'Connect wallet', onClick: connect }}
+          action={{ label: 'Connect wallet', onClick: () => setConnectModalOpen(true) }}
         >
           Withdrawal and lock extensions require a connected Stellar wallet.
         </Banner>
@@ -177,8 +181,8 @@ export default function BondDetail() {
                 ref={withdrawTriggerRef}
                 type="button"
                 variant={breakdown.penaltyUsdc > 0 ? 'danger' : 'primary'}
-                onClick={isConnected ? handleWithdrawClick : connect}
-                aria-haspopup={isConnected ? 'dialog' : undefined}
+                onClick={handleWithdrawClick}
+                aria-haspopup="dialog"
               >
                 {isConnected ? 'Withdraw' : 'Connect wallet to withdraw'}
               </Button>
@@ -221,6 +225,12 @@ export default function BondDetail() {
           returnFocusRef={withdrawTriggerRef}
         />
       )}
+
+      <ConnectWalletModal
+        open={connectModalOpen}
+        onClose={() => setConnectModalOpen(false)}
+        returnFocusRef={connectTriggerRef}
+      />
     </main>
   )
 }


### PR DESCRIPTION
## Summary

- Create `ConnectWalletModal` — a portal-rendered dialog with `useFocusTrap` (Tab/Shift+Tab wrapping, Escape, initial focus on Cancel, return focus to trigger on close), body scroll lock, and entrance animations disabled under `prefers-reduced-motion: reduce`
- Wire the modal into `Bond.tsx` and `BondDetail.tsx`, replacing all bare `connect()` calls so every wallet-connection entry point is announced as `role="dialog"` with `aria-modal="true"`
- Trigger buttons carry `aria-haspopup="dialog"`; `returnFocusRef` restores focus to the exact trigger element that opened the modal
- Add 24-test suite covering rendering, error states (not_installed, rejected, generic), connecting state, all close paths (Cancel, backdrop, Escape), auto-close on wallet connect, body scroll lock, and focus restoration

## Test plan

- [ ] `node_modules/.bin/vitest run src/components/ConnectWalletModal.test.tsx` — 24 passed
- [ ] `node_modules/.bin/vitest run src/pages/BondDetail.test.tsx` — 10 passed
- [ ] No new TypeScript errors in `ConnectWalletModal.tsx`, `Bond.tsx`, or `BondDetail.tsx`
- [ ] Open Bond page disconnected → click "Connect wallet to continue" → modal appears, Cancel returns focus to button
- [ ] Open BondDetail disconnected → click "Connect wallet to withdraw" → modal appears, Cancel returns focus to button
- [ ] OS `prefers-reduced-motion: reduce` suppresses backdrop fade-in and panel slide-up animations

Closes #378