### PR TITLE
fix: add visible focus ring with sufficient contrast on all interacti…

### DIFF
--- a/src/components/AddressInput.css
+++ b/src/components/AddressInput.css
@@ -69,7 +69,11 @@
   font-weight: var(--credence-font-weight-regular);
   line-height: var(--credence-line-height-base);
   padding: 0;
-  outline: none;
+}
+
+.address-input-field:focus-visible {
+  outline: var(--credence-focus-ring);
+  outline-offset: 2px;
 }
 
 .address-input-field::placeholder {

--- a/src/components/ConfirmDialog.css
+++ b/src/components/ConfirmDialog.css
@@ -139,7 +139,7 @@
 }
 
 .confirm-dialog__confirm-field input:focus-visible {
-  outline: 2px solid var(--credence-color-danger-border);
+  outline: var(--credence-focus-ring);
   outline-offset: 2px;
 }
 

--- a/src/pages/NotFound.css
+++ b/src/pages/NotFound.css
@@ -66,5 +66,4 @@
 .not-found-link:hover,
 .not-found-link:focus-visible {
   text-decoration: underline;
-  outline: none;
 }


### PR DESCRIPTION
# Closes #390

## Summary

Ensure every interactive element in the app displays a 2px visible focus ring (`var(--credence-focus-ring)`) with ≥3:1 contrast in both light and dark themes.

## What changed

| File | Change |
|---|---|
| `src/pages/NotFound.css` | Removed `outline: none` on `.not-found-link:focus-visible` — the `<a>` link now inherits the global `:focus-visible` rule. |
| `src/components/AddressInput.css` | Removed `outline: none` on `.address-input-field` and added explicit `:focus-visible` rule using `var(--credence-focus-ring)`. The JS-driven container border/box-shadow remains as an enhancement. |
| `src/components/ConfirmDialog.css` | Unified the danger-variant input focus ring from `2px solid var(--credence-color-danger-border)` to `var(--credence-focus-ring)`, matching the info variant and all other components. |

## Key design decisions

- All focus rings now resolve through `--credence-focus-ring` (`2px solid var(--credence-color-primary)`) — the single design token for focus indicators.
- No new dependencies, no JS changes, no component prop additions.
- The `AddressInput` container-level focus styling (border + box-shadow) is retained as a visual enhancement; the native outline is the guaranteed fallback and meets 3:1 contrast.

## Acceptance criteria checklist

- [x] Focus ring is `2px` outline using `var(--credence-focus-ring)`
- [x] Contrast ≥3:1 in light mode (#0284c7 on #f8fafc ≈ 3.6:1) and dark mode (#38bdf8 on #0f172a ≈ 8.7:1)
- [x] Every keyboard-reachable interactive element now has a visible focus indicator
- [x] Only CSS changes — no behavioral/ARIA regressions
- [x] Lint: 0 errors introduced (10 pre-existing in unrelated files)
- [x] Build: 0 errors introduced (pre-existing failures in unrelated files)
- [x] Tests: 0 failures introduced (108 pre-existing in unrelated files)

## Test output

```
Tests unchanged from main — 777 passed, 108 pre-existing failures (unrelated to this change).
```

## Follow-ups

- The pre-existing build and test failures in `RouteAnnouncer.test.tsx`, `TrustGauge.tsx`, `ToastProvider.test.tsx`, `Bond.tsx`, `App.tsx`, and `TrustScore.tsx` are outside scope.

## Security note

CSS-only change. No user input, no data flow, no server-side logic touched.


