### PR TITLE
feat: add back-to-top affordance on long lists

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -25,6 +25,7 @@ Related focused docs: [button system](./button-system.md), [notifications](./not
 | states/ErrorState      | Inline styles in `src/components/states/ErrorState.tsx`                             | Owns inline styles and should be migrated to CSS.                                                                         |
 | states/LoadingSkeleton | Inline styles in `src/components/states/LoadingSkeleton.tsx`                        | Owns inline styles and should be migrated to CSS.                                                                         |
 | SessionTimeoutModal    | Inline styles in `src/components/SessionTimeoutModal.tsx`                           | Uses `ConfirmDialog` primitive with internal warning styles.                                                              |
+| BackToTop              | `src/components/BackToTop.css`                                                      | None.                                                                                                                     |
 
 ## Shared vocabularies
 
@@ -449,4 +450,23 @@ Tokens: warning color tokens, spacing, radius.
   onStayLoggedIn={stay}
   onLogout={logout}
 />
+```
+
+## BackToTop
+
+Source: [`src/components/BackToTop.tsx`](../src/components/BackToTop.tsx).
+
+A fixed-position "Back to top" button that appears after the user scrolls more than 800 px. Clicking it smooth-scrolls the page to the top and moves keyboard focus to the first `<h1>` inside `#main-content`. Respects `prefers-reduced-motion` by falling back to an instant scroll.
+
+No props — the component is self-contained and driven by `useScrollToTop`.
+
+Accessibility: native `<button>` with `aria-label="Back to top"`, visible focus ring, and focus management. On mobile (≤ 639 px) the text label is hidden and only the arrow icon is shown; the `aria-label` keeps it usable for screen readers.
+
+Tokens: `--credence-color-primary`, `--credence-color-primary-strong`, `--credence-color-white`, `--credence-focus-ring`, `--credence-font-family-base`, `--credence-font-size-sm`, `--credence-font-weight-semibold`, `--credence-line-height-tight`, `--credence-motion-duration-fast`, `--credence-motion-easing-standard`, `--credence-radius-full`, `--credence-shadow-toast`, `--credence-space-2`, `--credence-space-3`, `--credence-space-4`, `--credence-space-6`, `--credence-space-8`.
+
+Constant: `BACK_TO_TOP_SCROLL_THRESHOLD = 800` (px) — exported from `src/hooks/useScrollToTop.ts`.
+
+```tsx
+// Rendered automatically by Layout — no manual usage needed.
+<BackToTop />
 ```

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -24,6 +24,7 @@ behavior notes, and a minimal usage example linking to source.
   - [`useFocusTrap`](#usefocustrap)
   - [`useDocumentTitle`](#usedocumenttitle)
   - [`useReducedMotion`](#usereducedmotion)
+  - [`useScrollToTop`](#usescrolltotop)
   - [`useTrustScore`](#usetrustscore)
   - [`useUsdcBalance`](#useusdcbalance)
   - [`useWallet`](#usewallet)
@@ -178,6 +179,31 @@ import { useReducedMotion } from '../hooks/useReducedMotion'
 function Banner() {
   const reduceMotion = useReducedMotion()
   return <div className={reduceMotion ? 'no-anim' : 'slide-in'}>…</div>
+}
+```
+
+---
+
+### `useScrollToTop`
+
+Source: [`src/hooks/useScrollToTop.ts`](../src/hooks/useScrollToTop.ts)
+
+```ts
+function useScrollToTop(): boolean
+```
+
+Returns `true` when the page has been scrolled more than `BACK_TO_TOP_SCROLL_THRESHOLD` (800 px) from the top, and `false` otherwise. Used by [`BackToTop`](../src/components/BackToTop.tsx) to decide when to render the affordance.
+
+**Exported constant:** `BACK_TO_TOP_SCROLL_THRESHOLD = 800` — the pixel threshold at which the button becomes visible.
+
+**Cleanup:** removes the passive `scroll` listener on unmount.
+
+```tsx
+import { useScrollToTop } from '../hooks/useScrollToTop'
+
+function MyComponent() {
+  const showButton = useScrollToTop()
+  return showButton ? <button>↑</button> : null
 }
 ```
 

--- a/src/components/BackToTop.css
+++ b/src/components/BackToTop.css
@@ -1,0 +1,54 @@
+.back-to-top {
+  position: fixed;
+  bottom: var(--credence-space-8);
+  right: var(--credence-space-8);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--credence-space-2);
+  padding: var(--credence-space-3) var(--credence-space-4);
+  background: var(--credence-color-primary);
+  color: var(--credence-color-white);
+  border: none;
+  border-radius: var(--credence-radius-full);
+  font-family: var(--credence-font-family-base);
+  font-size: var(--credence-font-size-sm);
+  font-weight: var(--credence-font-weight-semibold);
+  line-height: var(--credence-line-height-tight);
+  cursor: pointer;
+  z-index: 50;
+  box-shadow: var(--credence-shadow-toast);
+  transition:
+    background var(--credence-motion-duration-fast) var(--credence-motion-easing-standard),
+    transform var(--credence-motion-duration-fast) var(--credence-motion-easing-standard);
+}
+
+.back-to-top:hover {
+  background: var(--credence-color-primary-strong);
+}
+
+.back-to-top:active {
+  transform: translateY(1px);
+}
+
+.back-to-top:focus-visible {
+  outline: var(--credence-focus-ring);
+  outline-offset: 2px;
+}
+
+.back-to-top__icon {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+}
+
+@media (max-width: 639px) {
+  .back-to-top {
+    bottom: var(--credence-space-6);
+    right: var(--credence-space-4);
+    padding: var(--credence-space-3);
+  }
+
+  .back-to-top__label {
+    display: none;
+  }
+}

--- a/src/components/BackToTop.test.tsx
+++ b/src/components/BackToTop.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import BackToTop from './BackToTop'
+import * as useScrollToTopModule from '../hooks/useScrollToTop'
+import * as useReducedMotionModule from '../hooks/useReducedMotion'
+
+vi.mock('../hooks/useScrollToTop', () => ({
+  useScrollToTop: vi.fn(),
+  BACK_TO_TOP_SCROLL_THRESHOLD: 800,
+}))
+
+vi.mock('../hooks/useReducedMotion', () => ({
+  useReducedMotion: vi.fn(),
+}))
+
+function setVisible(value: boolean) {
+  vi.mocked(useScrollToTopModule.useScrollToTop).mockReturnValue(value)
+}
+
+function setReducedMotion(value: boolean) {
+  vi.mocked(useReducedMotionModule.useReducedMotion).mockReturnValue(value)
+}
+
+describe('BackToTop', () => {
+  beforeEach(() => {
+    setVisible(false)
+    setReducedMotion(false)
+    vi.spyOn(window, 'scrollTo').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  it('is not rendered when scroll is below threshold', () => {
+    setVisible(false)
+    render(<BackToTop />)
+    expect(screen.queryByRole('button', { name: /back to top/i })).not.toBeInTheDocument()
+  })
+
+  it('renders the button when scroll exceeds threshold', () => {
+    setVisible(true)
+    render(<BackToTop />)
+    expect(screen.getByRole('button', { name: /back to top/i })).toBeInTheDocument()
+  })
+
+  it('calls window.scrollTo with smooth behavior on click', () => {
+    setVisible(true)
+    render(<BackToTop />)
+
+    fireEvent.click(screen.getByRole('button', { name: /back to top/i }))
+
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' })
+  })
+
+  it('calls window.scrollTo with auto behavior when reduced motion is preferred', () => {
+    setVisible(true)
+    setReducedMotion(true)
+    render(<BackToTop />)
+
+    fireEvent.click(screen.getByRole('button', { name: /back to top/i }))
+
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'auto' })
+  })
+
+  it('focuses the h1 inside #main-content after click', () => {
+    setVisible(true)
+
+    const main = document.createElement('main')
+    main.id = 'main-content'
+    const heading = document.createElement('h1')
+    heading.textContent = 'Page Title'
+    main.appendChild(heading)
+    document.body.appendChild(main)
+
+    render(<BackToTop />)
+    const focusSpy = vi.spyOn(heading, 'focus')
+
+    fireEvent.click(screen.getByRole('button', { name: /back to top/i }))
+
+    expect(heading.getAttribute('tabindex')).toBe('-1')
+    expect(focusSpy).toHaveBeenCalledWith({ preventScroll: true })
+  })
+
+  it('does not overwrite tabindex if heading already has one', () => {
+    setVisible(true)
+
+    const main = document.createElement('main')
+    main.id = 'main-content'
+    const heading = document.createElement('h1')
+    heading.setAttribute('tabindex', '0')
+    main.appendChild(heading)
+    document.body.appendChild(main)
+
+    render(<BackToTop />)
+
+    fireEvent.click(screen.getByRole('button', { name: /back to top/i }))
+
+    expect(heading.getAttribute('tabindex')).toBe('0')
+  })
+
+  it('does not throw when there is no h1 in #main-content', () => {
+    setVisible(true)
+    render(<BackToTop />)
+    expect(() =>
+      fireEvent.click(screen.getByRole('button', { name: /back to top/i }))
+    ).not.toThrow()
+  })
+})

--- a/src/components/BackToTop.tsx
+++ b/src/components/BackToTop.tsx
@@ -1,0 +1,49 @@
+import { useScrollToTop } from '../hooks/useScrollToTop'
+import { useReducedMotion } from '../hooks/useReducedMotion'
+import './BackToTop.css'
+
+export default function BackToTop() {
+  const visible = useScrollToTop()
+  const reducedMotion = useReducedMotion()
+
+  if (!visible) return null
+
+  const handleClick = () => {
+    window.scrollTo({ top: 0, behavior: reducedMotion ? 'auto' : 'smooth' })
+
+    const main = document.getElementById('main-content')
+    const heading = main?.querySelector<HTMLElement>('h1')
+    if (heading) {
+      if (!heading.hasAttribute('tabindex')) {
+        heading.setAttribute('tabindex', '-1')
+      }
+      heading.focus({ preventScroll: true })
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      className="back-to-top"
+      aria-label="Back to top"
+      onClick={handleClick}
+    >
+      <svg
+        className="back-to-top__icon"
+        aria-hidden="true"
+        viewBox="0 0 24 24"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M12 4L4 12M12 4L20 12M12 4V20"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+      <span className="back-to-top__label">Back to top</span>
+    </button>
+  )
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -4,6 +4,7 @@ import ThemeToggle from './ThemeToggle'
 import MobileNav from './navigation/MobileNav'
 import RouteAnnouncer from './RouteAnnouncer'
 import KeyboardShortcutsDialog from './KeyboardShortcutsDialog'
+import BackToTop from './BackToTop'
 import LINKS from '../config/links'
 import './Layout.css'
 
@@ -125,6 +126,8 @@ export default function Layout() {
         onClose={closeShortcuts}
         returnFocusRef={shortcutsButtonRef}
       />
+
+      <BackToTop />
     </div>
   )
 }

--- a/src/hooks/useScrollToTop.test.ts
+++ b/src/hooks/useScrollToTop.test.ts
@@ -1,0 +1,97 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
+import { useScrollToTop, BACK_TO_TOP_SCROLL_THRESHOLD } from './useScrollToTop'
+
+function setScrollY(value: number) {
+  Object.defineProperty(window, 'scrollY', { value, configurable: true, writable: true })
+}
+
+describe('useScrollToTop', () => {
+  let capturedHandler: (() => void) | null = null
+  const originalAddEventListener = window.addEventListener.bind(window)
+  const originalRemoveEventListener = window.removeEventListener.bind(window)
+
+  beforeEach(() => {
+    capturedHandler = null
+    setScrollY(0)
+
+    vi.spyOn(window, 'addEventListener').mockImplementation((type, handler, options) => {
+      if (type === 'scroll') {
+        capturedHandler = handler as () => void
+      }
+      return originalAddEventListener(type, handler as EventListenerOrEventListenerObject, options)
+    })
+
+    vi.spyOn(window, 'removeEventListener').mockImplementation((type, handler, options) => {
+      if (type === 'scroll') {
+        capturedHandler = null
+      }
+      return originalRemoveEventListener(
+        type,
+        handler as EventListenerOrEventListenerObject,
+        options
+      )
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    setScrollY(0)
+  })
+
+  it('exports BACK_TO_TOP_SCROLL_THRESHOLD as 800', () => {
+    expect(BACK_TO_TOP_SCROLL_THRESHOLD).toBe(800)
+  })
+
+  it('returns false when scrollY is below the threshold', () => {
+    setScrollY(0)
+    const { result } = renderHook(() => useScrollToTop())
+    expect(result.current).toBe(false)
+  })
+
+  it('returns false when scrollY equals the threshold exactly', () => {
+    setScrollY(800)
+    const { result } = renderHook(() => useScrollToTop())
+    expect(result.current).toBe(false)
+  })
+
+  it('returns true when scrollY exceeds the threshold', () => {
+    setScrollY(801)
+    const { result } = renderHook(() => useScrollToTop())
+    expect(result.current).toBe(true)
+  })
+
+  it('updates to true when user scrolls past threshold', () => {
+    setScrollY(0)
+    const { result } = renderHook(() => useScrollToTop())
+    expect(result.current).toBe(false)
+
+    act(() => {
+      setScrollY(900)
+      capturedHandler?.()
+    })
+
+    expect(result.current).toBe(true)
+  })
+
+  it('updates to false when user scrolls back above threshold', () => {
+    setScrollY(900)
+    const { result } = renderHook(() => useScrollToTop())
+    expect(result.current).toBe(true)
+
+    act(() => {
+      setScrollY(100)
+      capturedHandler?.()
+    })
+
+    expect(result.current).toBe(false)
+  })
+
+  it('removes the scroll listener on unmount', () => {
+    const { unmount } = renderHook(() => useScrollToTop())
+    expect(capturedHandler).not.toBeNull()
+
+    unmount()
+    expect(capturedHandler).toBeNull()
+  })
+})

--- a/src/hooks/useScrollToTop.ts
+++ b/src/hooks/useScrollToTop.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react'
+
+export const BACK_TO_TOP_SCROLL_THRESHOLD = 800
+
+export function useScrollToTop(): boolean {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setVisible(window.scrollY > BACK_TO_TOP_SCROLL_THRESHOLD)
+    }
+
+    window.addEventListener('scroll', handleScroll, { passive: true })
+    handleScroll()
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [])
+
+  return visible
+}


### PR DESCRIPTION
Closes #391

## Summary

- Adds a fixed-position "Back to top" button that appears after 800 px of scroll
- Smooth-scrolls to the top on click (falls back to instant scroll when `prefers-reduced-motion` is active)
- Moves keyboard focus to the first `<h1>` inside `#main-content` after scrolling
- Self-contained: no props, driven by the new `useScrollToTop` hook
- All design tokens used — no hard-coded values

## New files

| File | Purpose |
|------|---------|
| `src/hooks/useScrollToTop.ts` | Passive scroll listener; exports `BACK_TO_TOP_SCROLL_THRESHOLD = 800` |
| `src/components/BackToTop.tsx` | Button component |
| `src/components/BackToTop.css` | Token-driven styles |
| `src/hooks/useScrollToTop.test.ts` | 7 hook unit tests |
| `src/components/BackToTop.test.tsx` | 7 component unit tests |

## Modified files

- `src/components/Layout.tsx` — mounts `<BackToTop />` in the app shell
- `docs/COMPONENTS.md` — BackToTop catalog entry
- `docs/HOOKS.md` — useScrollToTop catalog entry

## Test plan

- [x] `useScrollToTop` returns `false` below threshold, `true` above it
- [x] `useScrollToTop` removes its scroll listener on unmount
- [x] `BackToTop` is hidden when not scrolled, visible when scrolled past 800 px
- [x] Click calls `window.scrollTo({ top: 0, behavior: "smooth" })`
- [x] Click calls `window.scrollTo({ top: 0, behavior: "auto" })` under reduced-motion
- [x] Click focuses the `<h1>` in `#main-content` with `preventScroll: true`
- [x] All pre-existing Layout tests continue to pass
- [x] Lint clean on new/modified files
