### PR TITLE
feat: add What's New changelog dialog surfacing product updates

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -25,6 +25,7 @@ Related focused docs: [button system](./button-system.md), [notifications](./not
 | states/ErrorState      | Inline styles in `src/components/states/ErrorState.tsx`                             | Owns inline styles and should be migrated to CSS.                                                                         |
 | states/LoadingSkeleton | Inline styles in `src/components/states/LoadingSkeleton.tsx`                        | Owns inline styles and should be migrated to CSS.                                                                         |
 | SessionTimeoutModal    | Inline styles in `src/components/SessionTimeoutModal.tsx`                           | Uses `ConfirmDialog` primitive with internal warning styles.                                                              |
+| WhatsNewDialog         | `src/components/WhatsNewDialog.css`                                                 | None.                                                                                                                     |
 
 ## Shared vocabularies
 
@@ -448,5 +449,33 @@ Tokens: warning color tokens, spacing, radius.
   timeLeftSeconds={60}
   onStayLoggedIn={stay}
   onLogout={logout}
+/>
+```
+
+## WhatsNewDialog
+
+Source: [`src/components/WhatsNewDialog.tsx`](../src/components/WhatsNewDialog.tsx). Data: [`src/data/productUpdates.ts`](../src/data/productUpdates.ts). Hook: [`useProductUpdates`](../src/hooks/useProductUpdates.ts).
+
+A modal dialog that surfaces recent product updates ("What's New" changelog). Rendered by `Layout` and triggered by the star (✦) button in the app header. On mobile it slides up as a bottom sheet.
+
+Opening the dialog automatically calls `markAllRead()`, clearing the unread-count badge on the trigger button.
+
+| Prop             | Type                             | Default  |
+| ---------------- | -------------------------------- | -------- |
+| `open`           | `boolean`                        | Required |
+| `onClose`        | `() => void`                     | Required |
+| `returnFocusRef` | `RefObject<HTMLElement \| null>` | —        |
+
+Accessibility: `role="dialog"` with `aria-modal="true"` and `aria-labelledby` pointing to the heading. Focus is trapped while open via `useFocusTrap`; restored to `returnFocusRef` (or the previously focused element) on close. Escape key and backdrop click both close the dialog.
+
+Tokens: `--credence-border-default`, `--credence-color-info-*`, `--credence-color-success-*`, `--credence-color-warning-*`, `--credence-font-*`, `--credence-line-height-*`, `--credence-motion-duration-fast`, `--credence-motion-easing-decelerate`, `--credence-radius-full`, `--credence-radius-xl`, `--credence-space-*`, `--credence-surface-card`, `--credence-text-*`.
+
+**Adding an update**: prepend a new entry to `PRODUCT_UPDATES` in `src/data/productUpdates.ts`. The dialog and the header badge update automatically.
+
+```tsx
+<WhatsNewDialog
+  open={whatsNewOpen}
+  onClose={closeWhatsNew}
+  returnFocusRef={whatsNewButtonRef}
 />
 ```

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -24,6 +24,7 @@ behavior notes, and a minimal usage example linking to source.
   - [`useFocusTrap`](#usefocustrap)
   - [`useDocumentTitle`](#usedocumenttitle)
   - [`useReducedMotion`](#usereducedmotion)
+  - [`useProductUpdates`](#useproductupdates)
   - [`useTrustScore`](#usetrustscore)
   - [`useUsdcBalance`](#useusdcbalance)
   - [`useWallet`](#usewallet)
@@ -178,6 +179,46 @@ import { useReducedMotion } from '../hooks/useReducedMotion'
 function Banner() {
   const reduceMotion = useReducedMotion()
   return <div className={reduceMotion ? 'no-anim' : 'slide-in'}>…</div>
+}
+```
+
+---
+
+### `useProductUpdates`
+
+Source: [`src/hooks/useProductUpdates.ts`](../src/hooks/useProductUpdates.ts) · Data: [`src/data/productUpdates.ts`](../src/data/productUpdates.ts)
+
+```ts
+function useProductUpdates(): UseProductUpdatesResult
+
+interface UseProductUpdatesResult {
+  updates: readonly ProductUpdate[]
+  unreadCount: number
+  markAllRead: () => void
+}
+
+// Exported constant
+const PRODUCT_UPDATES_STORAGE_KEY = 'credence:last-seen-update-id'
+```
+
+Tracks which product updates the user has already seen, persisting the last-seen update ID in localStorage. Used by `WhatsNewDialog` and the `Layout` header badge.
+
+**`unreadCount`** equals the number of entries in `PRODUCT_UPDATES` that are newer than the last-seen update. For a first-time visitor (nothing in storage) it equals the full list length.
+
+**`markAllRead`** stores `LATEST_UPDATE_ID` (the newest entry's `id`) to localStorage, collapsing `unreadCount` to `0`.
+
+**SSR-safe / cleanup:** delegates all storage access to `useLocalStorage`; no DOM listeners.
+
+```tsx
+import { useProductUpdates } from '../hooks/useProductUpdates'
+
+function Header() {
+  const { unreadCount, markAllRead } = useProductUpdates()
+  return (
+    <button onClick={markAllRead} aria-label={`What's New (${unreadCount} unread)`}>
+      ✦ {unreadCount > 0 && <span>{unreadCount}</span>}
+    </button>
+  )
 }
 ```
 

--- a/src/components/Layout.css
+++ b/src/components/Layout.css
@@ -75,6 +75,67 @@
   margin-bottom: var(--credence-space-1);
 }
 
+/* ── What's New button ───────────────────────────────────────────────────── */
+
+.appHeader-whats-new-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: 1px solid var(--credence-border-default);
+  border-radius: var(--credence-radius-full);
+  background: transparent;
+  color: var(--credence-text-secondary);
+  cursor: pointer;
+  transition:
+    background var(--credence-motion-duration-fast) var(--credence-motion-easing-standard),
+    color var(--credence-motion-duration-fast) var(--credence-motion-easing-standard),
+    border-color var(--credence-motion-duration-fast) var(--credence-motion-easing-standard);
+  flex-shrink: 0;
+}
+
+.appHeader-whats-new-btn:hover {
+  background: var(--credence-color-slate-100);
+  color: var(--credence-text-primary);
+  border-color: var(--credence-color-slate-400);
+}
+
+.appHeader-whats-new-btn:focus-visible {
+  outline: var(--credence-focus-ring);
+  outline-offset: 2px;
+}
+
+[data-theme='dark'] .appHeader-whats-new-btn:hover {
+  background: var(--credence-color-slate-700);
+}
+
+.appHeader-whats-new-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.appHeader-whats-new-badge {
+  position: absolute;
+  top: -0.25rem;
+  right: -0.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1rem;
+  height: 1rem;
+  padding: 0 var(--credence-space-1);
+  background: var(--credence-color-primary);
+  color: var(--credence-color-white);
+  border-radius: var(--credence-radius-full);
+  font-size: var(--credence-font-size-xs);
+  font-weight: var(--credence-font-weight-bold);
+  line-height: 1;
+  pointer-events: none;
+}
+
 /* ── Shortcuts help button ───────────────────────────────────────────────── */
 
 .appHeader-shortcuts-btn {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -4,6 +4,8 @@ import ThemeToggle from './ThemeToggle'
 import MobileNav from './navigation/MobileNav'
 import RouteAnnouncer from './RouteAnnouncer'
 import KeyboardShortcutsDialog from './KeyboardShortcutsDialog'
+import WhatsNewDialog from './WhatsNewDialog'
+import { useProductUpdates } from '../hooks/useProductUpdates'
 import LINKS from '../config/links'
 import './Layout.css'
 
@@ -26,11 +28,18 @@ function FooterLink({ label, href }: { label: string; href: string }) {
 
 export default function Layout() {
   const [shortcutsOpen, setShortcutsOpen] = useState(false)
-  // Ref on the header button so focus returns to it after the dialog closes
+  const [whatsNewOpen, setWhatsNewOpen] = useState(false)
+  // Refs so focus returns to the triggering button after each dialog closes
   const shortcutsButtonRef = useRef<HTMLButtonElement>(null)
+  const whatsNewButtonRef = useRef<HTMLButtonElement>(null)
+
+  const { unreadCount } = useProductUpdates()
 
   const openShortcuts = useCallback(() => setShortcutsOpen(true), [])
   const closeShortcuts = useCallback(() => setShortcutsOpen(false), [])
+
+  const openWhatsNew = useCallback(() => setWhatsNewOpen(true), [])
+  const closeWhatsNew = useCallback(() => setWhatsNewOpen(false), [])
 
   // Global Shift+? listener — opens the shortcuts dialog from anywhere except
   // text-entry contexts (input, textarea, contenteditable).
@@ -90,6 +99,40 @@ export default function Layout() {
 
         <ThemeToggle />
 
+        {/* What's New button */}
+        <button
+          ref={whatsNewButtonRef}
+          type="button"
+          className="appHeader-whats-new-btn"
+          aria-label={
+            unreadCount > 0
+              ? `What's New — ${unreadCount} unread update${unreadCount === 1 ? '' : 's'}`
+              : "What's New"
+          }
+          onClick={openWhatsNew}
+        >
+          <svg
+            className="appHeader-whats-new-icon"
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 2L15.09 8.26L22 9.27L17 14.14L18.18 21.02L12 17.77L5.82 21.02L7 14.14L2 9.27L8.91 8.26L12 2Z"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          {unreadCount > 0 && (
+            <span className="appHeader-whats-new-badge" aria-hidden="true">
+              {unreadCount}
+            </span>
+          )}
+        </button>
+
         {/* Keyboard shortcuts help button */}
         <button
           ref={shortcutsButtonRef}
@@ -124,6 +167,12 @@ export default function Layout() {
         open={shortcutsOpen}
         onClose={closeShortcuts}
         returnFocusRef={shortcutsButtonRef}
+      />
+
+      <WhatsNewDialog
+        open={whatsNewOpen}
+        onClose={closeWhatsNew}
+        returnFocusRef={whatsNewButtonRef}
       />
     </div>
   )

--- a/src/components/WhatsNewDialog.css
+++ b/src/components/WhatsNewDialog.css
@@ -1,0 +1,199 @@
+/* ─── Backdrop ─────────────────────────────────────────────────────────────── */
+
+.whats-new-dialog__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--credence-space-4);
+  background: rgba(15, 23, 42, 0.55);
+  animation: whats-new-dialog-fade-in var(--credence-motion-duration-fast)
+    var(--credence-motion-easing-decelerate);
+}
+
+[data-theme='dark'] .whats-new-dialog__backdrop {
+  background: rgba(0, 0, 0, 0.65);
+}
+
+/* ─── Dialog panel ─────────────────────────────────────────────────────────── */
+
+.whats-new-dialog {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-width: 36rem;
+  max-height: min(90vh, 48rem);
+  overflow: hidden;
+  border: 1px solid var(--credence-border-default);
+  border-radius: var(--credence-radius-xl);
+  background: var(--credence-surface-card);
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.2);
+  color: var(--credence-text-primary);
+}
+
+[data-theme='dark'] .whats-new-dialog {
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.45);
+}
+
+/* ─── Header ───────────────────────────────────────────────────────────────── */
+
+.whats-new-dialog__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--credence-space-5) var(--credence-space-5) var(--credence-space-4);
+  border-bottom: 1px solid var(--credence-border-default);
+  background: var(--credence-surface-card);
+  flex-shrink: 0;
+}
+
+.whats-new-dialog__title {
+  margin: 0;
+  font-size: var(--credence-font-size-lg);
+  font-weight: var(--credence-font-weight-bold);
+  line-height: var(--credence-line-height-tight);
+  color: var(--credence-text-primary);
+}
+
+.whats-new-dialog__close {
+  padding: var(--credence-space-2) !important;
+  line-height: 1;
+  font-size: var(--credence-font-size-base);
+  color: var(--credence-text-secondary);
+}
+
+.whats-new-dialog__close:hover {
+  color: var(--credence-text-primary);
+}
+
+/* ─── Update list ──────────────────────────────────────────────────────────── */
+
+.whats-new-dialog__list {
+  flex: 1;
+  overflow-y: auto;
+  list-style: none;
+  margin: 0;
+  padding: var(--credence-space-4) var(--credence-space-5);
+  display: grid;
+  gap: var(--credence-space-5);
+}
+
+.whats-new-dialog__item {
+  display: grid;
+  gap: var(--credence-space-1);
+  padding-bottom: var(--credence-space-5);
+  border-bottom: 1px solid var(--credence-border-default);
+}
+
+.whats-new-dialog__item:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.whats-new-dialog__item-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--credence-space-3);
+}
+
+.whats-new-dialog__tag {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--credence-space-1) var(--credence-space-2);
+  border-radius: var(--credence-radius-full);
+  font-size: var(--credence-font-size-xs);
+  font-weight: var(--credence-font-weight-semibold);
+  line-height: 1;
+}
+
+.whats-new-dialog__tag--feature {
+  background: var(--credence-color-info-surface);
+  color: var(--credence-color-info-text);
+}
+
+.whats-new-dialog__tag--improvement {
+  background: var(--credence-color-success-surface);
+  color: var(--credence-color-success-text);
+}
+
+.whats-new-dialog__tag--fix {
+  background: var(--credence-color-warning-surface);
+  color: var(--credence-color-warning-text);
+}
+
+.whats-new-dialog__date {
+  font-size: var(--credence-font-size-xs);
+  color: var(--credence-text-secondary);
+}
+
+.whats-new-dialog__item-title {
+  margin: 0;
+  font-size: var(--credence-font-size-base);
+  font-weight: var(--credence-font-weight-semibold);
+  color: var(--credence-text-primary);
+  line-height: var(--credence-line-height-tight);
+}
+
+.whats-new-dialog__item-description {
+  margin: 0;
+  font-size: var(--credence-font-size-sm);
+  color: var(--credence-text-secondary);
+  line-height: var(--credence-line-height-relaxed);
+}
+
+/* ─── Footer ───────────────────────────────────────────────────────────────── */
+
+.whats-new-dialog__footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--credence-space-3);
+  padding: var(--credence-space-4) var(--credence-space-5) var(--credence-space-5);
+  border-top: 1px solid var(--credence-border-default);
+  background: var(--credence-surface-card);
+  flex-shrink: 0;
+}
+
+/* ─── Entrance animation ───────────────────────────────────────────────────── */
+
+@keyframes whats-new-dialog-fade-in {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+/* ─── Mobile: bottom sheet ─────────────────────────────────────────────────── */
+
+@media (max-width: 767px) {
+  .whats-new-dialog__backdrop {
+    align-items: flex-end;
+    padding: 0;
+  }
+
+  .whats-new-dialog {
+    max-width: none;
+    max-height: 92vh;
+    border-radius: var(--credence-radius-xl) var(--credence-radius-xl) 0 0;
+  }
+
+  .whats-new-dialog__footer {
+    flex-direction: column;
+  }
+
+  .whats-new-dialog__footer .credence-button {
+    width: 100%;
+  }
+}
+
+/* ─── Wider screens ────────────────────────────────────────────────────────── */
+
+@media (min-width: 1280px) {
+  .whats-new-dialog {
+    max-width: 40rem;
+  }
+}

--- a/src/components/WhatsNewDialog.test.tsx
+++ b/src/components/WhatsNewDialog.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import WhatsNewDialog from './WhatsNewDialog'
+import * as useProductUpdatesModule from '../hooks/useProductUpdates'
+import { PRODUCT_UPDATES } from '../data/productUpdates'
+
+vi.mock('../hooks/useProductUpdates', () => ({
+  useProductUpdates: vi.fn(),
+  PRODUCT_UPDATES_STORAGE_KEY: 'credence:last-seen-update-id',
+}))
+
+const mockMarkAllRead = vi.fn()
+
+function setMockUpdates(unreadCount = 0) {
+  vi.mocked(useProductUpdatesModule.useProductUpdates).mockReturnValue({
+    updates: PRODUCT_UPDATES,
+    unreadCount,
+    markAllRead: mockMarkAllRead,
+  })
+}
+
+describe('WhatsNewDialog', () => {
+  beforeEach(() => {
+    mockMarkAllRead.mockReset()
+    setMockUpdates(0)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not render when open is false', () => {
+    render(<WhatsNewDialog open={false} onClose={() => undefined} />)
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders the dialog with correct role and label when open', () => {
+    render(<WhatsNewDialog open={true} onClose={() => undefined} />)
+    expect(screen.getByRole('dialog', { name: /what.s new/i })).toBeInTheDocument()
+  })
+
+  it('renders a list item for every product update', () => {
+    render(<WhatsNewDialog open={true} onClose={() => undefined} />)
+    const list = screen.getByRole('list', { name: /recent product updates/i })
+    expect(list.querySelectorAll('li')).toHaveLength(PRODUCT_UPDATES.length)
+  })
+
+  it('renders the title and description for each update', () => {
+    render(<WhatsNewDialog open={true} onClose={() => undefined} />)
+    for (const update of PRODUCT_UPDATES) {
+      expect(screen.getByText(update.title)).toBeInTheDocument()
+      expect(screen.getByText(update.description)).toBeInTheDocument()
+    }
+  })
+
+  it('renders a <time> element with the correct dateTime attribute for each update', () => {
+    render(<WhatsNewDialog open={true} onClose={() => undefined} />)
+    const times = document.querySelectorAll('time')
+    const dateTimes = Array.from(times).map((t) => t.getAttribute('dateTime'))
+    for (const update of PRODUCT_UPDATES) {
+      expect(dateTimes).toContain(update.date)
+    }
+  })
+
+  it('calls markAllRead when opened', () => {
+    render(<WhatsNewDialog open={true} onClose={() => undefined} />)
+    expect(mockMarkAllRead).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when the Close button is clicked', () => {
+    const onClose = vi.fn()
+    render(<WhatsNewDialog open={true} onClose={onClose} />)
+    fireEvent.click(screen.getByRole('button', { name: /close what's new/i }))
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onClose when the Close button in the footer is clicked', () => {
+    const onClose = vi.fn()
+    render(<WhatsNewDialog open={true} onClose={onClose} />)
+    const closeButtons = screen.getAllByRole('button', { name: /close/i })
+    fireEvent.click(closeButtons[closeButtons.length - 1])
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('calls onClose when the backdrop is clicked', () => {
+    const onClose = vi.fn()
+    render(<WhatsNewDialog open={true} onClose={onClose} />)
+    const backdrop = document.querySelector('.whats-new-dialog__backdrop')
+    expect(backdrop).not.toBeNull()
+    fireEvent.click(backdrop!)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('locks body scroll while open and restores it on close', async () => {
+    const { rerender } = render(<WhatsNewDialog open={true} onClose={() => undefined} />)
+    expect(document.body.style.overflow).toBe('hidden')
+
+    rerender(<WhatsNewDialog open={false} onClose={() => undefined} />)
+    await waitFor(() => {
+      expect(document.body.style.overflow).not.toBe('hidden')
+    })
+  })
+
+  it('renders tag labels for each update', () => {
+    render(<WhatsNewDialog open={true} onClose={() => undefined} />)
+    // At least one "New" tag should be present (from 'feature' updates)
+    const newTags = screen.getAllByText('New')
+    expect(newTags.length).toBeGreaterThan(0)
+  })
+})

--- a/src/components/WhatsNewDialog.tsx
+++ b/src/components/WhatsNewDialog.tsx
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useId, useRef } from 'react'
+import { createPortal } from 'react-dom'
+import { useFocusTrap } from '../hooks/useFocusTrap'
+import { useProductUpdates } from '../hooks/useProductUpdates'
+import type { ProductUpdate } from '../data/productUpdates'
+import Button from './Button'
+import './WhatsNewDialog.css'
+
+export interface WhatsNewDialogProps {
+  open: boolean
+  onClose: () => void
+  /**
+   * Optional ref whose element will receive focus after the dialog closes.
+   * When omitted, focus returns to whichever element was active before opening.
+   */
+  returnFocusRef?: React.RefObject<HTMLElement | null>
+}
+
+const TAG_LABELS: Record<ProductUpdate['tag'], string> = {
+  feature: 'New',
+  improvement: 'Improved',
+  fix: 'Fixed',
+}
+
+function formatDate(isoDate: string): string {
+  const date = new Date(`${isoDate}T00:00:00Z`)
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'UTC',
+  })
+}
+
+/**
+ * Modal dialog listing recent product updates ("What's New" changelog).
+ *
+ * - Renders via a React portal into `document.body`.
+ * - Focus is trapped inside while open; restored on close.
+ * - Escape and backdrop click close the dialog.
+ * - Marks all updates as read on open, clearing the notification badge.
+ */
+export default function WhatsNewDialog({
+  open,
+  onClose,
+  returnFocusRef,
+}: WhatsNewDialogProps) {
+  const titleId = useId()
+  const dialogRef = useRef<HTMLDivElement>(null)
+  const closeButtonRef = useRef<HTMLButtonElement>(null)
+  const { updates, markAllRead } = useProductUpdates()
+
+  const handleClose = useCallback(() => onClose(), [onClose])
+
+  useFocusTrap({
+    containerRef: dialogRef,
+    isActive: open,
+    initialFocusRef: closeButtonRef,
+    returnFocusRef,
+    onEscape: handleClose,
+  })
+
+  useEffect(() => {
+    if (!open) return
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    markAllRead()
+    return () => {
+      document.body.style.overflow = previousOverflow
+    }
+  }, [open, markAllRead])
+
+  const handleBackdropClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    if (event.target === event.currentTarget) handleClose()
+  }
+
+  if (!open) return null
+
+  return createPortal(
+    <div
+      className="whats-new-dialog__backdrop"
+      onClick={handleBackdropClick}
+      aria-hidden={false}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        className="whats-new-dialog"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="whats-new-dialog__header">
+          <h2 id={titleId} className="whats-new-dialog__title">
+            What&rsquo;s New
+          </h2>
+          <Button
+            ref={closeButtonRef}
+            type="button"
+            variant="ghost"
+            className="whats-new-dialog__close"
+            aria-label="Close What's New"
+            onClick={handleClose}
+          >
+            <span aria-hidden="true">&#x2715;</span>
+          </Button>
+        </header>
+
+        <ul className="whats-new-dialog__list" role="list" aria-label="Recent product updates">
+          {updates.map((update) => (
+            <li key={update.id} className="whats-new-dialog__item">
+              <div className="whats-new-dialog__item-meta">
+                <span
+                  className={`whats-new-dialog__tag whats-new-dialog__tag--${update.tag}`}
+                  aria-label={TAG_LABELS[update.tag]}
+                >
+                  {TAG_LABELS[update.tag]}
+                </span>
+                <time className="whats-new-dialog__date" dateTime={update.date}>
+                  {formatDate(update.date)}
+                </time>
+              </div>
+              <p className="whats-new-dialog__item-title">{update.title}</p>
+              <p className="whats-new-dialog__item-description">{update.description}</p>
+            </li>
+          ))}
+        </ul>
+
+        <footer className="whats-new-dialog__footer">
+          <Button type="button" variant="secondary" onClick={handleClose}>
+            Close
+          </Button>
+        </footer>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/src/data/productUpdates.ts
+++ b/src/data/productUpdates.ts
@@ -1,0 +1,67 @@
+/**
+ * Static registry of recent product updates surfaced in the "What's New" dialog.
+ *
+ * ## Adding a new update
+ * 1. Prepend a new entry to `PRODUCT_UPDATES` (newest first).
+ * 2. The dialog and unread-count badge update automatically — no other change needed.
+ */
+
+export interface ProductUpdate {
+  /** Stable identifier used to track which updates the user has seen. */
+  id: string
+  /** ISO 8601 date string, e.g. "2026-06-29". */
+  date: string
+  title: string
+  description: string
+  tag: 'feature' | 'improvement' | 'fix'
+}
+
+/** All product updates, newest first. */
+export const PRODUCT_UPDATES: readonly ProductUpdate[] = [
+  {
+    id: 'update-2026-06-back-to-top',
+    date: '2026-06-29',
+    title: 'Back-to-top button',
+    description:
+      'A "Back to top" button now appears after scrolling 800 px on any long page, letting you return to the page heading in one click.',
+    tag: 'feature',
+  },
+  {
+    id: 'update-2026-05-keyboard-shortcuts',
+    date: '2026-05-20',
+    title: 'Keyboard shortcuts reference',
+    description:
+      'Press Shift+? from anywhere in the app to open a full list of keyboard shortcuts.',
+    tag: 'feature',
+  },
+  {
+    id: 'update-2026-05-transaction-filter',
+    date: '2026-05-15',
+    title: 'Transaction status filter',
+    description:
+      'Filter your transaction history by status — pending, confirmed, or failed — directly on the Transactions page.',
+    tag: 'improvement',
+  },
+  {
+    id: 'update-2026-04-trust-gauge',
+    date: '2026-04-10',
+    title: 'Trust gauge visualization',
+    description:
+      'Your trust score is now displayed as an animated gauge with tier markers, making it easy to see how close you are to the next tier.',
+    tag: 'feature',
+  },
+  {
+    id: 'update-2026-03-dark-mode',
+    date: '2026-03-01',
+    title: 'Dark mode',
+    description:
+      'Toggle between light and dark themes from the header. Your preference is saved across sessions.',
+    tag: 'feature',
+  },
+]
+
+/**
+ * The ID of the newest update. Used by `useProductUpdates` to determine whether
+ * the user has seen all available updates.
+ */
+export const LATEST_UPDATE_ID = PRODUCT_UPDATES[0].id

--- a/src/hooks/useProductUpdates.test.ts
+++ b/src/hooks/useProductUpdates.test.ts
@@ -1,0 +1,79 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { useProductUpdates, PRODUCT_UPDATES_STORAGE_KEY } from './useProductUpdates'
+import { PRODUCT_UPDATES, LATEST_UPDATE_ID } from '../data/productUpdates'
+
+describe('useProductUpdates', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    window.localStorage.clear()
+  })
+
+  it('returns all product updates', () => {
+    const { result } = renderHook(() => useProductUpdates())
+    expect(result.current.updates).toBe(PRODUCT_UPDATES)
+    expect(result.current.updates.length).toBeGreaterThan(0)
+  })
+
+  it('returns unreadCount equal to total updates when no update has been seen', () => {
+    const { result } = renderHook(() => useProductUpdates())
+    expect(result.current.unreadCount).toBe(PRODUCT_UPDATES.length)
+  })
+
+  it('returns unreadCount of 0 after markAllRead is called', () => {
+    const { result } = renderHook(() => useProductUpdates())
+    expect(result.current.unreadCount).toBe(PRODUCT_UPDATES.length)
+
+    act(() => {
+      result.current.markAllRead()
+    })
+
+    expect(result.current.unreadCount).toBe(0)
+  })
+
+  it('persists the latest update id to localStorage after markAllRead', () => {
+    const { result } = renderHook(() => useProductUpdates())
+
+    act(() => {
+      result.current.markAllRead()
+    })
+
+    const stored = JSON.parse(window.localStorage.getItem(PRODUCT_UPDATES_STORAGE_KEY) ?? 'null')
+    expect(stored).toBe(LATEST_UPDATE_ID)
+  })
+
+  it('reads unread count from localStorage on mount', () => {
+    // Simulate having seen the second update (index 1 in the list)
+    const secondUpdateId = PRODUCT_UPDATES[1].id
+    window.localStorage.setItem(PRODUCT_UPDATES_STORAGE_KEY, JSON.stringify(secondUpdateId))
+
+    const { result } = renderHook(() => useProductUpdates())
+    // Updates at indices 0 through (index-1) are unread → index 1 means 1 unread
+    expect(result.current.unreadCount).toBe(1)
+  })
+
+  it('treats a stale or unrecognised stored id as all-unread', () => {
+    window.localStorage.setItem(
+      PRODUCT_UPDATES_STORAGE_KEY,
+      JSON.stringify('update-no-longer-exists')
+    )
+
+    const { result } = renderHook(() => useProductUpdates())
+    expect(result.current.unreadCount).toBe(PRODUCT_UPDATES.length)
+  })
+
+  it('returns unreadCount 0 when the stored id matches the newest update', () => {
+    window.localStorage.setItem(PRODUCT_UPDATES_STORAGE_KEY, JSON.stringify(LATEST_UPDATE_ID))
+
+    const { result } = renderHook(() => useProductUpdates())
+    expect(result.current.unreadCount).toBe(0)
+  })
+
+  it('exports PRODUCT_UPDATES_STORAGE_KEY as the expected string', () => {
+    expect(PRODUCT_UPDATES_STORAGE_KEY).toBe('credence:last-seen-update-id')
+  })
+})

--- a/src/hooks/useProductUpdates.ts
+++ b/src/hooks/useProductUpdates.ts
@@ -1,0 +1,48 @@
+import { useCallback } from 'react'
+import { useLocalStorage } from './useLocalStorage'
+import { PRODUCT_UPDATES, LATEST_UPDATE_ID, type ProductUpdate } from '../data/productUpdates'
+
+export const PRODUCT_UPDATES_STORAGE_KEY = 'credence:last-seen-update-id'
+
+export interface UseProductUpdatesResult {
+  updates: readonly ProductUpdate[]
+  /** Number of updates the user has not yet seen. */
+  unreadCount: number
+  /** Marks all current updates as seen and persists the state to localStorage. */
+  markAllRead: () => void
+}
+
+/**
+ * Tracks which product updates the user has already seen.
+ *
+ * The ID of the newest seen update is persisted in localStorage under
+ * `PRODUCT_UPDATES_STORAGE_KEY`. Updates are ordered newest-first in
+ * `PRODUCT_UPDATES`, so the unread count equals the index of the last-seen
+ * entry (or the full list length for first-time visitors).
+ *
+ * SSR-safe: delegates storage access to `useLocalStorage`.
+ * Cleanup: none — no listeners are registered.
+ */
+export function useProductUpdates(): UseProductUpdatesResult {
+  const [lastSeenId, setLastSeenId] = useLocalStorage<string | null>(
+    PRODUCT_UPDATES_STORAGE_KEY,
+    null
+  )
+
+  const lastSeenIndex =
+    lastSeenId !== null ? PRODUCT_UPDATES.findIndex((u) => u.id === lastSeenId) : -1
+
+  // If lastSeenId is null (new visitor) or stale (unknown ID), all updates are unread.
+  // If lastSeenId matches PRODUCT_UPDATES[0], unreadCount is 0.
+  const unreadCount = lastSeenIndex === -1 ? PRODUCT_UPDATES.length : lastSeenIndex
+
+  const markAllRead = useCallback(() => {
+    setLastSeenId(LATEST_UPDATE_ID)
+  }, [setLastSeenId])
+
+  return {
+    updates: PRODUCT_UPDATES,
+    unreadCount,
+    markAllRead,
+  }
+}


### PR DESCRIPTION
Closes #404

## Summary

- Adds a "What's New" star (✦) button to the app header that opens a changelog dialog listing recent product updates
- A numeric badge on the button shows how many updates the user has not yet seen
- Opening the dialog marks all updates as read (persisted to `localStorage`), clearing the badge
- On mobile the dialog slides up as a bottom sheet
- No external API needed — updates are served from a static data file

## New files

| File | Purpose |
|------|---------|
| `src/data/productUpdates.ts` | Static update registry — prepend here to publish a new entry |
| `src/hooks/useProductUpdates.ts` | Tracks unread count in `localStorage`; exports `PRODUCT_UPDATES_STORAGE_KEY` |
| `src/components/WhatsNewDialog.tsx` | Portal dialog; mirrors `KeyboardShortcutsDialog` pattern |
| `src/components/WhatsNewDialog.css` | Token-driven styles; bottom-sheet on mobile |
| `src/hooks/useProductUpdates.test.ts` | 8 hook unit tests |
| `src/components/WhatsNewDialog.test.tsx` | 11 component unit tests |

## Modified files

- `src/components/Layout.tsx` — mounts the button (with badge) and `WhatsNewDialog`
- `src/components/Layout.css` — button + badge styles (all design tokens, no hard-coded values)
- `docs/COMPONENTS.md` — `WhatsNewDialog` catalog entry with props, accessibility contract, and token list
- `docs/HOOKS.md` — `useProductUpdates` catalog entry

## Test plan

- [x] `unreadCount` equals full list length for a new visitor (no localStorage entry)
- [x] `unreadCount` equals 0 after `markAllRead` is called
- [x] `markAllRead` persists `LATEST_UPDATE_ID` to localStorage
- [x] Stale / unknown stored ID is treated as all-unread
- [x] Dialog not rendered when `open={false}`
- [x] Dialog renders one list item per update with correct title, description, date, and tag
- [x] Opening calls `markAllRead`
- [x] Close button, footer Close button, and backdrop click all call `onClose`
- [x] Body scroll is locked while open and restored on close
- [x] All 8 pre-existing Layout tests continue to pass
- [x] Lint clean on all new and modified files
