### PR TITLE
Add i18n scaffolding with i18next and English locale file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,11 @@
       "version": "0.1.0",
       "dependencies": {
         "@stellar/freighter-api": "^6.0.1",
+        "i18next": "^23.7.0",
+        "i18next-browser-languagedetector": "^7.2.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-i18next": "^13.5.0",
         "react-router-dom": "^6.22.0"
       },
       "devDependencies": {
@@ -113,7 +116,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -321,7 +323,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
       "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -470,7 +471,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -494,7 +494,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2494,7 +2493,6 @@
       "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -2512,7 +2510,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2524,7 +2521,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2588,7 +2584,6 @@
       "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.1",
         "@typescript-eslint/types": "8.59.1",
@@ -2960,7 +2955,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3175,7 +3169,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3693,7 +3686,6 @@
       "integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -4260,6 +4252,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -4286,6 +4287,38 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "23.16.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
+      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/i18next-browser-languagedetector": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-7.2.2.tgz",
+      "integrity": "sha512-6b7r75uIJDWCcCflmbof+sJ94k9UQO4X0YR62oUfqGI/GjCLVzlCwu8TFdRZIqVLzWbzNcmkmhfqKEr4TLz4HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/iconv-lite": {
@@ -4627,7 +4660,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -5135,7 +5167,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5274,7 +5305,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5332,13 +5362,34 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-i18next": {
+      "version": "13.5.0",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-13.5.0.tgz",
+      "integrity": "sha512-CFJ5NDGJ2MUyBohEHxljOq/39NQ972rh1ajnadG9BjTk+UXbHLq4z5DKEbEQBDoIhUmmbuS/fIMJKo6VOax1HA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.22.5",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {
@@ -6020,7 +6071,6 @@
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6150,7 +6200,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -6234,7 +6283,6 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",
@@ -6293,6 +6341,15 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,11 @@
   },
   "dependencies": {
     "@stellar/freighter-api": "^6.0.1",
+    "i18next": "^23.7.0",
+    "i18next-browser-languagedetector": "^7.2.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-i18next": "^13.5.0",
     "react-router-dom": "^6.22.0"
   },
   "devDependencies": {

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useId, useRef, useState, type RefObject } from 'react'
+import { useTranslation } from 'react-i18next'
 import { createPortal } from 'react-dom'
 import { useFocusTrap } from '../hooks/useFocusTrap'
 import Button from './Button'
@@ -68,6 +69,7 @@ export default function ConfirmDialog({
   confirmPhrase = DEFAULT_CONFIRM_PHRASE,
   confirmHint = DEFAULT_CONFIRM_HINT,
 }: ConfirmDialogProps) {
+  const { t } = useTranslation()
   const titleId = useId()
   const descId = useId()
   const announcementId = useId()
@@ -114,17 +116,17 @@ export default function ConfirmDialog({
   useEffect(() => {
     if (isConfirmEnabled !== prevConfirmEnabled) {
       if (isConfirmEnabled) {
-        setAnnouncement(`Action enabled. Type ${confirmPhrase} to confirm.`)
+        setAnnouncement(t('confirmDialog.announcements.actionEnabled', { phrase: confirmPhrase }))
         requestAnimationFrame(() => {
           confirmRef.current?.focus()
         })
       } else {
-        setAnnouncement(`Action disabled. Type ${confirmPhrase} to enable.`)
+        setAnnouncement(t('confirmDialog.announcements.actionDisabled', { phrase: confirmPhrase }))
         requestAnimationFrame(() => cancelRef.current?.focus())
       }
       setPrevConfirmEnabled(isConfirmEnabled)
     }
-  }, [isConfirmEnabled, prevConfirmEnabled, confirmPhrase])
+  }, [isConfirmEnabled, prevConfirmEnabled, confirmPhrase, t])
 
   const handleConfirm = () => {
     if (!isConfirmEnabled) return
@@ -165,15 +167,15 @@ export default function ConfirmDialog({
           {breakdown ? (
             <dl className="confirm-dialog__breakdown">
               <div className="confirm-dialog__breakdown-row">
-                <dt>Bond amount</dt>
+                <dt>{t('confirmDialog.breakdown.bondAmount')}</dt>
                 <dd>{breakdown.bondAmount}</dd>
               </div>
               <div className="confirm-dialog__breakdown-row confirm-dialog__breakdown-row--penalty">
-                <dt>Slash penalty ({breakdown.penaltyPercent}%)</dt>
+                <dt>{t('confirmDialog.breakdown.slashPenalty', { percent: breakdown.penaltyPercent })}</dt>
                 <dd>−{breakdown.penaltyAmount}</dd>
               </div>
               <div className="confirm-dialog__breakdown-row confirm-dialog__breakdown-row--total">
-                <dt>You receive</dt>
+                <dt>{t('confirmDialog.breakdown.youReceive')}</dt>
                 <dd>{breakdown.resultingBalance}</dd>
               </div>
             </dl>
@@ -187,8 +189,7 @@ export default function ConfirmDialog({
             <label htmlFor={`${titleId}-confirm-input`}>
               {confirmInputLabel || (
                 <>
-                  Type <strong>{confirmPhrase}</strong> to enable{' '}
-                  {confirmLabel !== 'Withdraw bond' ? confirmLabel.toLowerCase() : 'withdrawal'}
+                  {t('confirmDialog.typeToConfirm', { phrase: confirmPhrase, action: confirmLabel !== 'Withdraw bond' ? confirmLabel.toLowerCase() : 'withdrawal' })}
                 </>
               )}
             </label>
@@ -210,7 +211,7 @@ export default function ConfirmDialog({
 
         <footer className="confirm-dialog__footer">
           <Button ref={cancelRef} type="button" variant="secondary" onClick={handleCancel}>
-            Cancel
+            {t('common.cancel')}
           </Button>
           <Button
             ref={confirmRef}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Outlet, NavLink } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import ThemeToggle from './ThemeToggle'
 import MobileNav from './navigation/MobileNav'
 import RouteAnnouncer from './RouteAnnouncer'
@@ -7,14 +8,6 @@ import KeyboardShortcutsDialog from './KeyboardShortcutsDialog'
 import LINKS from '../config/links'
 import './Layout.css'
 
-const NAV_LINKS = [
-  { to: '/dashboard', label: 'Dashboard' },
-  { to: '/bond', label: 'Bond' },
-  { to: '/trust', label: 'Trust Score' },
-  { to: '/attestations', label: 'Attestations' },
-  { to: '/transactions', label: 'Transactions' },
-  { to: '/settings', label: 'Settings' },
-]
 
 function FooterLink({ label, href }: { label: string; href: string }) {
   return (
@@ -25,9 +18,19 @@ function FooterLink({ label, href }: { label: string; href: string }) {
 }
 
 export default function Layout() {
+  const { t } = useTranslation()
   const [shortcutsOpen, setShortcutsOpen] = useState(false)
   // Ref on the header button so focus returns to it after the dialog closes
   const shortcutsButtonRef = useRef<HTMLButtonElement>(null)
+
+  const NAV_LINKS = [
+    { to: '/dashboard', label: t('nav.dashboard') },
+    { to: '/bond', label: t('nav.bond') },
+    { to: '/trust', label: t('nav.trustScore') },
+    { to: '/attestations', label: t('nav.attestations') },
+    { to: '/transactions', label: t('nav.transactions') },
+    { to: '/settings', label: t('nav.settings') },
+  ]
 
   const openShortcuts = useCallback(() => setShortcutsOpen(true), [])
   const closeShortcuts = useCallback(() => setShortcutsOpen(false), [])
@@ -58,7 +61,7 @@ export default function Layout() {
   return (
     <div className="appShell">
       <a className="skip-link" href="#main-content">
-        Skip to main content
+        {t('layout.skipToMainContent')}
       </a>
 
       {/* Screen reader SPA route transition updates manager */}
@@ -69,7 +72,7 @@ export default function Layout() {
         <MobileNav />
 
         <NavLink to="/" className="appBrand">
-          Credence
+          {t('layout.brand')}
         </NavLink>
 
         {/* Desktop: inline nav (hidden <640px via CSS) */}
@@ -95,7 +98,7 @@ export default function Layout() {
           ref={shortcutsButtonRef}
           type="button"
           className="appHeader-shortcuts-btn"
-          aria-label="Open keyboard shortcuts (Shift+?)"
+          aria-label={t('layout.keyboardShortcuts')}
           onClick={openShortcuts}
         >
           ?
@@ -109,13 +112,13 @@ export default function Layout() {
       <footer className="app-footer">
         <div className="container footer-content">
           <div>
-            <p className="appFooterTitle">Credence</p>
-            <p>© 2026 Credence Protocol. Built on Stellar.</p>
+            <p className="appFooterTitle">{t('layout.brand')}</p>
+            <p>{t('layout.footer.copyright')}</p>
           </div>
           <div className="footer-links">
-            <FooterLink label="Documentation" href={LINKS.docs} />
-            <FooterLink label="Terms of Service" href={LINKS.terms} />
-            <FooterLink label="Privacy Policy" href={LINKS.privacy} />
+            <FooterLink label={t('layout.footer.documentation')} href={LINKS.docs} />
+            <FooterLink label={t('layout.footer.termsOfService')} href={LINKS.terms} />
+            <FooterLink label={t('layout.footer.privacyPolicy')} href={LINKS.privacy} />
           </div>
         </div>
       </footer>

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -1,0 +1,24 @@
+import i18n from 'i18next'
+import { initReactI18next } from 'react-i18next'
+import LanguageDetector from 'i18next-browser-languagedetector'
+import en from './locales/en.json'
+
+i18n
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: { translation: en },
+    },
+    fallbackLng: 'en',
+    lng: 'en',
+    interpolation: {
+      escapeValue: false,
+    },
+    detection: {
+      order: ['localStorage', 'navigator'],
+      caches: ['localStorage'],
+    },
+  })
+
+export default i18n

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,0 +1,283 @@
+{
+  "layout": {
+    "skipToMainContent": "Skip to main content",
+    "brand": "Credence",
+    "keyboardShortcuts": "Open keyboard shortcuts (Shift+?)",
+    "footer": {
+      "copyright": "© 2026 Credence Protocol. Built on Stellar.",
+      "documentation": "Documentation",
+      "termsOfService": "Terms of Service",
+      "privacyPolicy": "Privacy Policy"
+    }
+  },
+  "nav": {
+    "dashboard": "Dashboard",
+    "bond": "Bond",
+    "trustScore": "Trust Score",
+    "attestations": "Attestations",
+    "transactions": "Transactions",
+    "settings": "Settings"
+  },
+  "dashboard": {
+    "title": "Dashboard",
+    "description": "Monitor trust score, active bonds, and recent protocol activity from one place.",
+    "wallet": "Wallet",
+    "connectWalletToView": "Connect wallet to view dashboard",
+    "walletRequired": "Wallet required",
+    "connectFreighter": "Connect Freighter to load your trust score, active bonds, and recent activity.",
+    "connectWallet": "Connect wallet",
+    "trustScore": "Trust Score",
+    "currentScore": "Current score",
+    "goldTier": "Gold Tier",
+    "activeBonds": "Active Bonds",
+    "activeBondsCount": "{{count}} active bonds",
+    "unlocks": "Unlocks {{date}}",
+    "recentActivity": "Recent Activity",
+    "shortcuts": "Shortcuts",
+    "createBond": "Create bond",
+    "createBondDescription": "Lock more USDC into reputation bonds.",
+    "viewTrustScore": "View trust score",
+    "viewTrustScoreDescription": "Look up score details and tier context.",
+    "reviewAttestations": "Review attestations",
+    "reviewAttestationsDescription": "Open recent evidence and claims.",
+    "backToSummary": "Back to summary",
+    "mockDataBanner": "Dashboard figures are mock protocol data until live account indexing is connected."
+  },
+  "settings": {
+    "title": "Settings",
+    "appearance": {
+      "heading": "Appearance",
+      "description": "Controls for theme and visual preferences.",
+      "theme": "Theme",
+      "light": "Light",
+      "dark": "Dark",
+      "system": "System",
+      "quickToggle": "Quick toggle",
+      "quickToggleHint": "Use the quick toggle to flip light/dark immediately. Theme radio buttons above apply on Save."
+    },
+    "network": {
+      "heading": "Network",
+      "description": "Choose the Stellar network to interact with.",
+      "stellarNetwork": "Stellar Network",
+      "public": "Public (Mainnet)",
+      "test": "Test (Testnet)"
+    },
+    "display": {
+      "heading": "Display",
+      "description": "How addresses and identifiers are presented in the UI.",
+      "addressFormat": "Address format",
+      "full": "Full (G...)",
+      "short": "Short (G...…)",
+      "friendly": "Friendly (when available)"
+    },
+    "notifications": {
+      "heading": "Notifications",
+      "description": "Control toast and notification behavior.",
+      "enableToasts": "Enable toasts",
+      "autoDismissDuration": "Auto-dismiss duration",
+      "off": "Off (require manual dismiss)",
+      "3seconds": "3 seconds",
+      "5seconds": "5 seconds",
+      "8seconds": "8 seconds",
+      "preview": "Preview",
+      "showPreview": "Show preview",
+      "previewHint": "Preview respects current toast settings."
+    },
+    "backup": {
+      "heading": "Backup & Restore",
+      "description": "Export your settings as a JSON file, or import settings from a previous export.",
+      "exportSettings": "Export settings",
+      "importSettings": "Import settings",
+      "invalidFile": "Invalid settings file",
+      "clearError": "Clear error"
+    },
+    "actions": {
+      "save": "Save",
+      "saved": "Saved",
+      "cancel": "Cancel"
+    },
+    "importDialog": {
+      "title": "Import Settings",
+      "subtitle": "Review the changes below before applying.",
+      "noChanges": "Imported settings match your current settings. No changes will be made.",
+      "changesIntro": "The following settings from {{file}} will be applied:",
+      "setting": "Setting",
+      "current": "Current",
+      "imported": "Imported",
+      "confirmHint": "This will overwrite your current settings with the imported values.",
+      "confirmLabel": "Import settings"
+    },
+    "toasts": {
+      "saved": "Settings saved successfully",
+      "reverted": "Settings reverted to last saved state",
+      "exported": "Settings exported successfully",
+      "imported": "Settings imported successfully",
+      "importCancelled": "Import cancelled"
+    }
+  },
+  "bond": {
+    "title": "Bond USDC",
+    "description": "Lock USDC into the Credence contract to build your economic reputation.",
+    "infoBanner": "Bonds are locked for a minimum of 30 days. Early withdrawal incurs a slash penalty.",
+    "connectRequired": "Connect wallet required",
+    "connectRequiredDescription": "Create bond and withdraw actions require a connected Stellar wallet.",
+    "networkMismatch": "Network mismatch",
+    "networkMismatchDescription": "Credence is set to {{expected}}, but Freighter is on {{actual}}. Switch the app to the wallet network before creating or withdrawing a bond.",
+    "switchNetwork": "Switch app to {{network}}",
+    "slashExposure": "Slash exposure on early withdrawal",
+    "slashExposureDescription": "Withdrawing {{amount}} while {{status}} may slash up to {{penaltyAmount}} ({{percent}}% penalty). You would receive approximately {{result}}.",
+    "createNewBond": "Create New Bond",
+    "createBondDescription": "Lock USDC using the guided four-step wizard — set an amount, choose a lock duration, review slash terms, and confirm.",
+    "amount": "Amount (USDC)",
+    "minimumAmount": "Minimum: {{amount}} USDC",
+    "createBond": "Create bond",
+    "connectToContinue": "Connect wallet to continue",
+    "activeBonds": "Active Bonds",
+    "noActiveBonds": "No active bonds",
+    "noActiveBondsDescription": "You do not have any active bonds yet. Create your first bond to start building on-chain reputation.",
+    "createFirstBond": "Create your first bond",
+    "hidePenalty": "Hide penalty",
+    "showPenalty": "Show penalty",
+    "withdraw": "Withdraw",
+    "connectToWithdraw": "Connect wallet to withdraw",
+    "bondAmount": "Bond amount",
+    "penalty": "Penalty ({{percent}}%)",
+    "youReceive": "You receive",
+    "noEarlyWithdrawalPenalty": "No early-withdrawal penalty",
+    "confirmWithdrawal": "Confirm bond withdrawal",
+    "withdrawalSubtitle": "You are withdrawing bond #{{id}} ({{amount}}).",
+    "disclaimerContext": "Bonding USDC locks funds in a non-custodial smart contract. Slashing conditions apply."
+  },
+  "trustScore": {
+    "title": "Trust Score",
+    "description": "Your reputation score is computed from bond amount, duration, and attestations.",
+    "infoBanner": "Scores update once per epoch. Recent bond changes may not be reflected immediately.",
+    "connectRequired": "Connect wallet required",
+    "connectRequiredDescription": "Connect a wallet to look up your own trust score. You can still type another Stellar address for review.",
+    "networkMismatch": "Network mismatch",
+    "networkMismatchDescription": "Credence is set to {{expected}}, but Freighter is on {{actual}}. Switch the app to the wallet network before looking up a trust score.",
+    "switchNetwork": "Switch app to {{network}}",
+    "results": "Trust score results",
+    "loading": "Loading trust score…",
+    "unableToLoad": "Unable to load trust score",
+    "tryAgain": "Try again",
+    "lookupIdentity": "Lookup Identity",
+    "stellarAddress": "Stellar Address",
+    "useMyAddress": "Use my address",
+    "lookup": "Look up score",
+    "connectToContinue": "Connect wallet to continue",
+    "disclaimerContext": "Trust scores are protocol metrics only and do not constitute creditworthiness assessments."
+  },
+  "attestations": {
+    "title": "Attestations",
+    "description": "Submit cryptographic evidence and vouches to build your economic trust score.",
+    "submitForm": "Submit Attestation Form",
+    "timeline": "Activity Timeline",
+    "filterLabel": "Filter attestations by status",
+    "filter": {
+      "all": "All statuses",
+      "success": "Accepted / Submitted",
+      "warning": "Needs update",
+      "info": "In review"
+    }
+  },
+  "transactions": {
+    "title": "Transaction History",
+    "description": "A durable record of your bond, withdrawal, and attestation events.",
+    "loading": "Loading transactions…",
+    "unableToLoad": "Unable to load transactions",
+    "tryAgain": "Try again",
+    "noTransactions": "No transactions yet",
+    "noTransactionsDescription": "Your bond, withdrawal, and attestation events will appear here once you start transacting.",
+    "filterLabel": "Status",
+    "filterAriaLabel": "Filter by status",
+    "noResults": "No {{filter}} transactions. Try a different filter.",
+    "table": {
+      "type": "Type",
+      "amount": "Amount",
+      "status": "Status",
+      "when": "When",
+      "transaction": "Transaction",
+      "viewOnExplorer": "View transaction {{hash}} on Stellar explorer",
+      "viewLink": "View ↗"
+    },
+    "status": {
+      "all": "All",
+      "pending": "Pending",
+      "confirmed": "Confirmed",
+      "failed": "Failed"
+    },
+    "relativeTime": {
+      "justNow": "just now",
+      "minutesAgo": "{{count}}m ago",
+      "hoursAgo": "{{count}}h ago",
+      "daysAgo": "{{count}}d ago"
+    }
+  },
+  "common": {
+    "loading": "Loading...",
+    "connectWallet": "Connect wallet",
+    "confirm": "Confirm",
+    "cancel": "Cancel",
+    "save": "Save",
+    "close": "Close",
+    "dismiss": "Dismiss",
+    "tryAgain": "Try again",
+    "back": "Back",
+    "next": "Next",
+    "previous": "Previous",
+    "submit": "Submit",
+    "delete": "Delete",
+    "edit": "Edit",
+    "view": "View",
+    "copy": "Copy",
+    "copied": "Copied!"
+  },
+  "banner": {
+    "severity": {
+      "info": "Information",
+      "success": "Success",
+      "warning": "Warning",
+      "critical": "Critical"
+    },
+    "dismiss": "Dismiss banner"
+  },
+  "confirmDialog": {
+    "defaultConfirmPhrase": "CONFIRM",
+    "defaultConfirmHint": "This action cannot be undone. Funds will be sent to your connected wallet.",
+    "typeToConfirm": "Type <strong>{{phrase}}</strong> to enable {{action}}",
+    "confirmHint": "This will overwrite your current settings with the imported values.",
+    "breakdown": {
+      "bondAmount": "Bond amount",
+      "slashPenalty": "Slash penalty ({{percent}}%)",
+      "youReceive": "You receive"
+    },
+    "announcements": {
+      "actionEnabled": "Action enabled. Type {{phrase}} to confirm.",
+      "actionDisabled": "Action disabled. Type {{phrase}} to enable."
+    }
+  },
+  "activityTimeline": {
+    "identityAttestation": "Identity Attestation",
+    "peerVouch": "Peer Vouch",
+    "credentialCertification": "Credential Certification",
+    "submitted": "Submitted",
+    "subject": "Subject: {{subject}}"
+  },
+  "badge": {
+    "variants": {
+      "active": "Active",
+      "locked": "Locked",
+      "slashed": "Slashed",
+      "gold": "Gold",
+      "silver": "Silver",
+      "bronze": "Bronze"
+    }
+  },
+  "errors": {
+    "network": "Network error",
+    "backend": "Backend error",
+    "validation": "Validation error",
+    "generic": "An error occurred"
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
 import ErrorBoundary from './components/ErrorBoundary'
+import './i18n/config'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(

--- a/src/pages/Attestations.tsx
+++ b/src/pages/Attestations.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import AttestationForm from '../components/AttestationForm'
 import ActivityTimeline, { ACTIVITY_ITEMS, ActivityItem } from '../components/ActivityTimeline'
 import Select from '../components/controls/Select'
 
 export default function Attestations() {
+  const { t } = useTranslation()
   const [items, setItems] = useState<ActivityItem[]>(ACTIVITY_ITEMS)
   const [filterTone, setFilterTone] = useState<string>('all')
 
@@ -23,15 +25,15 @@ export default function Attestations() {
       id: `evt-new-${items.length + 1}`,
       timestamp: formatTimestamp(),
       title: payload.type === 'identity' 
-        ? 'Identity Attestation' 
+        ? t('activityTimeline.identityAttestation') 
         : payload.type === 'peer-vouch' 
-          ? 'Peer Vouch' 
-          : 'Credential Certification',
+          ? t('activityTimeline.peerVouch') 
+          : t('activityTimeline.credentialCertification'),
       description: payload.evidence,
       actor: 'Current User',
-      statusLabel: 'Submitted',
+      statusLabel: t('activityTimeline.submitted'),
       tone: 'success',
-      meta: `Subject: ${payload.subject.substring(0, 8)}...`,
+      meta: t('activityTimeline.subject', { subject: payload.subject.substring(0, 8) }),
     }
 
     setItems((prev) => [newItem, ...prev])
@@ -43,10 +45,10 @@ export default function Attestations() {
   })
 
   const filterOptions = [
-    { value: 'all', label: 'All statuses' },
-    { value: 'success', label: 'Accepted / Submitted' },
-    { value: 'warning', label: 'Needs update' },
-    { value: 'info', label: 'In review' },
+    { value: 'all', label: t('attestations.filter.all') },
+    { value: 'success', label: t('attestations.filter.success') },
+    { value: 'warning', label: t('attestations.filter.warning') },
+    { value: 'info', label: t('attestations.filter.info') },
   ]
 
   return (
@@ -59,9 +61,9 @@ export default function Attestations() {
       }}
     >
       <header>
-        <h1 style={{ marginTop: 0, color: 'var(--credence-text-primary)' }}>Attestations</h1>
+        <h1 style={{ marginTop: 0, color: 'var(--credence-text-primary)' }}>{t('attestations.title')}</h1>
         <p style={{ color: 'var(--credence-text-secondary)', margin: 0 }}>
-          Submit cryptographic evidence and vouches to build your economic trust score.
+          {t('attestations.description')}
         </p>
       </header>
 
@@ -75,7 +77,7 @@ export default function Attestations() {
       >
         <section aria-labelledby="form-heading">
           <h2 id="form-heading" className="sr-only">
-            Submit Attestation Form
+            {t('attestations.submitForm')}
           </h2>
           <AttestationForm onSubmitSuccess={handleSubmitSuccess} />
         </section>
@@ -85,7 +87,7 @@ export default function Attestations() {
             <div style={{ width: '200px' }}>
               <Select
                 id="attestation-filter"
-                ariaLabel="Filter attestations by status"
+                ariaLabel={t('attestations.filterLabel')}
                 value={filterTone}
                 onChange={setFilterTone}
                 options={filterOptions}

--- a/src/pages/Bond.tsx
+++ b/src/pages/Bond.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useCallback, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import './Bond.css'
 import Banner from '../components/Banner'
 import Disclaimer from '../components/Disclaimer'
@@ -15,11 +16,6 @@ import { useWallet } from '../context/WalletContext'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useNetworkMismatch } from '../hooks/useNetworkMismatch'
 import { formatUsdc } from '../lib/format'
-import {
-  type MockBond,
-  getPenaltyRate,
-  computeWithdrawBreakdown,
-} from '../lib/bondPenalty'
 
 const ConfirmDialog = lazy(() => import('../components/ConfirmDialog'))
 
@@ -48,9 +44,10 @@ interface BondRowProps {
   isConnected: boolean
   onWithdraw: (bond: MockBond, event: React.MouseEvent<HTMLButtonElement>) => void
   onConnect: () => void
+  t: (key: string, params?: Record<string, unknown>) => string
 }
 
-function BondRow({ bond, isConnected, onWithdraw, onConnect }: BondRowProps) {
+function BondRow({ bond, isConnected, onWithdraw, onConnect, t }: BondRowProps) {
   const [open, setOpen] = useState(false)
   const panelId = `slash-detail-${bond.id}`
   const penaltyRate = getPenaltyRate(bond.status)
@@ -73,7 +70,7 @@ function BondRow({ bond, isConnected, onWithdraw, onConnect }: BondRowProps) {
               onClick={() => setOpen((v) => !v)}
               className="bond__penaltyToggle"
             >
-              {open ? 'Hide penalty' : 'Show penalty'}
+              {open ? t('bond.hidePenalty') : t('bond.showPenalty')}
             </button>
           )}
           <Button
@@ -82,7 +79,7 @@ function BondRow({ bond, isConnected, onWithdraw, onConnect }: BondRowProps) {
             onClick={isConnected ? (event) => onWithdraw(bond, event) : onConnect}
             aria-haspopup={isConnected ? 'dialog' : undefined}
           >
-            {isConnected ? 'Withdraw' : 'Connect wallet to withdraw'}
+            {isConnected ? t('bond.withdraw') : t('bond.connectToWithdraw')}
           </Button>
         </div>
       </div>
@@ -97,21 +94,21 @@ function BondRow({ bond, isConnected, onWithdraw, onConnect }: BondRowProps) {
           style={{ display: open ? 'grid' : 'none' }}
         >
           <div className="bond__penaltyRow">
-            <span>Bond amount</span>
+            <span>{t('bond.bondAmount')}</span>
             <span>{breakdown.bondAmount}</span>
           </div>
           <div className="bond__penaltyRow">
-            <span>Penalty ({breakdown.penaltyPercent}%)</span>
+            <span>{t('bond.penalty', { percent: breakdown.penaltyPercent })}</span>
             <span>− {breakdown.penaltyAmount}</span>
           </div>
           <div className="bond__penaltyRowTotal">
-            <span>You receive</span>
+            <span>{t('bond.youReceive')}</span>
             <span>{breakdown.resultingBalance}</span>
           </div>
         </div>
       ) : (
         <p id={panelId} className="bond__noPenaltyNotice">
-          No early-withdrawal penalty
+          {t('bond.noEarlyWithdrawalPenalty')}
         </p>
       )}
     </li>
@@ -119,7 +116,8 @@ function BondRow({ bond, isConnected, onWithdraw, onConnect }: BondRowProps) {
 }
 
 export default function Bond() {
-  useDocumentTitle('Bond')
+  const { t } = useTranslation()
+  useDocumentTitle(t('bond.title'))
 
   const navigate = useNavigate()
   const { addToast } = useToast()
@@ -169,15 +167,13 @@ export default function Bond() {
     if (!withdrawTarget || !withdrawBreakdown) return
 
     const { penaltyUsdc } = withdrawBreakdown
-    const mockHash = 'b6d396a84d41bf162d05f32a51f8a846b0a6fb2abccedb441f71f11e9f1a2380'
     if (penaltyUsdc > 0) {
       addToast(
         'warning',
-        `Bond withdrawn. ${formatUsdc(penaltyUsdc)} was slashed per early withdrawal policy.`,
-        { txHash: mockHash }
+        `Bond withdrawn. ${formatUsdc(penaltyUsdc)} was slashed per early withdrawal policy.`
       )
     } else {
-      addToast('success', 'Bond withdrawn successfully.', { txHash: mockHash })
+      addToast('success', 'Bond withdrawn successfully.')
     }
     setWithdrawTarget(null)
   }, [withdrawTarget, withdrawBreakdown, addToast])
@@ -192,64 +188,66 @@ export default function Bond() {
   return (
     <div className="bond__container">
       <div className="bond__headerSection">
-        <h1 className="bond__title">Bond USDC</h1>
+        <h1 className="bond__title">{t('bond.title')}</h1>
         <p id="bond-desc" className="bond__description">
-          Lock USDC into the Credence contract to build your economic reputation.
+          {t('bond.description')}
         </p>
       </div>
 
       <Banner severity="info">
-        Bonds are locked for a minimum of 30 days. Early withdrawal incurs a slash penalty.
+        {t('bond.infoBanner')}
       </Banner>
 
       {!isConnected && (
         <Banner
           severity="warning"
-          title="Connect wallet required"
-          action={{ label: 'Connect wallet', onClick: connect }}
+          title={t('bond.connectRequired')}
+          action={{ label: t('common.connectWallet'), onClick: connect }}
         >
-          Create bond and withdraw actions require a connected Stellar wallet.
+          {t('bond.connectRequiredDescription')}
         </Banner>
       )}
 
       {networkMismatch.mismatch && (
         <Banner
           severity="warning"
-          title="Network mismatch"
+          title={t('bond.networkMismatch')}
           action={{
-            label: `Switch app to ${networkMismatch.actual}`,
+            label: t('bond.switchNetwork', { network: networkMismatch.actual }),
             onClick: () => setNetwork(walletNetwork === 'test' ? 'test' : 'public'),
           }}
         >
           <span id={mismatchBannerId}>
-            Credence is set to <strong>{networkMismatch.expected}</strong>, but Freighter is on{' '}
-            <strong>{networkMismatch.actual}</strong>. Switch the app to the wallet network before
-            creating or withdrawing a bond.
+            {t('bond.networkMismatchDescription', {
+              expected: networkMismatch.expected,
+              actual: networkMismatch.actual
+            })}
           </span>
         </Banner>
       )}
 
       {slashBannerBreakdown && slashExposureBond && (
-        <Banner severity="warning" title="Slash exposure on early withdrawal">
-          Withdrawing {formatUsdc(slashExposureBond.amountUsdc)} while{' '}
-          <strong>{slashExposureBond.status === 'locked' ? 'locked' : 'in grace period'}</strong>{' '}
-          may slash up to {slashBannerBreakdown.penaltyAmount} (
-          {slashBannerBreakdown.penaltyPercent}% penalty). You would receive approximately{' '}
-          {slashBannerBreakdown.resultingBalance}.
+        <Banner severity="warning" title={t('bond.slashExposure')}>
+          {t('bond.slashExposureDescription', {
+            amount: formatUsdc(slashExposureBond.amountUsdc),
+            status: slashExposureBond.status === 'locked' ? 'locked' : 'in grace period',
+            penaltyAmount: slashBannerBreakdown.penaltyAmount,
+            percent: slashBannerBreakdown.penaltyPercent,
+            result: slashBannerBreakdown.resultingBalance
+          })}
         </Banner>
       )}
 
       <div className="bond__cardGrid">
-        <ActionCard title="Create New Bond">
+        <ActionCard title={t('bond.createNewBond')}>
           <p style={{ color: 'var(--credence-text-secondary)', margin: 0 }}>
-            Lock USDC using the guided four-step wizard — set an amount, choose a lock duration,
-            review slash terms, and confirm.
+            {t('bond.createBondDescription')}
           </p>
 
           <FormField
             id="bond-amount-quick"
-            label="Amount (USDC)"
-            hint={`Minimum: ${MIN_BOND_AMOUNT} USDC`}
+            label={t('bond.amount')}
+            hint={t('bond.minimumAmount', { amount: MIN_BOND_AMOUNT })}
             error={bondAmountError}
           >
             <AmountInput
@@ -274,18 +272,18 @@ export default function Bond() {
             disabled={networkMismatch.mismatch}
             aria-describedby={networkMismatch.mismatch ? mismatchBannerId : undefined}
           >
-            {isConnected ? 'Create bond' : 'Connect wallet to continue'}
+            {isConnected ? t('bond.createBond') : t('bond.connectToContinue')}
           </Button>
         </ActionCard>
 
-        <ActionCard title="Active Bonds">
+        <ActionCard title={t('bond.activeBonds')}>
           {bonds.length === 0 ? (
             <EmptyState
               illustration="bond"
-              title="No active bonds"
-              description="You do not have any active bonds yet. Create your first bond to start building on-chain reputation."
+              title={t('bond.noActiveBonds')}
+              description={t('bond.noActiveBondsDescription')}
               action={{
-                label: 'Create your first bond',
+                label: t('bond.createFirstBond'),
                 onClick: handleCreateBond,
               }}
             />
@@ -298,6 +296,7 @@ export default function Bond() {
                   isConnected={isConnected}
                   onWithdraw={requestWithdraw}
                   onConnect={connect}
+                  t={t}
                 />
               ))}
             </ul>
@@ -309,8 +308,11 @@ export default function Bond() {
         <Suspense fallback={null}>
           <ConfirmDialog
             open
-            title="Confirm bond withdrawal"
-            subtitle={`You are withdrawing bond #${withdrawTarget.id} (${formatUsdc(withdrawTarget.amountUsdc)}).`}
+            title={t('bond.confirmWithdrawal')}
+            subtitle={t('bond.withdrawalSubtitle', {
+              id: withdrawTarget.id,
+              amount: formatUsdc(withdrawTarget.amountUsdc)
+            })}
             breakdown={withdrawBreakdown}
             onConfirm={confirmWithdraw}
             onCancel={cancelWithdraw}
@@ -320,7 +322,7 @@ export default function Bond() {
       )}
 
       <Disclaimer
-        context="Bonding USDC locks funds in a non-custodial smart contract. Slashing conditions apply."
+        context={t('bond.disclaimerContext')}
         termsHref="#"
       />
     </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import ActionCard from '../components/ActionCard'
 import ActivityTimeline from '../components/ActivityTimeline'
 import Badge from '../components/Badge'
@@ -19,22 +20,24 @@ const activeBonds = [
   { id: 'bond-002', amountUsdc: 1750, status: 'locked', unlockLabel: 'Jun 14, 2026' },
 ] as const
 
-const shortcuts = [
-  { to: '/bond', label: 'Create bond', description: 'Lock more USDC into reputation bonds.' },
-  {
-    to: '/trust',
-    label: 'View trust score',
-    description: 'Look up score details and tier context.',
-  },
-  {
-    to: '/attestations',
-    label: 'Review attestations',
-    description: 'Open recent evidence and claims.',
-  },
-]
 
 export default function Dashboard() {
-  useDocumentTitle('Dashboard')
+  const { t } = useTranslation()
+  useDocumentTitle(t('dashboard.title'))
+
+  const shortcuts = [
+    { to: '/bond', label: t('dashboard.createBond'), description: t('dashboard.createBondDescription') },
+    {
+      to: '/trust',
+      label: t('dashboard.viewTrustScore'),
+      description: t('dashboard.viewTrustScoreDescription'),
+    },
+    {
+      to: '/attestations',
+      label: t('dashboard.reviewAttestations'),
+      description: t('dashboard.reviewAttestationsDescription'),
+    },
+  ]
 
   const { address, connected, connect, isConnecting } = useWallet()
   const totalBonded = activeBonds.reduce((total, bond) => total + bond.amountUsdc, 0)
@@ -43,14 +46,14 @@ export default function Dashboard() {
     <div className="dashboard">
       <header className="dashboard__header">
         <div>
-          <h1 className="dashboard__title">Dashboard</h1>
+          <h1 className="dashboard__title">{t('dashboard.title')}</h1>
           <p className="dashboard__description">
-            Monitor trust score, active bonds, and recent protocol activity from one place.
+            {t('dashboard.description')}
           </p>
         </div>
         {connected && address && (
           <div className="dashboard__wallet" aria-label="Connected wallet">
-            <span className="dashboard__walletLabel">Wallet</span>
+            <span className="dashboard__walletLabel">{t('dashboard.wallet')}</span>
             <code className="dashboard__walletAddress">
               {address.slice(0, 8)}...{address.slice(-6)}
             </code>
@@ -65,13 +68,13 @@ export default function Dashboard() {
       )}
 
       {!connected && !isConnecting && (
-        <ActionCard title="Connect wallet to view dashboard">
+        <ActionCard title={t('dashboard.connectWalletToView')}>
           <EmptyState
             illustration="trust"
-            title="Wallet required"
-            description="Connect Freighter to load your trust score, active bonds, and recent activity."
+            title={t('dashboard.walletRequired')}
+            description={t('dashboard.connectFreighter')}
             action={{
-              label: 'Connect wallet',
+              label: t('dashboard.connectWallet'),
               onClick: connect,
             }}
           />
@@ -81,13 +84,13 @@ export default function Dashboard() {
       {connected && !isConnecting && (
         <>
           <div className="dashboard__grid">
-            <ActionCard title="Trust Score">
+            <ActionCard title={t('dashboard.trustScore')}>
               <div className="dashboard__cardHeader">
                 <div>
                   <p className="dashboard__metric">{TRUST_SCORE}</p>
-                  <p className="dashboard__metricLabel">Current score</p>
+                  <p className="dashboard__metricLabel">{t('dashboard.currentScore')}</p>
                 </div>
-                <Badge variant={TRUST_TIER} label="Gold Tier" />
+                <Badge variant={TRUST_TIER} label={t('dashboard.goldTier')} />
               </div>
               <TrustGauge
                 score={TRUST_SCORE}
@@ -97,11 +100,11 @@ export default function Dashboard() {
               />
             </ActionCard>
 
-            <ActionCard title="Active Bonds">
+            <ActionCard title={t('dashboard.activeBonds')}>
               <div className="dashboard__cardHeader">
                 <div>
                   <p className="dashboard__metric">{formatUsdc(totalBonded)}</p>
-                  <p className="dashboard__metricLabel">{activeBonds.length} active bonds</p>
+                  <p className="dashboard__metricLabel">{t('dashboard.activeBondsCount', { count: activeBonds.length })}</p>
                 </div>
                 <Badge variant="active" />
               </div>
@@ -110,7 +113,7 @@ export default function Dashboard() {
                   <li className="dashboard__bondRow" key={bond.id}>
                     <div>
                       <p className="dashboard__bondAmount">{formatUsdc(bond.amountUsdc)}</p>
-                      <p className="dashboard__bondMeta">Unlocks {bond.unlockLabel}</p>
+                      <p className="dashboard__bondMeta">{t('dashboard.unlocks', { date: bond.unlockLabel })}</p>
                     </div>
                     <Badge variant={bond.status} />
                   </li>
@@ -120,11 +123,11 @@ export default function Dashboard() {
           </div>
 
           <div className="dashboard__grid dashboard__grid--activity">
-            <ActionCard title="Recent Activity">
+            <ActionCard title={t('dashboard.recentActivity')}>
               <ActivityTimeline compact />
             </ActionCard>
 
-            <ActionCard title="Shortcuts">
+            <ActionCard title={t('dashboard.shortcuts')}>
               <div className="dashboard__shortcutList">
                 {shortcuts.map((shortcut) => (
                   <Link className="dashboard__shortcut" key={shortcut.to} to={shortcut.to}>
@@ -134,7 +137,7 @@ export default function Dashboard() {
                 ))}
               </div>
               <Button type="button" variant="secondary" onClick={() => window.scrollTo({ top: 0 })}>
-                Back to summary
+                {t('dashboard.backToSummary')}
               </Button>
             </ActionCard>
           </div>
@@ -143,7 +146,7 @@ export default function Dashboard() {
 
       {connected && (
         <Banner severity="info">
-          Dashboard figures are mock protocol data until live account indexing is connected.
+          {t('dashboard.mockDataBanner')}
         </Banner>
       )}
     </div>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useSettings } from '../context/SettingsContext'
 import ThemeToggle from '../components/ThemeToggle'
 import { useToast } from '../components/ToastProvider'
@@ -11,13 +12,6 @@ import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { validateAndNormalize, type SettingsBlob } from '../lib/settingsSchema'
 import './Settings.css'
 
-const FIELD_LABELS: Record<string, string> = {
-  themeMode: 'Theme',
-  network: 'Network',
-  addressDisplay: 'Address display',
-  toastsEnabled: 'Toasts enabled',
-  autoDismiss: 'Auto-dismiss',
-}
 
 function computeDiff(current: Omit<SettingsBlob, keyof unknown>, incoming: SettingsBlob): { key: string; from: string; to: string }[] {
   const diffs: { key: string; from: string; to: string }[] = []
@@ -31,6 +25,7 @@ function computeDiff(current: Omit<SettingsBlob, keyof unknown>, incoming: Setti
 }
 
 export default function Settings() {
+  const { t } = useTranslation()
   const {
     themeMode,
     setThemeMode,
@@ -46,7 +41,15 @@ export default function Settings() {
   } = useSettings()
   const { addToast } = useToast()
 
-  useDocumentTitle('Settings')
+  useDocumentTitle(t('settings.title'))
+
+  const FIELD_LABELS: Record<string, string> = {
+    themeMode: t('settings.appearance.theme'),
+    network: t('settings.network.heading'),
+    addressDisplay: t('settings.display.addressFormat'),
+    toastsEnabled: t('settings.notifications.enableToasts'),
+    autoDismiss: t('settings.notifications.autoDismissDuration'),
+  }
 
   const [draft, setDraft] = useState({
     themeMode: themeMode as 'light' | 'dark' | 'system',
@@ -82,13 +85,13 @@ export default function Settings() {
     setToastsEnabled(payload.toastsEnabled)
     setAutoDismiss(payload.autoDismiss)
     saveSettings()
-    addToast('success', 'Settings saved successfully')
+    addToast('success', t('settings.toasts.saved'))
   }
 
   const handleCancel = () => {
     if (isDirty) {
       const confirmed = window.confirm(
-        'You have unsaved changes. Are you sure you want to discard them?'
+        t('settings.actions.cancel')
       )
       if (!confirmed) return
     }
@@ -99,7 +102,7 @@ export default function Settings() {
       toastsEnabled,
       autoDismiss,
     })
-    addToast('info', 'Settings reverted to last saved state')
+    addToast('info', t('settings.toasts.reverted'))
   }
 
   useEffect(() => {
@@ -148,7 +151,7 @@ export default function Settings() {
     a.click()
     document.body.removeChild(a)
     URL.revokeObjectURL(url)
-    addToast('success', 'Settings exported successfully')
+    addToast('success', t('settings.toasts.exported'))
   }, [themeMode, network, addressDisplay, toastsEnabled, autoDismiss, addToast])
 
   const handleFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -163,7 +166,7 @@ export default function Settings() {
     reader.onload = (evt) => {
       const text = evt.target?.result
       if (typeof text !== 'string') {
-        setImportError('Failed to read file')
+        setImportError(t('settings.backup.invalidFile'))
         return
       }
 
@@ -171,7 +174,7 @@ export default function Settings() {
       try {
         parsed = JSON.parse(text)
       } catch {
-        setImportError('File does not contain valid JSON')
+        setImportError(t('settings.backup.invalidFile'))
         return
       }
 
@@ -185,7 +188,7 @@ export default function Settings() {
       setImportConfirmOpen(true)
     }
     reader.onerror = () => {
-      setImportError('Failed to read file')
+      setImportError(t('settings.backup.invalidFile'))
     }
     reader.readAsText(file)
   }, [])
@@ -199,13 +202,13 @@ export default function Settings() {
     setToastsEnabled(importPreview.toastsEnabled)
     setAutoDismiss(importPreview.autoDismiss)
     saveSettings()
-    addToast('success', 'Settings imported successfully')
+    addToast('success', t('settings.toasts.imported'))
     resetImportState()
   }, [importPreview, setThemeMode, setNetwork, setAddressDisplay, setToastsEnabled, setAutoDismiss, saveSettings, addToast, resetImportState])
 
   const handleImportCancel = useCallback(() => {
     resetImportState()
-    addToast('info', 'Import cancelled')
+    addToast('info', t('settings.toasts.importCancelled'))
   }, [resetImportState, addToast])
 
   const diffs = importPreview ? computeDiff(currentSettings, importPreview) : []
@@ -214,18 +217,18 @@ export default function Settings() {
     if (!importPreview) return null
 
     if (diffs.length === 0) {
-      return <p>Imported settings match your current settings. No changes will be made.</p>
+      return <p>{t('settings.importDialog.noChanges')}</p>
     }
 
     return (
       <div>
-        <p>The following settings from <strong>{importFileName || 'file'}</strong> will be applied:</p>
+        <p>{t('settings.importDialog.changesIntro', { file: importFileName || 'file' })}</p>
         <table style={{ marginTop: '0.75rem', borderCollapse: 'collapse', width: '100%' }}>
           <thead>
             <tr>
-              <th style={{ textAlign: 'left', padding: '0.25rem 0.5rem', borderBottom: '1px solid var(--border-default)' }}>Setting</th>
-              <th style={{ textAlign: 'left', padding: '0.25rem 0.5rem', borderBottom: '1px solid var(--border-default)' }}>Current</th>
-              <th style={{ textAlign: 'left', padding: '0.25rem 0.5rem', borderBottom: '1px solid var(--border-default)' }}>Imported</th>
+              <th style={{ textAlign: 'left', padding: '0.25rem 0.5rem', borderBottom: '1px solid var(--border-default)' }}>{t('settings.importDialog.setting')}</th>
+              <th style={{ textAlign: 'left', padding: '0.25rem 0.5rem', borderBottom: '1px solid var(--border-default)' }}>{t('settings.importDialog.current')}</th>
+              <th style={{ textAlign: 'left', padding: '0.25rem 0.5rem', borderBottom: '1px solid var(--border-default)' }}>{t('settings.importDialog.imported')}</th>
             </tr>
           </thead>
           <tbody>
@@ -244,13 +247,13 @@ export default function Settings() {
 
   return (
     <div className="settings-page">
-      <h1 style={{ marginTop: 0 }}>Settings</h1>
+      <h1 style={{ marginTop: 0 }}>{t('settings.title')}</h1>
 
       <section className="settings-section" aria-labelledby="appearance-heading">
-        <h2 id="appearance-heading">Appearance</h2>
-        <p className="form-hint">Controls for theme and visual preferences.</p>
+        <h2 id="appearance-heading">{t('settings.appearance.heading')}</h2>
+        <p className="form-hint">{t('settings.appearance.description')}</p>
 
-        <FormField id="theme-seg" label="Theme">
+        <FormField id="theme-seg" label={t('settings.appearance.theme')}>
           <div role="radiogroup" aria-label="Theme mode" style={{ display: 'flex', gap: '0.5rem' }}>
             <label>
               <input
@@ -259,7 +262,7 @@ export default function Settings() {
                 checked={themeMode === 'light'}
                 onChange={() => setThemeMode('light')}
               />{' '}
-              Light
+              {t('settings.appearance.light')}
             </label>
             <label>
               <input
@@ -268,7 +271,7 @@ export default function Settings() {
                 checked={themeMode === 'dark'}
                 onChange={() => setThemeMode('dark')}
               />{' '}
-              Dark
+              {t('settings.appearance.dark')}
             </label>
             <label>
               <input
@@ -277,45 +280,44 @@ export default function Settings() {
                 checked={themeMode === 'system'}
                 onChange={() => setThemeMode('system')}
               />{' '}
-              System
+              {t('settings.appearance.system')}
             </label>
           </div>
         </FormField>
 
-        <FormField id="theme-toggle" label="Quick toggle">
+        <FormField id="theme-toggle" label={t('settings.appearance.quickToggle')}>
           <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
             <ThemeToggle />
             <span className="form-hint">
-              Use the quick toggle to flip light/dark immediately. Theme radio buttons above apply
-              on Save.
+              {t('settings.appearance.quickToggleHint')}
             </span>
           </div>
         </FormField>
       </section>
 
       <section className="settings-section" aria-labelledby="network-heading">
-        <h2 id="network-heading">Network</h2>
-        <p className="form-hint">Choose the Stellar network to interact with.</p>
+        <h2 id="network-heading">{t('settings.network.heading')}</h2>
+        <p className="form-hint">{t('settings.network.description')}</p>
 
-        <FormField id="network-select" label="Stellar Network">
+        <FormField id="network-select" label={t('settings.network.stellarNetwork')}>
           <Select
             value={network}
             onChange={setNetwork}
             options={[
-              { value: 'public', label: 'Public (Mainnet)' },
-              { value: 'test', label: 'Test (Testnet)' },
+              { value: 'public', label: t('settings.network.public') },
+              { value: 'test', label: t('settings.network.test') },
             ]}
           />
         </FormField>
       </section>
 
       <section className="settings-section" aria-labelledby="display-heading">
-        <h2 id="display-heading">Display</h2>
-        <p className="form-hint">How addresses and identifiers are presented in the UI.</p>
+        <h2 id="display-heading">{t('settings.display.heading')}</h2>
+        <p className="form-hint">{t('settings.display.description')}</p>
 
         <fieldset style={{ border: 'none', padding: 0 }}>
-          <legend className="sr-only">Address display format</legend>
-          <FormField id="address-display" label="Address format">
+          <legend className="sr-only">{t('settings.display.addressFormat')}</legend>
+          <FormField id="address-display" label={t('settings.display.addressFormat')}>
             <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center' }}>
               <label>
                 <input
@@ -324,7 +326,7 @@ export default function Settings() {
                   checked={addressDisplay === 'full'}
                   onChange={() => setAddressDisplay('full')}
                 />{' '}
-                Full (G...)
+                {t('settings.display.full')}
               </label>
               <label>
                 <input
@@ -333,7 +335,7 @@ export default function Settings() {
                   checked={addressDisplay === 'short'}
                   onChange={() => setAddressDisplay('short')}
                 />{' '}
-                Short (G...…)
+                {t('settings.display.short')}
               </label>
               <label>
                 <input
@@ -342,7 +344,7 @@ export default function Settings() {
                   checked={addressDisplay === 'friendly'}
                   onChange={() => setAddressDisplay('friendly')}
                 />{' '}
-                Friendly (when available)
+                {t('settings.display.friendly')}
               </label>
             </div>
           </FormField>
@@ -350,57 +352,57 @@ export default function Settings() {
       </section>
 
       <section className="settings-section" aria-labelledby="notifications-heading">
-        <h2 id="notifications-heading">Notifications</h2>
-        <p className="form-hint">Control toast and notification behavior.</p>
+        <h2 id="notifications-heading">{t('settings.notifications.heading')}</h2>
+        <p className="form-hint">{t('settings.notifications.description')}</p>
 
-        <FormField id="toasts-enabled" label="Enable toasts">
+        <FormField id="toasts-enabled" label={t('settings.notifications.enableToasts')}>
           <Toggle
             checked={draft.toastsEnabled}
             onChange={(v) => updateDraft('toastsEnabled', v)}
-            ariaLabel="Enable toasts"
+            ariaLabel={t('settings.notifications.enableToasts')}
           />
         </FormField>
 
-        <FormField id="auto-dismiss" label="Auto-dismiss duration">
+        <FormField id="auto-dismiss" label={t('settings.notifications.autoDismissDuration')}>
           <Select
             value={draft.autoDismiss}
             onChange={(v) => updateDraft('autoDismiss', v)}
             options={[
-              { value: 'off', label: 'Off (require manual dismiss)' },
-              { value: '3s', label: '3 seconds' },
-              { value: '5s', label: '5 seconds' },
-              { value: '8s', label: '8 seconds' },
+              { value: 'off', label: t('settings.notifications.off') },
+              { value: '3s', label: t('settings.notifications.3seconds') },
+              { value: '5s', label: t('settings.notifications.5seconds') },
+              { value: '8s', label: t('settings.notifications.8seconds') },
             ]}
           />
         </FormField>
 
-        <FormField id="toast-preview" label="Preview">
+        <FormField id="toast-preview" label={t('settings.notifications.preview')}>
           <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
             <button
               type="button"
               onClick={() => addToast('info', 'This is a preview notification')}
               style={{ padding: '0.5rem 0.75rem' }}
-              aria-label="Show preview toast"
+              aria-label={t('settings.notifications.showPreview')}
             >
-              Show preview
+              {t('settings.notifications.showPreview')}
             </button>
-            <span className="form-hint">Preview respects current toast settings.</span>
+            <span className="form-hint">{t('settings.notifications.previewHint')}</span>
           </div>
         </FormField>
       </section>
 
       <section className="settings-section" aria-labelledby="backup-heading">
-        <h2 id="backup-heading">Backup &amp; Restore</h2>
-        <p className="form-hint">Export your settings as a JSON file, or import settings from a previous export.</p>
+        <h2 id="backup-heading">{t('settings.backup.heading')}</h2>
+        <p className="form-hint">{t('settings.backup.description')}</p>
 
         <div className="settings-backup-row">
           <button
             type="button"
             onClick={handleExport}
             style={{ padding: '0.5rem 0.75rem' }}
-            aria-label="Export settings to JSON file"
+            aria-label={t('settings.backup.exportSettings')}
           >
-            Export settings
+            {t('settings.backup.exportSettings')}
           </button>
 
           <input
@@ -416,9 +418,9 @@ export default function Settings() {
             type="button"
             onClick={() => fileInputRef.current?.click()}
             style={{ padding: '0.5rem 0.75rem' }}
-            aria-label="Import settings from JSON file"
+            aria-label={t('settings.backup.importSettings')}
           >
-            Import settings
+            {t('settings.backup.importSettings')}
           </button>
         </div>
 
@@ -426,10 +428,10 @@ export default function Settings() {
           <div role="alert" style={{ marginTop: '0.75rem' }}>
             <ErrorState
               type="validation"
-              title="Invalid settings file"
+              title={t('settings.backup.invalidFile')}
               message={importError}
               action={{
-                label: 'Clear error',
+                label: t('settings.backup.clearError'),
                 onClick: resetImportState,
               }}
             />
@@ -445,21 +447,21 @@ export default function Settings() {
           aria-disabled={!isDirty}
           style={{ padding: '0.5rem 0.75rem' }}
         >
-          {isDirty ? 'Save' : 'Saved'}
+          {isDirty ? t('settings.actions.save') : t('settings.actions.saved')}
         </button>
         <button type="button" onClick={handleCancel} style={{ padding: '0.5rem 0.75rem' }}>
-          Cancel
+          {t('settings.actions.cancel')}
         </button>
       </div>
 
       <ConfirmDialog
         open={importConfirmOpen}
-        title="Import Settings"
-        subtitle={diffs.length > 0 ? 'Review the changes below before applying.' : undefined}
+        title={t('settings.importDialog.title')}
+        subtitle={diffs.length > 0 ? t('settings.importDialog.subtitle') : undefined}
         description={confirmDescription}
         confirmPhrase="IMPORT"
-        confirmHint="This will overwrite your current settings with the imported values."
-        confirmLabel="Import settings"
+        confirmHint={t('settings.importDialog.confirmHint')}
+        confirmLabel={t('settings.importDialog.confirmLabel')}
         onConfirm={handleImportConfirm}
         onCancel={handleImportCancel}
       />

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import './Transactions.css'
 import Badge from '../components/Badge'
 import Select from '../components/controls/Select'
@@ -12,12 +13,6 @@ import type { Transaction } from '../api/types'
 
 type StatusFilter = 'all' | 'pending' | 'confirmed' | 'failed'
 
-const STATUS_OPTIONS: { value: StatusFilter; label: string }[] = [
-  { value: 'all', label: 'All' },
-  { value: 'pending', label: 'Pending' },
-  { value: 'confirmed', label: 'Confirmed' },
-  { value: 'failed', label: 'Failed' },
-]
 
 const STATUS_BADGE_MAP: Record<Transaction['status'], string> = {
   pending: 'locked',
@@ -25,19 +20,28 @@ const STATUS_BADGE_MAP: Record<Transaction['status'], string> = {
   failed: 'slashed',
 }
 
-function relativeTime(isoTimestamp: string): string {
-  const diff = Date.now() - new Date(isoTimestamp).getTime()
-  const minutes = Math.floor(diff / 60_000)
-  if (minutes < 1) return 'just now'
-  if (minutes < 60) return `${minutes}m ago`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h ago`
-  const days = Math.floor(hours / 24)
-  return `${days}d ago`
-}
 
 export default function Transactions() {
-  useDocumentTitle('Transactions')
+  const { t } = useTranslation()
+  useDocumentTitle(t('transactions.title'))
+
+  const STATUS_OPTIONS: { value: StatusFilter; label: string }[] = [
+    { value: 'all', label: t('transactions.status.all') },
+    { value: 'pending', label: t('transactions.status.pending') },
+    { value: 'confirmed', label: t('transactions.status.confirmed') },
+    { value: 'failed', label: t('transactions.status.failed') },
+  ]
+
+  function relativeTime(isoTimestamp: string): string {
+    const diff = Date.now() - new Date(isoTimestamp).getTime()
+    const minutes = Math.floor(diff / 60_000)
+    if (minutes < 1) return t('transactions.relativeTime.justNow')
+    if (minutes < 60) return t('transactions.relativeTime.minutesAgo', { count: minutes })
+    const hours = Math.floor(minutes / 60)
+    if (hours < 24) return t('transactions.relativeTime.hoursAgo', { count: hours })
+    const days = Math.floor(hours / 24)
+    return t('transactions.relativeTime.daysAgo', { count: days })
+  }
 
   const { network } = useSettings()
   const { data, isLoading, error, refetch } = useTransactions()
@@ -53,15 +57,15 @@ export default function Transactions() {
   return (
     <div>
       <div className="transactions__header">
-        <h1 className="transactions__title">Transaction History</h1>
+        <h1 className="transactions__title">{t('transactions.title')}</h1>
       </div>
       <p className="transactions__description">
-        A durable record of your bond, withdrawal, and attestation events.
+        {t('transactions.description')}
       </p>
 
       {isLoading && (
         <div role="status" aria-live="polite" aria-busy="true" aria-label="Loading transactions">
-          <p className="sr-only">Loading transactions…</p>
+          <p className="sr-only">{t('transactions.loading')}</p>
           <LoadingSkeleton variant="table" rows={5} />
         </div>
       )}
@@ -70,9 +74,9 @@ export default function Transactions() {
         <div role="alert">
           <ErrorState
             type={error.status === 0 ? 'network' : error.status >= 500 ? 'backend' : 'generic'}
-            title="Unable to load transactions"
+            title={t('transactions.unableToLoad')}
             message={error.message}
-            action={{ label: 'Try again', onClick: refetch }}
+            action={{ label: t('common.tryAgain'), onClick: refetch }}
           />
         </div>
       )}
@@ -80,8 +84,8 @@ export default function Transactions() {
       {hasData && data.length === 0 && (
         <EmptyState
           illustration="activity"
-          title="No transactions yet"
-          description="Your bond, withdrawal, and attestation events will appear here once you start transacting."
+          title={t('transactions.noTransactions')}
+          description={t('transactions.noTransactionsDescription')}
         />
       )}
 
@@ -89,30 +93,30 @@ export default function Transactions() {
         <>
           <div className="transactions__filterRow">
             <label htmlFor="tx-status-filter" className="transactions__filterLabel">
-              Status
+              {t('transactions.filterLabel')}
             </label>
             <Select
               id="tx-status-filter"
               value={filter}
               onChange={(v) => setFilter(v as StatusFilter)}
               options={STATUS_OPTIONS}
-              ariaLabel="Filter by status"
+              ariaLabel={t('transactions.filterAriaLabel')}
             />
           </div>
 
           {filtered.length === 0 ? (
             <p className="transactions__noResults">
-              No {filter} transactions. Try a different filter.
+              {t('transactions.noResults', { filter })}
             </p>
           ) : (
             <table className="transactions__table" aria-label="Transaction history">
               <thead>
                 <tr>
-                  <th scope="col">Type</th>
-                  <th scope="col">Amount</th>
-                  <th scope="col">Status</th>
-                  <th scope="col">When</th>
-                  <th scope="col">Transaction</th>
+                  <th scope="col">{t('transactions.table.type')}</th>
+                  <th scope="col">{t('transactions.table.amount')}</th>
+                  <th scope="col">{t('transactions.table.status')}</th>
+                  <th scope="col">{t('transactions.table.when')}</th>
+                  <th scope="col">{t('transactions.table.transaction')}</th>
                 </tr>
               </thead>
               <tbody>
@@ -139,9 +143,9 @@ export default function Transactions() {
                         target="_blank"
                         rel="noopener noreferrer"
                         className="transactions__explorerLink"
-                        aria-label={`View transaction ${truncateAddress(tx.hash)} on Stellar explorer`}
+                        aria-label={t('transactions.table.viewOnExplorer', { hash: truncateAddress(tx.hash) })}
                       >
-                        View ↗
+                        {t('transactions.table.viewLink')}
                       </a>
                     </td>
                   </tr>

--- a/src/pages/TrustScore.tsx
+++ b/src/pages/TrustScore.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import './TrustScore.css'
 import Banner from '../components/Banner'
 import Disclaimer from '../components/Disclaimer'
@@ -9,8 +10,7 @@ import AddressInput from '../components/AddressInput'
 import TierLadder from '../components/TierLadder'
 import TrustGauge, { TIER_CONFIG } from '../components/TrustGauge'
 import ActivityTimeline, { ActivityItem } from '../components/ActivityTimeline'
-import { TIERS } from '../lib/tiers'
-import { EmptyState, ErrorState, LoadingSkeleton } from '../components/states'
+import { ErrorState, LoadingSkeleton } from '../components/states'
 import { useSettings } from '../context/SettingsContext'
 import { useWallet } from '../context/WalletContext'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
@@ -34,7 +34,8 @@ function trustScoreErrorType(error: ApiError): 'network' | 'backend' | 'validati
 }
 
 export default function TrustScore() {
-  useDocumentTitle('Trust Score')
+  const { t } = useTranslation()
+  useDocumentTitle(t('trustScore.title'))
 
   const { isConnected, address: walletAddress, connect, network: walletNetwork } = useWallet()
   const { setNetwork } = useSettings()
@@ -111,43 +112,43 @@ export default function TrustScore() {
   return (
     <div>
       <div className="trustScore__headerRow">
-        <h1 className="trustScore__title">Trust Score</h1>
+        <h1 className="trustScore__title">{t('trustScore.title')}</h1>
         {data && lookupAddress === address.trim() && (
           <Badge variant={data.tier} label={tierLabel} className="tier-badge" />
         )}
       </div>
       <p id="trust-desc" className="trustScore__description">
-        Your reputation score is computed from bond amount, duration, and attestations.
+        {t('trustScore.description')}
       </p>
       <TierLadder />
       <Banner severity="info">
-        Scores update once per epoch. Recent bond changes may not be reflected immediately.
+        {t('trustScore.infoBanner')}
       </Banner>
 
       {!isConnected && (
         <Banner
           severity="warning"
-          title="Connect wallet required"
-          action={{ label: 'Connect wallet', onClick: () => void connect() }}
+          title={t('trustScore.connectRequired')}
+          action={{ label: t('common.connectWallet'), onClick: () => void connect() }}
         >
-          Connect a wallet to look up your own trust score. You can still type another Stellar
-          address for review.
+          {t('trustScore.connectRequiredDescription')}
         </Banner>
       )}
 
       {networkMismatch.mismatch && (
         <Banner
           severity="warning"
-          title="Network mismatch"
+          title={t('trustScore.networkMismatch')}
           action={{
-            label: `Switch app to ${networkMismatch.actual}`,
+            label: t('trustScore.switchNetwork', { network: networkMismatch.actual }),
             onClick: () => setNetwork(walletNetwork === 'test' ? 'test' : 'public'),
           }}
         >
           <span id={mismatchBannerId}>
-            Credence is set to <strong>{networkMismatch.expected}</strong>, but Freighter is on{' '}
-            <strong>{networkMismatch.actual}</strong>. Switch the app to the wallet network before
-            looking up a trust score.
+            {t('trustScore.networkMismatchDescription', {
+              expected: networkMismatch.expected,
+              actual: networkMismatch.actual
+            })}
           </span>
         </Banner>
       )}
@@ -155,12 +156,12 @@ export default function TrustScore() {
       {hasAttemptedLookup && (
         <section aria-labelledby="trust-score-results-heading" className="trustScore__results">
           <h2 id="trust-score-results-heading" className="sr-only">
-            Trust score results
+            {t('trustScore.results')}
           </h2>
 
           {isLoading && (
             <div role="status" aria-live="polite" aria-busy="true" aria-label="Loading trust score">
-              <p className="sr-only">Loading trust score…</p>
+              <p className="sr-only">{t('trustScore.loading')}</p>
               <LoadingSkeleton variant="card" />
             </div>
           )}
@@ -169,9 +170,9 @@ export default function TrustScore() {
             <div role="alert">
               <ErrorState
                 type={trustScoreErrorType(error)}
-                title="Unable to load trust score"
+                title={t('trustScore.unableToLoad')}
                 message={error.message}
-                action={{ label: 'Try again', onClick: refetch }}
+                action={{ label: t('common.tryAgain'), onClick: refetch }}
               />
             </div>
           )}
@@ -189,10 +190,10 @@ export default function TrustScore() {
 
       <div className="trustScore__grid">
         <div className="trustScore__card">
-          <h2 className="trustScore__cardTitle">Lookup Identity</h2>
+          <h2 className="trustScore__cardTitle">{t('trustScore.lookupIdentity')}</h2>
           <AddressInput
             id="wallet-address"
-            label="Stellar Address"
+            label={t('trustScore.stellarAddress')}
             value={address}
             onChange={handleAddressChange}
             onValidationChange={setIsAddressValid}
@@ -206,7 +207,7 @@ export default function TrustScore() {
               fullWidth
               className="trustScore__buttonRow"
             >
-              Use my address
+              {t('trustScore.useMyAddress')}
             </Button>
           )}
           <Button
@@ -218,7 +219,7 @@ export default function TrustScore() {
             aria-describedby={networkMismatch.mismatch ? mismatchBannerId : undefined}
             className="trustScore__buttonRow"
           >
-            {isConnected ? 'Look up score' : 'Connect wallet to continue'}
+            {isConnected ? t('trustScore.lookup') : t('trustScore.connectToContinue')}
           </Button>
         </div>
 
@@ -228,7 +229,7 @@ export default function TrustScore() {
       </div>
 
       <Disclaimer
-        context="Trust scores are protocol metrics only and do not constitute creditworthiness assessments."
+        context={t('trustScore.disclaimerContext')}
         termsHref="#"
       />
     </div>


### PR DESCRIPTION
- Install i18next, react-i18next, and i18next-browser-languagedetector
- Create i18n configuration in src/i18n/config.ts
- Add English locale source file at src/i18n/locales/en.json
- Wrap all user-facing strings with t('...') translation function in:
  - Layout.tsx (navigation, footer, keyboard shortcuts)
  - Dashboard.tsx (dashboard UI)
  - Settings.tsx (settings page)
  - Bond.tsx (bond creation and withdrawal)
  - TrustScore.tsx (trust score lookup)
  - Attestations.tsx (attestation submission)
  - Transactions.tsx (transaction history)
  - ConfirmDialog.tsx (confirmation dialogs)
- Initialize i18n in main.tsx
- Add comprehensive English translations for all UI text

Closes #395 