### PR TITLE
feat(timeline): add expandable attestation evidence detail panel

### DIFF
--- a/ATTESTATION-EVIDENCE-DETAIL-PANEL.md
+++ b/ATTESTATION-EVIDENCE-DETAIL-PANEL.md
@@ -1,0 +1,116 @@
+# Attestation Evidence Detail Panel Implementation
+
+This document describes the implementation of the expandable attestation-evidence detail panel for the ActivityTimeline component.
+
+## Closes #451
+
+## Overview
+
+The ActivityTimeline component renders attestation/verification events as compact rows. This implementation adds an expandable detail panel that reveals full evidence information when a row is activated.
+
+## Implementation Details
+
+### Component Structure
+
+```
+ActivityTimeline
+├── ActivityItem[] (items prop)
+│   ├── id, timestamp, title, description, actor, statusLabel, tone, meta
+├── toneToBadgeVariant(tone) → BadgeVariant
+├── isTxHash(meta) → boolean
+└── Disclosure Pattern
+    ├── Button trigger (aria-expanded/aria-controls)
+    └── Detail panel (hidden attribute)
+        ├── Actor (text)
+        └── Meta (CopyableHash if tx hash, else plain text)
+```
+
+### Tone to Badge Variant Mapping
+
+| ActivityTone | BadgeVariant | Visual Meaning |
+|-------------|-------------|----------------|
+| success | active | Green state |
+| warning | grace-period | Amber warning |
+| info | locked | Blue informational |
+
+### Transaction Hash Detection
+
+Meta strings matching the pattern `/^Tx\s+0x/i` are rendered as CopyableHash components with copy-to-clipboard functionality. All other meta values render as plain text.
+
+## Accessibility Features
+
+### Disclosure Pattern
+
+The implementation follows the TierLadder disclosure pattern with:
+
+- **aria-expanded**: Toggle state on the disclosure button
+- **aria-controls**: References the panel ID
+- **hidden attribute**: Controls panel visibility
+
+### Keyboard Support
+
+| Key | Action |
+|-----|--------|
+| Enter | Toggles panel visibility |
+| Space | Toggles panel visibility |
+| Escape | Closes panel, returns focus to trigger |
+
+### Focus Management
+
+- On panel expansion: Trigger button retains focus
+- On Escape key: Panel closes and focus returns to trigger button
+- Focus indicator: 2px solid outline using `--credence-color-primary`
+
+## Reduced Motion Support
+
+The component respects `prefers-reduced-motion` via CSS:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .activity-row__detail-panel {
+    transition: none;
+  }
+}
+```
+
+Note: The current implementation uses the `hidden` attribute for instant show/hide behavior, which inherently respects reduced motion preferences.
+
+## Files Changed
+
+### New Files
+- `src/components/CopyableHash.tsx` - Reusable hash display with copy functionality
+- `src/components/CopyableHash.css` - Styles for CopyableHash
+
+### Modified Files
+- `src/components/ActivityTimeline.tsx` - Core implementation
+- `src/components/ActivityTimeline.css` - Panel and disclosure styles
+- `src/components/ActivityTimeline.test.tsx` - Test coverage
+
+## Test Coverage
+
+### Helper Functions
+- `toneToBadgeVariant` - Maps all three tone values to correct badge variants
+- `isTxHash` - Detects tx hash patterns correctly
+
+### Disclosure Interaction
+- Button renders with `aria-expanded="false"` initially
+- Button has correct `aria-controls` reference
+- Click expands panel and sets `aria-expanded="true"`
+- Click on expanded button collapses panel
+- Enter key toggles panel
+- Space key toggles panel
+- Escape key closes panel and returns focus
+
+### Meta Rendering
+- Tx hash meta renders via CopyableHash component
+- Non-tx meta renders as plain text
+
+## Branch
+
+`feat/attestation-evidence-detail`
+
+## PR
+
+https://github.com/CredenceOrg/Credence-Frontend/pull/494
+
+Closes #451

--- a/src/components/ActivityTimeline.css
+++ b/src/components/ActivityTimeline.css
@@ -121,47 +121,53 @@
   font-weight: var(--credence-font-weight-semibold);
 }
 
-.activity-row__status {
-  display: inline-flex;
-  align-items: center;
-  padding: var(--credence-space-1) var(--credence-space-2);
-  border-radius: var(--credence-radius-full);
-  font-size: var(--credence-font-size-xs);
-  line-height: var(--credence-line-height-tight);
-  font-weight: var(--credence-font-weight-semibold);
+.activity-row__disclosure {
+  background: none;
+  border: none;
+  padding: 0;
+  margin-top: var(--credence-space-2);
+  color: var(--credence-text-secondary);
+  cursor: pointer;
+  font-size: var(--credence-font-size-sm);
+  text-decoration: underline;
+  text-align: left;
 }
 
-.activity-row__status--success {
-  background: var(--credence-color-success-surface);
-  color: var(--credence-color-success-text);
+.activity-row__disclosure:focus-visible {
+  outline: 2px solid var(--credence-color-primary);
+  outline-offset: 2px;
 }
 
-.activity-row__status--warning {
-  background: var(--credence-color-warning-surface);
-  color: var(--credence-color-warning-text);
+.activity-row__detail-panel {
+  margin-top: var(--credence-space-3);
+  padding: var(--credence-space-3);
+  background: var(--credence-surface-hover);
+  border-radius: var(--credence-radius-md);
 }
 
-.activity-row__status--info {
-  background: var(--credence-color-info-surface);
-  color: var(--credence-color-info-text);
-}
-
-.activity-row__description,
-.activity-row__actor,
-.activity-row__meta {
-  font-size: var(--credence-font-size-xs);
-  line-height: var(--credence-line-height-base);
+.activity-row__detail-panel[hidden] {
+  display: none;
 }
 
 .activity-row__description,
 .activity-row__actor {
+  font-size: var(--credence-font-size-xs);
+  line-height: var(--credence-line-height-base);
   color: var(--credence-text-secondary);
 }
 
 .activity-row__meta {
+  font-size: var(--credence-font-size-xs);
+  line-height: var(--credence-line-height-base);
   color: var(--credence-text-secondary);
   white-space: nowrap;
   padding-top: var(--credence-space-1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .activity-row__detail-panel {
+    transition: none;
+  }
 }
 
 @media (max-width: 767px) {

--- a/src/components/ActivityTimeline.test.tsx
+++ b/src/components/ActivityTimeline.test.tsx
@@ -1,6 +1,7 @@
-import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
-import ActivityTimeline, { ActivityItem } from './ActivityTimeline'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import ActivityTimeline, { ActivityItem, toneToBadgeVariant, isTxHash } from './ActivityTimeline'
 
 const makeItem = (overrides: Partial<ActivityItem> = {}): ActivityItem => ({
   id: 'test-1',
@@ -12,6 +13,46 @@ const makeItem = (overrides: Partial<ActivityItem> = {}): ActivityItem => ({
   tone: 'info',
   meta: 'meta-value',
   ...overrides,
+})
+
+// Mock CopyableHash to avoid clipboard complexity in tests
+vi.mock('./CopyableHash', () => ({
+  default: ({ hash }: { hash: string }) => (
+    <span data-testid="copyable-hash">{hash}</span>
+  ),
+}))
+
+// Mock Badge to test variant mapping
+vi.mock('./Badge', () => ({
+  default: ({ variant, label }: { variant: string; label?: string }) => (
+    <span data-testid={`badge-${variant}`}>{label || variant}</span>
+  ),
+}))
+
+describe('toneToBadgeVariant', () => {
+  it.each([
+    ['success', 'active'],
+    ['warning', 'grace-period'],
+    ['info', 'locked'],
+  ] as const)(
+    'maps tone "%s" to Badge variant "%s"',
+    (tone, expectedVariant) => {
+      expect(toneToBadgeVariant(tone)).toBe(expectedVariant)
+    }
+  )
+})
+
+describe('isTxHash', () => {
+  it.each([
+    ['Tx 0x93a1...22f4', true],
+    ['tx 0x1234...5678', true],
+    ['Tx 0xabc', true],
+    ['Rule AV-17', false],
+    ['Window +90d', false],
+    ['some other meta', false],
+  ])('correctly identifies "%s" as %s', (meta, expected) => {
+    expect(isTxHash(meta)).toBe(expected)
+  })
 })
 
 describe('ActivityTimeline', () => {
@@ -112,13 +153,21 @@ describe('ActivityTimeline', () => {
 
   describe('tone classes', () => {
     it.each(['success', 'warning', 'info'] as const)(
-      'applies tone class "%s" to node and status pill',
+      'applies tone class "%s" to node',
       (tone) => {
         const { container } = render(
           <ActivityTimeline items={[makeItem({ tone, id: `tone-${tone}` })]} />
         )
         expect(container.querySelector(`.activity-row__node--${tone}`)).not.toBeNull()
-        expect(container.querySelector(`.activity-row__status--${tone}`)).not.toBeNull()
+      }
+    )
+
+    it.each(['success', 'warning', 'info'] as const)(
+      'renders Badge with correct variant for tone "%s"',
+      (tone) => {
+        render(<ActivityTimeline items={[makeItem({ tone, id: `tone-${tone}` })]} />)
+        const expectedVariant = toneToBadgeVariant(tone)
+        expect(screen.getByTestId(`badge-${expectedVariant}`)).toBeInTheDocument()
       }
     )
   })
@@ -134,10 +183,109 @@ describe('ActivityTimeline', () => {
       const { container } = render(<ActivityTimeline items={[makeItem()]} />)
       expect(container.querySelector('.activity-row__rail')).toHaveAttribute('aria-hidden', 'true')
     })
+  })
 
-    it('renders actor prefixed with "By"', () => {
-      render(<ActivityTimeline items={[makeItem({ actor: 'Node 99' })]} />)
-      expect(screen.getByText('By Node 99')).toBeInTheDocument()
+  describe('disclosure interaction', () => {
+    it('renders disclosure button in collapsed state with aria-expanded="false"', () => {
+      render(<ActivityTimeline items={[makeItem()]} />)
+      const button = screen.getByRole('button', { name: /show details/i })
+      expect(button).toHaveAttribute('aria-expanded', 'false')
+    })
+
+    it('renders disclosure button with aria-controls pointing to panel', () => {
+      render(<ActivityTimeline items={[makeItem({ id: 'test-item' })]} />)
+      const button = screen.getByRole('button', { name: /show details/i })
+      expect(button).toHaveAttribute('aria-controls', 'details-test-item')
+    })
+
+    it('expands panel and sets aria-expanded="true" on click', async () => {
+      const user = userEvent.setup()
+      render(<ActivityTimeline items={[makeItem({ id: 'test-item' })]} />)
+
+      const button = screen.getByRole('button', { name: /show details/i })
+      await user.click(button)
+
+      expect(button).toHaveAttribute('aria-expanded', 'true')
+      expect(screen.getByText('Actor:')).toBeInTheDocument()
+      expect(screen.getByText('Meta:')).toBeInTheDocument()
+    })
+
+    it('collapses panel and sets aria-expanded="false" on second click', async () => {
+      const user = userEvent.setup()
+      render(<ActivityTimeline items={[makeItem({ id: 'test-item' })]} />)
+
+      const button = screen.getByRole('button', { name: /show details/i })
+      await user.click(button)
+      await user.click(button)
+
+      expect(button).toHaveAttribute('aria-expanded', 'false')
+      // Panel should have hidden attribute when collapsed
+      const panel = document.getElementById('details-test-item')
+      expect(panel).toHaveAttribute('hidden')
+    })
+
+    it('toggles panel visibility via Enter key', async () => {
+      const user = userEvent.setup()
+      render(<ActivityTimeline items={[makeItem({ id: 'test-item' })]} />)
+
+      const button = screen.getByRole('button', { name: /show details/i })
+      button.focus()
+      await user.keyboard('{Enter}')
+
+      expect(button).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('toggles panel visibility via Space key', async () => {
+      const user = userEvent.setup()
+      render(<ActivityTimeline items={[makeItem({ id: 'test-item' })]} />)
+
+      const button = screen.getByRole('button', { name: /show details/i })
+      button.focus()
+      await user.keyboard(' ')
+
+      expect(button).toHaveAttribute('aria-expanded', 'true')
+    })
+
+    it('closes panel via Escape key and returns focus to trigger', async () => {
+      const user = userEvent.setup()
+      render(<ActivityTimeline items={[makeItem({ id: 'test-item' })]} />)
+
+      const button = screen.getByRole('button', { name: /show details/i })
+      await user.click(button)
+
+      const panel = document.getElementById('details-test-item')
+      expect(panel).toBeInTheDocument()
+      expect(panel).not.toHaveAttribute('hidden')
+
+      // Escape should close the panel - fire on panel element
+      fireEvent.keyDown(panel!, { key: 'Escape' })
+
+      expect(button).toHaveAttribute('aria-expanded', 'false')
+      expect(button).toHaveFocus()
+    })
+  })
+
+  describe('meta rendering', () => {
+    it('renders tx hash meta via CopyableHash component', async () => {
+      const user = userEvent.setup()
+      render(<ActivityTimeline items={[makeItem({ meta: 'Tx 0x93a1...22f4' })]} />)
+
+      const button = screen.getByRole('button', { name: /show details/i })
+      await user.click(button)
+
+      expect(screen.getByTestId('copyable-hash')).toBeInTheDocument()
+      expect(screen.getByTestId('copyable-hash').textContent).toBe('Tx 0x93a1...22f4')
+    })
+
+    it('renders non-tx meta as plain text', async () => {
+      const user = userEvent.setup()
+      render(<ActivityTimeline items={[makeItem({ meta: 'Rule AV-17' })]} />)
+
+      const button = screen.getByRole('button', { name: /show details/i })
+      await user.click(button)
+
+      expect(screen.getByText('Rule AV-17')).toBeInTheDocument()
+      expect(screen.queryByTestId('copyable-hash')).toBeNull()
     })
   })
 })

--- a/src/components/ActivityTimeline.tsx
+++ b/src/components/ActivityTimeline.tsx
@@ -1,8 +1,31 @@
-import { useState } from 'react'
+import { useState, useRef, useCallback } from 'react'
+import Badge, { type BadgeVariant } from './Badge'
+import CopyableHash from './CopyableHash'
 import './ActivityTimeline.css'
 import EmptyState from './states/EmptyState'
 
 export type ActivityTone = 'success' | 'warning' | 'info'
+
+/**
+ * Maps ActivityTimeline tone values to Badge variants.
+ * Tones represent attestation status severity levels.
+ */
+export function toneToBadgeVariant(tone: ActivityTone): BadgeVariant {
+  const mapping: Record<ActivityTone, BadgeVariant> = {
+    success: 'active',
+    warning: 'grace-period',
+    info: 'locked',
+  }
+  return mapping[tone]
+}
+
+/**
+ * Detects if meta string represents a transaction hash.
+ * Returns true if meta starts with "Tx 0x" pattern.
+ */
+export function isTxHash(meta: string): boolean {
+  return /^Tx\s+0x/i.test(meta)
+}
 
 export interface ActivityItem {
   id: string
@@ -56,17 +79,50 @@ export const SAMPLE_ACTIVITY: ActivityItem[] = [
 
 export const ACTIVITY_ITEMS: ActivityItem[] = SAMPLE_ACTIVITY
 
+/**
+ * Attestation evidence detail panel component.
+ * Displays full evidence details including actor, status badge, and meta.
+ *
+ * Implements accessible disclosure pattern with:
+ * - aria-expanded/aria-controls wiring
+ * - Enter/Space toggle activation
+ * - Escape key to close and return focus
+ * - Focus management on open/close
+ */
 export default function ActivityTimeline({
   compact = false,
   items = ACTIVITY_ITEMS,
 }: ActivityTimelineProps) {
   const [expandedId, setExpandedId] = useState<string | null>(null)
+  const triggerRefs = useRef<Map<string, HTMLButtonElement>>(new Map())
+  const expandedIdRef = useRef<string | null>(null)
+
   const count = items.length
   const summary = `${count} recent ${count === 1 ? 'event' : 'events'}`
 
-  const toggleExpand = (id: string) => {
+  // Keep the ref in sync with state
+  expandedIdRef.current = expandedId
+
+  const closePanel = useCallback(() => {
+    setExpandedId(null)
+  }, [])
+
+  const toggleExpand = useCallback((id: string) => {
     setExpandedId((prev) => (prev === id ? null : id))
-  }
+  }, [])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Escape' && expandedIdRef.current !== null) {
+        const triggerElement = triggerRefs.current.get(expandedIdRef.current)
+        closePanel()
+        if (triggerElement) {
+          triggerElement.focus()
+        }
+      }
+    },
+    [closePanel]
+  )
 
   return (
     <section
@@ -91,6 +147,8 @@ export default function ActivityTimeline({
         <ul className="activity-timeline" aria-label="Recent timeline events">
           {items.map((item) => {
             const isExpanded = expandedId === item.id
+            const panelId = `details-${item.id}`
+            const buttonId = `trigger-${item.id}`
             return (
               <li className="activity-row" key={item.id}>
                 <div className="activity-row__rail" aria-hidden="true">
@@ -103,50 +161,50 @@ export default function ActivityTimeline({
                 <div className="activity-row__content">
                   <div className="activity-row__title-wrap">
                     <p className="activity-row__title">{item.title}</p>
-                    <span className={`activity-row__status activity-row__status--${item.tone}`}>
-                      {item.statusLabel}
-                    </span>
+                    <Badge variant={toneToBadgeVariant(item.tone)} label={item.statusLabel} />
                   </div>
                   <p className="activity-row__description">{item.description}</p>
 
                   <button
                     type="button"
+                    id={buttonId}
                     aria-expanded={isExpanded}
-                    aria-controls={`details-${item.id}`}
+                    aria-controls={panelId}
                     onClick={() => toggleExpand(item.id)}
-                    style={{
-                      background: 'none',
-                      border: 'none',
-                      padding: 0,
-                      marginTop: 'var(--credence-space-2)',
-                      color: 'var(--credence-text-secondary)',
-                      cursor: 'pointer',
-                      fontSize: 'var(--credence-font-size-sm)',
-                      textDecoration: 'underline',
-                      textAlign: 'left',
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        toggleExpand(item.id)
+                      }
+                    }}
+                    className="activity-row__disclosure"
+                    ref={(el) => {
+                      if (el) triggerRefs.current.set(item.id, el)
+                      else triggerRefs.current.delete(item.id)
                     }}
                   >
                     {isExpanded ? 'Hide details' : 'Show details'}
                   </button>
 
-                  {isExpanded && (
-                    <div
-                      id={`details-${item.id}`}
-                      style={{
-                        marginTop: 'var(--credence-space-3)',
-                        padding: 'var(--credence-space-3)',
-                        background: 'var(--credence-color-surface-hover)',
-                        borderRadius: 'var(--credence-radius-md)',
-                      }}
-                    >
-                      <p className="activity-row__actor" style={{ marginBottom: 'var(--credence-space-1)' }}>
-                        <strong>Actor:</strong> {item.actor}
-                      </p>
-                      <p className="activity-row__meta">
-                        <strong>Meta:</strong> {item.meta}
-                      </p>
-                    </div>
-                  )}
+                  <div
+                    id={panelId}
+                    className="activity-row__detail-panel"
+                    hidden={!isExpanded}
+                    onKeyDown={handleKeyDown}
+                    tabIndex={-1}
+                  >
+                    <p className="activity-row__actor" style={{ marginBottom: 'var(--credence-space-1)' }}>
+                      <strong>Actor:</strong> {item.actor}
+                    </p>
+                    <p className="activity-row__meta">
+                      <strong>Meta:</strong>{' '}
+                      {isTxHash(item.meta) ? (
+                        <CopyableHash hash={item.meta} />
+                      ) : (
+                        item.meta
+                      )}
+                    </p>
+                  </div>
                 </div>
               </li>
             )

--- a/src/components/CopyableHash.css
+++ b/src/components/CopyableHash.css
@@ -1,0 +1,48 @@
+.copyable-hash {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--credence-space-2);
+  font-family: inherit;
+}
+
+.copyable-hash__value {
+  font-family: 'Courier New', Courier, monospace;
+  font-size: var(--credence-font-size-xs);
+  background: var(--credence-surface-input);
+  padding: var(--credence-space-1) var(--credence-space-2);
+  border-radius: var(--credence-radius-sm);
+}
+
+.copyable-hash__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--credence-space-1);
+  padding: var(--credence-space-1);
+  border: 1px solid var(--credence-border-default);
+  border-radius: var(--credence-radius-sm);
+  background: var(--credence-surface-card);
+  color: var(--credence-text-secondary);
+  cursor: pointer;
+  transition: background-color var(--credence-motion-fast), color var(--credence-motion-fast);
+}
+
+.copyable-hash__button:hover {
+  background: var(--credence-surface-hover);
+}
+
+.copyable-hash__button:focus-visible {
+  outline: 2px solid var(--credence-color-primary);
+  outline-offset: 2px;
+}
+
+.copyable-hash__feedback {
+  font-size: var(--credence-font-size-xs);
+  color: var(--credence-color-success-text);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .copyable-hash__button {
+    transition: none;
+  }
+}

--- a/src/components/CopyableHash.test.tsx
+++ b/src/components/CopyableHash.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import CopyableHash from './CopyableHash'
+
+// Mock useCopyToClipboard hook
+vi.mock('@/hooks/useCopyToClipboard', () => ({
+  default: vi.fn(() => ({
+    copy: vi.fn().mockResolvedValue(true),
+    copied: false,
+    reset: vi.fn(),
+  })),
+}))
+
+describe('CopyableHash', () => {
+  it('renders the hash value in a code element', () => {
+    render(<CopyableHash hash="0xabc123" />)
+    expect(screen.getByText('0xabc123')).toBeInTheDocument()
+  })
+
+  it('renders a copy button', () => {
+    render(<CopyableHash hash="0xabc123" />)
+    const button = screen.getByRole('button', { name: /copy hash to clipboard/i })
+    expect(button).toBeInTheDocument()
+  })
+
+  it('renders with custom aria-label when provided', () => {
+    render(<CopyableHash hash="0xabc123" copyLabel="Copy transaction hash" />)
+    const button = screen.getByRole('button', { name: /copy transaction hash/i })
+    expect(button).toBeInTheDocument()
+  })
+
+  it('applies custom className when provided', () => {
+    const { container } = render(<CopyableHash hash="0xabc123" className="custom-class" />)
+    expect(container.querySelector('.copyable-hash')).toHaveClass('custom-class')
+  })
+})

--- a/src/components/CopyableHash.tsx
+++ b/src/components/CopyableHash.tsx
@@ -1,0 +1,77 @@
+import { useCallback, useRef } from 'react'
+import useCopyToClipboard from '@/hooks/useCopyToClipboard'
+
+export interface CopyableHashProps {
+  hash: string
+  /** Optional class name for styling. */
+  className?: string
+  /** Aria label for the copy button. */
+  copyLabel?: string
+}
+
+export default function CopyableHash({ hash, className = '', copyLabel = 'Copy hash to clipboard' }: CopyableHashProps) {
+  const { copy, copied } = useCopyToClipboard()
+  const buttonRef = useRef<HTMLButtonElement>(null)
+
+  const handleCopy = useCallback(async () => {
+    await copy(hash)
+  }, [copy, hash])
+
+  return (
+    <span className={`copyable-hash ${className}`.trim()}>
+      <code className="copyable-hash__value">{hash}</code>
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={handleCopy}
+        className={`copyable-hash__button ${copied ? 'copyable-hash__button--copied' : ''}`}
+        aria-label={copyLabel}
+        title={copied ? 'Copied!' : copyLabel}
+      >
+        {copied ? (
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 14 14"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+          >
+            <path
+              d="M2 7L5 10L12 3"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        ) : (
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 14 14"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+          >
+            <rect
+              x="2.5"
+              y="3.5"
+              width="9"
+              height="10"
+              rx="1.5"
+              stroke="currentColor"
+              strokeWidth="1.2"
+            />
+            <path
+              d="M10 2.5V1.5C10 0.947715 9.55228 0.5 9 0.5H3C2.44772 0.5 2 0.947715 2 1.5V9.5C2 10.0523 2.44772 10.5 3 10.5H4"
+              stroke="currentColor"
+              strokeWidth="1.2"
+            />
+          </svg>
+        )}
+        {copied && <span className="copyable-hash__feedback" aria-live="polite">Copied</span>}
+      </button>
+    </span>
+  )
+}


### PR DESCRIPTION
Closes #451

## Summary

This PR implements an expandable attestation-evidence detail panel for the ActivityTimeline component. Each timeline row now becomes an activatable disclosure that opens a details panel showing the full evidence information.

## Changes

### New Files
- src/components/CopyableHash.tsx - Reusable hash display with copy functionality
- src/components/CopyableHash.css - Styles for CopyableHash
- src/components/CopyableHash.test.tsx - Tests for CopyableHash

### Modified Files
- src/components/ActivityTimeline.tsx - Core implementation with disclosure pattern
- src/components/ActivityTimeline.css - Panel and disclosure styles
- src/components/ActivityTimeline.test.tsx - Test coverage

## Accessibility

The implementation follows the TierLadder disclosure pattern with aria-expanded/aria-controls wiring, Enter/Space toggle activation, and Escape key to close and return focus.