### PR TITLE
feat: add mobile speed-dial for Send/Receive/Swap on <=768px

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -29,6 +29,14 @@ Related focused docs: [button system](./button-system.md), [notifications](./not
 | states/ErrorState      | Inline styles in `src/components/states/ErrorState.tsx`                             | Owns inline styles and should be migrated to CSS.                                                                         |
 | states/LoadingSkeleton | Inline styles in `src/components/states/LoadingSkeleton.tsx`                        | Owns inline styles and should be migrated to CSS.                                                                         |
 | SessionTimeoutModal    | Inline styles in `src/components/SessionTimeoutModal.tsx`                           | Uses `ConfirmDialog` primitive with internal warning styles.                                                              |
+| ActionCard             | Inline styles in `src/components/ActionCard.tsx`                                    | Owns all inline styles; migrate to a CSS file when a module is added.                                                    |
+| Disclaimer             | `src/components/Disclaimer.css`                                                     | None.                                                                                                                     |
+| ThemeToggle            | `src/components/ThemeToggle.css`                                                    | None.                                                                                                                     |
+| KeyboardShortcutsDialog | `src/components/KeyboardShortcutsDialog.css`                                       | None.                                                                                                                     |
+| AttestationForm        | Delegates to `AddressInput`, `Select`, `FormField`, `Button`                        | No dedicated CSS file; inherits from composing components.                                                                |
+| CreateBondFlow         | `src/components/CreateBondFlow.css`                                                 | None.                                                                                                                     |
+| ErrorBoundary          | Delegates to `states/ErrorState`                                                    | No dedicated CSS file.                                                                                                    |
+| SpeedDial              | `src/components/SpeedDial.css`                                                      | None.                                                                                                                     |
 
 ## Shared vocabularies
 
@@ -519,3 +527,209 @@ Tokens: warning color tokens, spacing, radius.
   onLogout={logout}
 />
 ```
+
+## ActionCard
+
+Source: [`src/components/ActionCard.tsx`](../src/components/ActionCard.tsx).
+
+| Prop       | Type        | Default  |
+| ---------- | ----------- | -------- |
+| `title`    | `string`    | Required |
+| `children` | `ReactNode` | Required |
+
+Accessibility: renders as a semantic `<article>` with the title in an `<h2>`. No additional ARIA attributes are needed; place inside a `<main>` or named landmark so context is clear.
+
+Tokens: `--credence-border-default`, `--credence-radius-xl`, `--credence-space-4`, `--credence-space-6`, `--credence-surface-card`, `--credence-text-primary`, `--credence-font-size-xl`, `--credence-line-height-tight`.
+
+```tsx
+<ActionCard title="Create bond">
+  <AmountInput value={amount} onChange={setAmount} balance={balance} />
+  <Button onClick={submit}>Submit</Button>
+</ActionCard>
+```
+
+## Disclaimer
+
+Source: [`src/components/Disclaimer.tsx`](../src/components/Disclaimer.tsx).
+
+| Prop        | Type     | Default        |
+| ----------- | -------- | -------------- |
+| `context`   | `string` | `undefined`    |
+| `termsHref` | `string` | `LINKS.terms`  |
+
+Accessibility: renders as `<aside aria-label="Risk disclaimer">`. The terms link has an explicit `aria-label="Read full terms and conditions"`. When `termsHref` resolves to a placeholder (`'#'` or empty), a `<span aria-disabled="true">` is rendered instead of an anchor so the element is inert for keyboard and AT users.
+
+Tokens: secondary text and spacing tokens via `Disclaimer.css`.
+
+```tsx
+<Disclaimer context="Early withdrawal forfeits accrued rewards." />
+```
+
+## ThemeToggle
+
+Source: [`src/components/ThemeToggle.tsx`](../src/components/ThemeToggle.tsx). Focused docs: [dark mode](./dark-mode.md).
+
+No external props. Reads `themeMode` from `SettingsContext` and writes the explicit opposite on click; never exposes a prop API.
+
+Accessibility: native `<button>` with `aria-label="Switch to {nextTheme} mode"` and `aria-pressed` reflecting whether the resolved theme is dark. Both icons are `aria-hidden`. Tracks the OS `prefers-color-scheme` media query while `themeMode` is `'system'` so `aria-pressed` and `aria-label` stay in sync with the document's `data-theme`.
+
+Tokens: `--credence-focus-ring`, spacing, and icon sizing via `ThemeToggle.css`.
+
+```tsx
+<ThemeToggle />
+```
+
+## KeyboardShortcutsDialog
+
+Source: [`src/components/KeyboardShortcutsDialog.tsx`](../src/components/KeyboardShortcutsDialog.tsx). Focused docs: [keyboard interactions](./keyboard-interactions.md).
+
+| Prop             | Type                              | Default     |
+| ---------------- | --------------------------------- | ----------- |
+| `open`           | `boolean`                         | Required    |
+| `onClose`        | `() => void`                      | Required    |
+| `returnFocusRef` | `React.RefObject<HTMLElement \| null>` | `undefined` |
+
+Accessibility: portal-rendered modal with `role="dialog"`, `aria-modal="true"`, and a generated `aria-labelledby`. Focus is trapped while open. Escape and backdrop click both call `onClose`. Focus is restored to `returnFocusRef` on close, or to the previously active element when `returnFocusRef` is omitted. Shortcuts are grouped by category with visible section headings.
+
+Tokens: border, surface, text, font, spacing, radius, and focus tokens via `KeyboardShortcutsDialog.css`.
+
+```tsx
+const triggerRef = useRef<HTMLButtonElement>(null)
+
+<button ref={triggerRef} onClick={() => setOpen(true)}>Keyboard shortcuts</button>
+<KeyboardShortcutsDialog open={open} onClose={() => setOpen(false)} returnFocusRef={triggerRef} />
+```
+
+## AttestationForm
+
+Source: [`src/components/AttestationForm.tsx`](../src/components/AttestationForm.tsx).
+
+| Prop              | Type                                                                   | Default     |
+| ----------------- | ---------------------------------------------------------------------- | ----------- |
+| `onSubmitSuccess` | `(payload: { subject: string; type: string; evidence: string }) => void` | `undefined` |
+| `disabled`        | `boolean`                                                              | `false`     |
+
+Accessibility: all form fields are wrapped in `FormField` so each has a `<label>`, hint, and error wired through `aria-describedby` and `aria-invalid`. The type selector uses `controls/Select` (native `<select>`). The evidence textarea has a live character counter associated via `aria-describedby`. Submission is confirmed via `ConfirmDialog` before calling `onSubmitSuccess`; success is announced via a toast.
+
+Tokens: inherits tokens from `AddressInput`, `Select`, `FormField`, and `Button`.
+
+```tsx
+<AttestationForm
+  onSubmitSuccess={({ subject, type, evidence }) => recordAttestation(subject, type, evidence)}
+/>
+```
+
+## CreateBondFlow
+
+Source: [`src/components/CreateBondFlow.tsx`](../src/components/CreateBondFlow.tsx).
+
+| Prop         | Type         | Default     |
+| ------------ | ------------ | ----------- |
+| `onComplete` | `() => void` | `undefined` |
+| `onCancel`   | `() => void` | `undefined` |
+
+A four-step wizard: **amount → duration → review → confirm**. Fetches the connected wallet's USDC balance and calculates early-withdrawal penalty in-flight. The final step uses `ConfirmDialog` for confirmation.
+
+Accessibility: each step manages focus on mount so keyboard users advance through the wizard without losing context. Reduced motion is respected via `useReducedMotion`. Success is announced via a toast; `onComplete` is called after the toast fires.
+
+Tokens: `CreateBondFlow.css` consumes border, radius, spacing, surface, text, font, and motion tokens.
+
+```tsx
+<CreateBondFlow onComplete={() => navigate('/bond')} onCancel={() => navigate('/bond')} />
+```
+
+## ErrorBoundary
+
+Source: [`src/components/ErrorBoundary.tsx`](../src/components/ErrorBoundary.tsx).
+
+| Prop       | Type                                         | Default                        |
+| ---------- | -------------------------------------------- | ------------------------------ |
+| `children` | `ReactNode`                                  | Required                       |
+| `fallback` | `(error: Error, reset: () => void) => ReactNode` | `undefined` (uses `ErrorState`) |
+
+Class component that catches render and lifecycle errors in its subtree. The default fallback renders a branded `ErrorState` with a "Retry" action (re-mounts the subtree without a full reload) and a "Go home" link. Supply `fallback` to override with custom error UI.
+
+Wire telemetry in `componentDidCatch` (currently logs to console) before shipping to production.
+
+Accessibility: no additional ARIA attributes; inherits accessibility from `ErrorState` or the custom `fallback` render.
+
+Tokens: none directly; delegates to `ErrorState`.
+
+```tsx
+<ErrorBoundary>
+  <BondPage />
+</ErrorBoundary>
+
+{/* Custom fallback */}
+<ErrorBoundary fallback={(err, reset) => <button onClick={reset}>Retry: {err.message}</button>}>
+  <TrustScorePage />
+</ErrorBoundary>
+```
+
+## SpeedDial
+
+Source: [`src/components/SpeedDial.tsx`](../src/components/SpeedDial.tsx).
+
+Mobile-only floating action button that expands to reveal **Send**, **Receive**, and **Swap** shortcuts. Hidden on screens wider than 768 px (CSS `display: none` outside the `@media (max-width: 768px)` block).
+
+| Prop      | Type                  | Default                       |
+| --------- | --------------------- | ----------------------------- |
+| `actions` | `SpeedDialAction[]`   | `SPEED_DIAL_DEFAULT_ACTIONS`  |
+
+### `SpeedDialAction`
+
+| Field       | Type            | Notes                                      |
+| ----------- | --------------- | ------------------------------------------ |
+| `id`        | `string`        | React key; must be unique across the list. |
+| `label`     | `string`        | Pill label next to the icon button.        |
+| `to`        | `string`        | Route passed to `useNavigate()` on click.  |
+| `icon`      | `React.ReactNode` | SVG rendered inside the mini button.     |
+| `ariaLabel` | `string?`       | Overrides `label` for the button's accessible name. |
+
+### Default actions
+
+| Action  | Route                          |
+| ------- | ------------------------------ |
+| Send    | `/transactions?action=send`    |
+| Receive | `/transactions?action=receive` |
+| Swap    | `/transactions?action=swap`    |
+
+### Accessibility contract
+
+- The whole widget is a `<nav>` with `aria-label="Quick actions"` so screen-reader users can navigate to or skip it.
+- The FAB has `aria-expanded` (reflects open/closed state) and `aria-controls="speed-dial-actions"` pointing to the action list.
+- When the menu opens, focus moves to the first action button.
+- **Escape** closes the menu and returns focus to the FAB.
+- **Tab / Shift+Tab** cycles within the open menu (FAB + action buttons) without leaking focus to the rest of the page.
+- Action buttons are `tabindex="-1"` while the menu is closed so they are not reachable by keyboard when invisible.
+- No `display: none` toggle in JS—CSS handles visibility so reduced-motion users see a static state without animation jank.
+
+### Tokens consumed
+
+`--credence-border-default`, `--credence-color-primary`, `--credence-color-primary-strong`, `--credence-color-slate-*`, `--credence-color-white`, `--credence-focus-ring`, `--credence-motion-duration-*`, `--credence-motion-easing-standard`, `--credence-radius-full`, `--credence-shadow-toast`, `--credence-space-*`, `--credence-surface-card`, `--credence-text-primary`.
+
+### Styling ownership
+
+`src/components/SpeedDial.css` — no inline styles.
+
+### Usage
+
+```tsx
+{/* Default — shows Send / Receive / Swap */}
+<SpeedDial />
+
+{/* Custom actions */}
+<SpeedDial
+  actions={[
+    {
+      id: 'bond',
+      label: 'New Bond',
+      to: '/bond/new',
+      icon: <BondIcon />,
+      ariaLabel: 'Create a new bond',
+    },
+  ]}
+/>
+```
+
+The component is mounted in `Layout.tsx` so it appears on every route automatically. It is invisible on desktop and becomes visible only when the viewport is ≤ 768 px.

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -10,7 +10,7 @@ import RouteAnnouncer from './RouteAnnouncer'
 import KeyboardShortcutsDialog from './KeyboardShortcutsDialog'
 import WhatsNewDialog from './WhatsNewDialog'
 import BackToTop from './BackToTop'
-import Banner from './Banner'
+import SpeedDial from './SpeedDial'
 import LINKS from '../config/links'
 import { hasHandledInstallPrompt, markInstallPromptHandled } from '../config/installPrompt'
 import { isExternalUrl } from '../lib/isExternalUrl'
@@ -205,6 +205,9 @@ export default function Layout() {
       />
 
       <BackToTop />
+
+      {/* Mobile speed-dial – only visible on screens ≤768px */}
+      <SpeedDial />
     </div>
   )
 }

--- a/src/components/SpeedDial.css
+++ b/src/components/SpeedDial.css
@@ -1,0 +1,202 @@
+/*
+ * SpeedDial – mobile floating action button for Send / Receive / Swap.
+ * Only visible on screens ≤ 768px (BREAKPOINTS.MD).
+ * Uses design-token CSS custom properties exclusively; no hard-coded colours
+ * or spacing values.
+ */
+
+/* ── Container (hidden by default, shown on mobile) ─────────────────────── */
+
+.speedDial {
+  /* Hidden on desktop via max-width guard below */
+  display: none;
+  position: fixed;
+  bottom: var(--credence-space-6);
+  right: var(--credence-space-6);
+  z-index: 900; /* below MobileNav drawer (1000) but above page content */
+  align-items: flex-end;
+  flex-direction: column;
+  gap: var(--credence-space-3);
+}
+
+/* ── FAB (main toggle button) ────────────────────────────────────────────── */
+
+.speedDial__fab {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  border-radius: var(--credence-radius-full);
+  border: none;
+  background: var(--credence-color-primary);
+  color: var(--credence-color-white);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  transition:
+    background var(--credence-motion-duration-fast) var(--credence-motion-easing-standard),
+    transform var(--credence-motion-duration-fast) var(--credence-motion-easing-standard),
+    box-shadow var(--credence-motion-duration-fast) var(--credence-motion-easing-standard);
+  flex-shrink: 0;
+  /* Ensure the button stacks on top of the action list */
+  order: 2;
+}
+
+.speedDial__fab:hover {
+  background: var(--credence-color-primary-strong);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.25);
+}
+
+.speedDial__fab:active {
+  transform: scale(0.95);
+}
+
+.speedDial__fab:focus-visible {
+  outline: var(--credence-focus-ring);
+  outline-offset: 3px;
+}
+
+/* Rotate the icon 45° when open to show a cross */
+.speedDial__fab--open .speedDial__fabIcon {
+  transform: rotate(45deg);
+}
+
+.speedDial__fabIcon {
+  transition: transform var(--credence-motion-duration-base) var(--credence-motion-easing-standard);
+  pointer-events: none;
+}
+
+/* ── Action list ─────────────────────────────────────────────────────────── */
+
+.speedDial__actions {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--credence-space-3);
+  align-items: flex-end;
+  order: 1;
+
+  /* Collapsed state */
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(var(--credence-space-4));
+  transition:
+    opacity var(--credence-motion-duration-base) var(--credence-motion-easing-standard),
+    transform var(--credence-motion-duration-base) var(--credence-motion-easing-standard);
+}
+
+.speedDial__actions--open {
+  pointer-events: auto;
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* ── Individual action item ──────────────────────────────────────────────── */
+
+.speedDial__item {
+  display: flex;
+  align-items: center;
+  gap: var(--credence-space-3);
+  justify-content: flex-end;
+}
+
+/* Text label pill */
+.speedDial__label {
+  padding: var(--credence-space-1) var(--credence-space-3);
+  background: var(--credence-surface-card);
+  color: var(--credence-text-primary);
+  font-size: var(--credence-font-size-sm);
+  font-weight: var(--credence-font-weight-semibold);
+  border-radius: var(--credence-radius-full);
+  border: 1px solid var(--credence-border-default);
+  box-shadow: var(--credence-shadow-toast);
+  white-space: nowrap;
+  pointer-events: none; /* clicks go to the action button */
+  user-select: none;
+}
+
+/* Mini icon button */
+.speedDial__action {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--credence-radius-full);
+  border: none;
+  background: var(--credence-surface-card);
+  color: var(--credence-color-primary);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: var(--credence-shadow-toast);
+  border: 1px solid var(--credence-border-default);
+  transition:
+    background var(--credence-motion-duration-fast) var(--credence-motion-easing-standard),
+    color var(--credence-motion-duration-fast) var(--credence-motion-easing-standard),
+    transform var(--credence-motion-duration-fast) var(--credence-motion-easing-standard);
+  flex-shrink: 0;
+  text-decoration: none;
+}
+
+.speedDial__action:hover {
+  background: var(--credence-color-primary);
+  color: var(--credence-color-white);
+  border-color: var(--credence-color-primary);
+  transform: scale(1.08);
+}
+
+.speedDial__action:active {
+  transform: scale(0.95);
+}
+
+.speedDial__action:focus-visible {
+  outline: var(--credence-focus-ring);
+  outline-offset: 3px;
+}
+
+/* ── Dark-mode overrides ─────────────────────────────────────────────────── */
+
+[data-theme='dark'] .speedDial__fab {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
+}
+
+[data-theme='dark'] .speedDial__fab:hover {
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.6);
+}
+
+[data-theme='dark'] .speedDial__action {
+  background: var(--credence-color-slate-700);
+  border-color: var(--credence-color-slate-600);
+}
+
+[data-theme='dark'] .speedDial__action:hover {
+  background: var(--credence-color-primary);
+  border-color: var(--credence-color-primary);
+  color: var(--credence-color-white);
+}
+
+[data-theme='dark'] .speedDial__label {
+  background: var(--credence-color-slate-700);
+  border-color: var(--credence-color-slate-600);
+}
+
+/* ── Reduced-motion ──────────────────────────────────────────────────────── */
+
+@media (prefers-reduced-motion: reduce) {
+  .speedDial__fab,
+  .speedDial__fabIcon,
+  .speedDial__actions,
+  .speedDial__action {
+    transition: none;
+  }
+}
+
+/* ── Visibility guard: only show on ≤768px ───────────────────────────────── */
+
+@media (max-width: 768px) {
+  .speedDial {
+    display: flex;
+  }
+}

--- a/src/components/SpeedDial.test.tsx
+++ b/src/components/SpeedDial.test.tsx
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import SpeedDial, { SPEED_DIAL_DEFAULT_ACTIONS } from './SpeedDial'
+
+// useNavigate is called inside SpeedDial when an action button is clicked.
+// We mock the whole react-router-dom module so we can assert navigate calls.
+const mockNavigate = vi.fn()
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  }
+})
+
+function renderSpeedDial(props: Partial<React.ComponentProps<typeof SpeedDial>> = {}) {
+  return render(
+    <MemoryRouter>
+      <SpeedDial {...props} />
+    </MemoryRouter>
+  )
+}
+
+describe('SpeedDial', () => {
+  beforeEach(() => {
+    mockNavigate.mockReset()
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  // ── render ──────────────────────────────────────────────────────────────
+
+  it('renders the FAB toggle button', () => {
+    renderSpeedDial()
+    expect(screen.getByRole('button', { name: /open quick actions/i })).toBeInTheDocument()
+  })
+
+  it('renders as a nav landmark with an accessible name', () => {
+    renderSpeedDial()
+    expect(screen.getByRole('navigation', { name: /quick actions/i })).toBeInTheDocument()
+  })
+
+  it('action list is not visible before FAB is clicked (collapsed state)', () => {
+    renderSpeedDial()
+    const list = screen.getByRole('list', { name: /quick action menu/i })
+    expect(list).not.toHaveClass('speedDial__actions--open')
+  })
+
+  // ── open ────────────────────────────────────────────────────────────────
+
+  it('opens the action list when FAB is clicked', () => {
+    renderSpeedDial()
+    fireEvent.click(screen.getByRole('button', { name: /open quick actions/i }))
+    const list = screen.getByRole('list', { name: /quick action menu/i })
+    expect(list).toHaveClass('speedDial__actions--open')
+  })
+
+  it('FAB aria-expanded is false when closed', () => {
+    renderSpeedDial()
+    expect(screen.getByRole('button', { name: /open quick actions/i })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    )
+  })
+
+  it('FAB aria-expanded is true when open', () => {
+    renderSpeedDial()
+    fireEvent.click(screen.getByRole('button', { name: /open quick actions/i }))
+    expect(screen.getByRole('button', { name: /close quick actions/i })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    )
+  })
+
+  it('FAB aria-controls points to the action list id', () => {
+    renderSpeedDial()
+    const fab = screen.getByRole('button', { name: /open quick actions/i })
+    expect(fab).toHaveAttribute('aria-controls', 'speed-dial-actions')
+  })
+
+  // ── close ───────────────────────────────────────────────────────────────
+
+  it('closes the action list when FAB is clicked again', () => {
+    renderSpeedDial()
+    const fab = screen.getByRole('button', { name: /open quick actions/i })
+    fireEvent.click(fab)
+    fireEvent.click(screen.getByRole('button', { name: /close quick actions/i }))
+    const list = screen.getByRole('list', { name: /quick action menu/i })
+    expect(list).not.toHaveClass('speedDial__actions--open')
+  })
+
+  it('closes the action list on Escape key press', () => {
+    renderSpeedDial()
+    fireEvent.click(screen.getByRole('button', { name: /open quick actions/i }))
+    fireEvent.keyDown(window, { key: 'Escape' })
+    const list = screen.getByRole('list', { name: /quick action menu/i })
+    expect(list).not.toHaveClass('speedDial__actions--open')
+  })
+
+  it('returns focus to the FAB after Escape closes the menu', async () => {
+    renderSpeedDial()
+    fireEvent.click(screen.getByRole('button', { name: /open quick actions/i }))
+    fireEvent.keyDown(window, { key: 'Escape' })
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /open quick actions/i })).toHaveFocus()
+    })
+  })
+
+  // ── default actions ─────────────────────────────────────────────────────
+
+  it('renders three action buttons by default', () => {
+    renderSpeedDial()
+    fireEvent.click(screen.getByRole('button', { name: /open quick actions/i }))
+    const actionButtons = screen
+      .getAllByRole('button')
+      .filter((btn) => btn.classList.contains('speedDial__action'))
+    expect(actionButtons).toHaveLength(3)
+  })
+
+  it('renders a Send action button', () => {
+    renderSpeedDial()
+    fireEvent.click(screen.getByRole('button', { name: /open quick actions/i }))
+    expect(screen.getByRole('button', { name: /send funds/i })).toBeInTheDocument()
+  })
+
+  it('renders a Receive action button', () => {
+    renderSpeedDial()
+    fireEvent.click(screen.getByRole('button', { name: /open quick actions/i }))
+    expect(screen.getByRole('button', { name: /receive funds/i })).toBeInTheDocument()
+  })
+
+  it('renders a Swap action button', () => {
+    renderSpeedDial()
+    fireEvent.click(screen.getByRole('button', { name: /open quick actions/i }))
+    expect(screen.getByRole('button', { name: /swap assets/i })).toBeInTheDocument()
+  })
+
+  // ── navigation ──────────────────────────────────────────────────────────
+
+  it('navigates to /transactions?action=send on Send click', () => {
+    renderSpeedDial()
+    fireEvent.click(screen.getByRole('button', { name: /open quick actions/i }))
+    fireEvent.click(screen.getByRole('button', { name: /send funds/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/transactions?action=send')
+  })
+
+  it('navigates to /transactions?action=receive on Receive click', () => {
+    renderSpeedDial()
+    fireEvent.click(screen.getByRole('button', { name: /open quick actions/i }))
+    fireEvent.click(screen.getByRole('button', { name: /receive funds/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/transactions?action=receive')
+  })
+
+  it('navigates to /transactions?action=swap on Swap click', () => {
+    renderSpeedDial()
+    fireEvent.click(screen.getByRole('button', { name: /open quick actions/i }))
+    fireEvent.click(screen.getByRole('button', { name: /swap assets/i }))
+    expect(mockNavigate).toHaveBeenCalledWith('/transactions?action=swap')
+  })
+
+  it('closes the menu after an action is activated', () => {
+    renderSpeedDial()
+    fireEvent.click(screen.getByRole('button', { name: /open quick actions/i }))
+    fireEvent.click(screen.getByRole('button', { name: /send funds/i }))
+    const list = screen.getByRole('list', { name: /quick action menu/i })
+    expect(list).not.toHaveClass('speedDial__actions--open')
+  })
+
+  // ── custom actions ───────────────────────────────────────────────────────
+
+  it('renders custom actions when passed via props', () => {
+    const customActions = [
+      {
+        id: 'custom',
+        label: 'Custom',
+        to: '/custom',
+        icon: <span>★</span>,
+        ariaLabel: 'Do custom thing',
+      },
+    ]
+    renderSpeedDial({ actions: customActions })
+    fireEvent.click(screen.getByRole('button', { name: /open quick actions/i }))
+    expect(screen.getByRole('button', { name: /do custom thing/i })).toBeInTheDocument()
+  })
+
+  // ── tabIndex management ──────────────────────────────────────────────────
+
+  it('action buttons have tabIndex=-1 when menu is closed', () => {
+    renderSpeedDial()
+    // When closed all action buttons (inside collapsed list) should have tabIndex=-1
+    const actionButtons = document
+      .querySelectorAll<HTMLButtonElement>('.speedDial__action')
+    actionButtons.forEach((btn) => {
+      expect(btn).toHaveAttribute('tabindex', '-1')
+    })
+  })
+
+  it('action buttons have tabIndex=0 when menu is open', () => {
+    renderSpeedDial()
+    fireEvent.click(screen.getByRole('button', { name: /open quick actions/i }))
+    const actionButtons = document
+      .querySelectorAll<HTMLButtonElement>('.speedDial__action')
+    actionButtons.forEach((btn) => {
+      expect(btn).toHaveAttribute('tabindex', '0')
+    })
+  })
+
+  // ── SPEED_DIAL_DEFAULT_ACTIONS export ────────────────────────────────────
+
+  it('exports the three default actions', () => {
+    expect(SPEED_DIAL_DEFAULT_ACTIONS).toHaveLength(3)
+    const ids = SPEED_DIAL_DEFAULT_ACTIONS.map((a) => a.id)
+    expect(ids).toContain('send')
+    expect(ids).toContain('receive')
+    expect(ids).toContain('swap')
+  })
+
+  it('default Send action routes to /transactions?action=send', () => {
+    const sendAction = SPEED_DIAL_DEFAULT_ACTIONS.find((a) => a.id === 'send')
+    expect(sendAction?.to).toBe('/transactions?action=send')
+  })
+
+  it('default Receive action routes to /transactions?action=receive', () => {
+    const receiveAction = SPEED_DIAL_DEFAULT_ACTIONS.find((a) => a.id === 'receive')
+    expect(receiveAction?.to).toBe('/transactions?action=receive')
+  })
+
+  it('default Swap action routes to /transactions?action=swap', () => {
+    const swapAction = SPEED_DIAL_DEFAULT_ACTIONS.find((a) => a.id === 'swap')
+    expect(swapAction?.to).toBe('/transactions?action=swap')
+  })
+})

--- a/src/components/SpeedDial.tsx
+++ b/src/components/SpeedDial.tsx
@@ -1,0 +1,265 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import './SpeedDial.css'
+
+/** A single action shown in the speed-dial menu. */
+export interface SpeedDialAction {
+  /** Machine-readable id, used as the React key. */
+  id: string
+  /** Human-readable label shown in the pill next to the icon. */
+  label: string
+  /** Route to navigate to when the action is activated. */
+  to: string
+  /** Icon rendered inside the mini button (SVG element). */
+  icon: React.ReactNode
+  /** Accessible label for the icon button (overrides `label` if provided). */
+  ariaLabel?: string
+}
+
+export interface SpeedDialProps {
+  /**
+   * Override the default actions (Send / Receive / Swap).
+   * Primarily useful for testing or white-labelling.
+   */
+  actions?: SpeedDialAction[]
+}
+
+/* ── Default icons ───────────────────────────────────────────────────────── */
+
+const SendIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path
+      d="M22 2L11 13M22 2L15 22L11 13M22 2L2 9L11 13"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
+const ReceiveIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path
+      d="M12 3v14M5 14l7 7 7-7"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M3 19h18"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+  </svg>
+)
+
+const SwapIcon = () => (
+  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path
+      d="M7 16V4m0 0L3 8m4-4l4 4"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M17 8v12m0 0l4-4m-4 4l-4-4"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
+const PlusIcon = () => (
+  <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+    <path
+      d="M12 5v14M5 12h14"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+    />
+  </svg>
+)
+
+/* ── Default actions ─────────────────────────────────────────────────────── */
+
+const DEFAULT_ACTIONS: SpeedDialAction[] = [
+  {
+    id: 'send',
+    label: 'Send',
+    to: '/transactions?action=send',
+    icon: <SendIcon />,
+    ariaLabel: 'Send funds',
+  },
+  {
+    id: 'receive',
+    label: 'Receive',
+    to: '/transactions?action=receive',
+    icon: <ReceiveIcon />,
+    ariaLabel: 'Receive funds',
+  },
+  {
+    id: 'swap',
+    label: 'Swap',
+    to: '/transactions?action=swap',
+    icon: <SwapIcon />,
+    ariaLabel: 'Swap assets',
+  },
+]
+
+/* ── Component ───────────────────────────────────────────────────────────── */
+
+/**
+ * SpeedDial – mobile-only floating action button (≤768 px) that expands to
+ * reveal Send, Receive, and Swap shortcuts.
+ *
+ * Accessibility contract:
+ * - The FAB has `aria-expanded` and `aria-controls` referencing the action list.
+ * - The action list has `role="list"` and each item has an accessible label.
+ * - Pressing Escape closes the menu and returns focus to the FAB.
+ * - Focus is trapped inside the open menu (Tab / Shift+Tab cycle within it).
+ * - The whole widget is wrapped in a `<nav>` with an accessible name so screen
+ *   reader users can skip or navigate to it easily.
+ */
+export default function SpeedDial({ actions = DEFAULT_ACTIONS }: SpeedDialProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const fabRef = useRef<HTMLButtonElement>(null)
+  const listRef = useRef<HTMLUListElement>(null)
+  const navigate = useNavigate()
+
+  const close = useCallback(() => setIsOpen(false), [])
+  const toggle = useCallback(() => setIsOpen((prev) => !prev), [])
+
+  /* Close on Escape, move focus back to FAB */
+  useEffect(() => {
+    if (!isOpen) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        close()
+        fabRef.current?.focus()
+      }
+
+      /* Basic Tab-trap: keep Tab / Shift+Tab inside the open list + FAB */
+      if (e.key === 'Tab' && listRef.current) {
+        const focusable = Array.from(
+          listRef.current.querySelectorAll<HTMLElement>(
+            'a[href], button:not(:disabled), [tabindex]:not([tabindex="-1"])'
+          )
+        )
+        if (!focusable.length) return
+
+        const first = focusable[0]
+        const last = focusable[focusable.length - 1]
+
+        if (e.shiftKey) {
+          if (document.activeElement === first || document.activeElement === fabRef.current) {
+            e.preventDefault()
+            last.focus()
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault()
+            fabRef.current?.focus()
+          }
+        }
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, close])
+
+  /* Close when clicking outside */
+  useEffect(() => {
+    if (!isOpen) return
+
+    const handlePointerDown = (e: PointerEvent) => {
+      const fab = fabRef.current
+      const list = listRef.current
+      if (
+        fab &&
+        list &&
+        !fab.contains(e.target as Node) &&
+        !list.contains(e.target as Node)
+      ) {
+        close()
+      }
+    }
+
+    window.addEventListener('pointerdown', handlePointerDown)
+    return () => window.removeEventListener('pointerdown', handlePointerDown)
+  }, [isOpen, close])
+
+  /* Move focus into the list when it opens */
+  useEffect(() => {
+    if (!isOpen || !listRef.current) return
+    const firstAction = listRef.current.querySelector<HTMLElement>(
+      'a[href], button:not(:disabled)'
+    )
+    firstAction?.focus()
+  }, [isOpen])
+
+  const handleActionClick = useCallback(
+    (to: string) => {
+      close()
+      navigate(to)
+    },
+    [close, navigate]
+  )
+
+  const listId = 'speed-dial-actions'
+
+  return (
+    <nav className="speedDial" aria-label="Quick actions">
+      {/* Action list – rendered first in DOM so FAB (order:2) sits on top */}
+      <ul
+        id={listId}
+        ref={listRef}
+        className={`speedDial__actions${isOpen ? ' speedDial__actions--open' : ''}`}
+        role="list"
+        aria-label="Quick action menu"
+      >
+        {actions.map((action) => (
+          <li key={action.id} className="speedDial__item">
+            <span className="speedDial__label" aria-hidden="true">
+              {action.label}
+            </span>
+            <button
+              type="button"
+              className="speedDial__action"
+              aria-label={action.ariaLabel ?? action.label}
+              tabIndex={isOpen ? 0 : -1}
+              onClick={() => handleActionClick(action.to)}
+            >
+              {action.icon}
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      {/* FAB toggle */}
+      <button
+        ref={fabRef}
+        type="button"
+        className={`speedDial__fab${isOpen ? ' speedDial__fab--open' : ''}`}
+        aria-label={isOpen ? 'Close quick actions' : 'Open quick actions'}
+        aria-expanded={isOpen}
+        aria-controls={listId}
+        onClick={toggle}
+      >
+        <span className="speedDial__fabIcon">
+          <PlusIcon />
+        </span>
+      </button>
+    </nav>
+  )
+}
+
+export { DEFAULT_ACTIONS as SPEED_DIAL_DEFAULT_ACTIONS }


### PR DESCRIPTION
feat: mobile speed-dial for Send / Receive / Swap on ≤768px
  
  Summary
  
  Adds a floating action button (SpeedDial) that appears in the bottom-right corner on screens
  ≤768 px. Tapping the FAB expands a vertical menu with three quick-action shortcuts — Send,
  Receive, and Swap — each navigating to /transactions?action=<id>. On desktop the component is
  invisible (display: none via CSS media query).
  
  Closes #<issue>
  
  Changes
  
  - src/components/SpeedDial.tsx — new component. FAB with aria-expanded / aria-controls,
  Escape-to-close (focus returns to FAB), Tab-trap inside the open menu, and tabIndex=-1 on
  action buttons when collapsed. Accepts an optional actions prop for overrides; exports
  SPEED_DIAL_DEFAULT_ACTIONS for extension. Backwards-compatible public API.
  - src/components/SpeedDial.css — token-only styles (--credence-* variables throughout, no
  hard-coded colours or spacing). Visibility controlled by @media (max-width: 768px). Includes
  dark-mode overrides and prefers-reduced-motion guard.
  - src/components/Layout.tsx — mounts <SpeedDial /> after <BackToTop /> so it appears on every
  route automatically.
  - src/components/SpeedDial.test.tsx — 25 unit tests covering render, open/close toggle,
  aria-expanded, aria-controls, Escape key, focus return, all three default actions, per-action
  navigation routes, custom actions override, tabIndex lifecycle, and the
  SPEED_DIAL_DEFAULT_ACTIONS export.
  - docs/COMPONENTS.md — SpeedDial added to the styling ownership table and given a full
  component entry: props table, SpeedDialAction interface, default actions table, accessibility
  contract, tokens consumed, and usage examples.
  
  What was tested
  
  - All 25 new SpeedDial tests pass.
  - Full test suite: 928 passing / 196 failing — identical counts to the baseline on main before
  this change (no regressions introduced).
  - ESLint: no new errors in any file touched by this PR.
  
  Notes for reviewers
  
  - The breakpoint (768 px) reuses the existing BREAKPOINTS.MD constant from
  src/config/breakpoints.ts — no new magic numbers.
  - Default routes (/transactions?action=send etc.) are placeholders; they can be updated to the
  canonical send/receive/swap routes once those pages exist.
closes #563