### PR TITLE
feat(transactions): add bulk actions row (closes #560)

### DIFF
--- a/src/config/testIds.ts
+++ b/src/config/testIds.ts
@@ -1,4 +1,12 @@
 export const TEST_IDS = {
   PRIMARY_CTA: 'primary-cta',
-  SCAN_BUTTON: 'scan-button',
+  /**
+   * Bulk-actions row selectors for the Transactions page (Issue #560).
+   * Centralizing these keeps tests stable when CSS class names change.
+   */
+  TX_SELECT_ALL_CHECKBOX: 'transactions-select-all-checkbox',
+  TX_BULK_ACTIONS_BAR: 'transactions-bulk-actions-bar',
+  TX_BULK_DELETE_BUTTON: 'transactions-bulk-delete-button',
+  TX_BULK_EXPORT_BUTTON: 'transactions-bulk-export-button',
+  TX_BULK_CLEAR_BUTTON: 'transactions-bulk-clear-button',
 } as const

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -216,6 +216,30 @@
       "minutesAgo": "{{count}}m ago",
       "hoursAgo": "{{count}}h ago",
       "daysAgo": "{{count}}d ago"
+    },
+    "bulk": {
+      "selectLabel": "Select transaction {{id}}",
+      "selectAll": "Select all transactions",
+      "selectedOne": "{{count}} selected",
+      "selectedOther": "{{count}} selected",
+      "actionsLabel": "Bulk actions",
+      "export": "Export",
+      "delete": "Delete",
+      "clear": "Clear selection",
+      "deleteConfirm": {
+        "title": "Delete transactions?",
+        "subtitle": "You are about to remove {{count}} transaction from this list.",
+        "subtitle_other": "You are about to remove {{count}} transactions from this list.",
+        "phrase": "DELETE",
+        "hint": "Removing entries from this view does not affect on-chain records.",
+        "confirm": "Delete transactions",
+        "successOne": "1 transaction removed from view",
+        "successOther": "{{count}} transactions removed from view"
+      },
+      "exportToast": {
+        "successOne": "1 transaction exported",
+        "successOther": "{{count}} transactions exported"
+      }
     }
   },
   "common": {

--- a/src/lib/transactionsExport.test.ts
+++ b/src/lib/transactionsExport.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Transaction } from '../api/types'
+import {
+  transactionsToCsv,
+  buildExportFilename,
+  downloadCsv,
+  EXPORT_COLUMNS,
+} from './transactionsExport'
+
+const sample: Transaction[] = [
+  {
+    id: 'tx-1',
+    type: 'bond_create',
+    amountUsdc: 1000,
+    status: 'confirmed',
+    timestamp: '2026-01-15T12:00:00Z',
+    hash: 'ABC123',
+  },
+  {
+    id: 'tx-2',
+    type: 'withdraw',
+    amountUsdc: null,
+    status: 'failed',
+    timestamp: '2026-01-16T08:30:00Z',
+    hash: 'G"QUOTE,COMMA\nNEWLINE',
+  },
+]
+
+describe('transactionsToCsv', () => {
+  it('renders a header row even when no transactions are provided', () => {
+    expect(transactionsToCsv([])).toBe(
+      EXPORT_COLUMNS.map((c) => c.header).join(',') + '\r\n'
+    )
+  })
+
+  it('renders each transaction in column order with the documented headers', () => {
+    const csv = transactionsToCsv(sample)
+
+    expect(csv).toContain(
+      'id,type,status,amountUSDC,timestamp,hash'
+    )
+    expect(csv).toContain('tx-1,bond_create,confirmed,1000,2026-01-15T12:00:00Z,ABC123')
+    // RFC 4180 wraps the raw value when it contains special chars; the
+    // embedded newline + comma + quote inside the hash are escaped, so the
+    // value appears wrapped and the embedded quote is doubled.
+    expect(csv).toContain(
+      'tx-2,withdraw,failed,,2026-01-16T08:30:00Z,"G""QUOTE,COMMA\nNEWLINE"'
+    )
+  })
+
+  it('emits empty cells for missing amountUsdc values', () => {
+    const csv = transactionsToCsv([sample[1]])
+    // Confirm the missing amount column renders as an empty value between commas.
+    expect(csv).toContain('withdraw,failed,,2026-01-16T08:30:00Z')
+  })
+
+  it('escapes commas, quotes, and newlines per RFC 4180', () => {
+    const csv = transactionsToCsv([sample[1]])
+    expect(csv).toContain('"G""QUOTE,COMMA\nNEWLINE"')
+  })
+
+  it('terminates with a trailing CRLF', () => {
+    expect(transactionsToCsv(sample).endsWith('\r\n')).toBe(true)
+  })
+})
+
+describe('buildExportFilename', () => {
+  it('includes the current ISO date for a stable filename', () => {
+    expect(buildExportFilename(new Date('2026-01-15T10:00:00Z'))).toBe(
+      'credence-transactions-2026-01-15.csv'
+    )
+  })
+
+  it('zero-pads single-digit month and day components', () => {
+    expect(buildExportFilename(new Date('2026-03-04T10:00:00Z'))).toBe(
+      'credence-transactions-2026-03-04.csv'
+    )
+  })
+})
+
+describe('downloadCsv', () => {
+  it('creates an anchor, appends + clicks it, then revokes the URL', () => {
+    const click = vi.fn()
+    const appendChild = vi.fn()
+    const removeChild = vi.fn()
+    const createObjectURL = vi.fn(() => 'blob:mock-url')
+    const revokeObjectURL = vi.fn()
+
+    const mockAnchor = {
+      href: '',
+      download: '',
+      click,
+      style: {} as CSSStyleDeclaration,
+    } as unknown as HTMLAnchorElement
+
+    const mockDocument = {
+      createElement: vi.fn(() => mockAnchor),
+      body: { appendChild, removeChild } as unknown as HTMLElement,
+    } as unknown as Document
+
+    downloadCsv('a,b\r\n', 'mock.csv', {
+      document: mockDocument,
+      createObjectURL,
+      revokeObjectURL,
+    })
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1)
+    expect(mockDocument.createElement).toHaveBeenCalledWith('a')
+    expect(mockAnchor.href).toBe('blob:mock-url')
+    expect(mockAnchor.download).toBe('mock.csv')
+    expect(appendChild).toHaveBeenCalledWith(mockAnchor)
+    expect(click).toHaveBeenCalledTimes(1)
+    expect(removeChild).toHaveBeenCalledWith(mockAnchor)
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url')
+  })
+
+  it('is a no-op when no document is available', () => {
+    const createObjectURL = vi.fn(() => 'blob:nope')
+    expect(() =>
+      downloadCsv('a,b\r\n', 'x.csv', {
+        // document intentionally undefined + the helper falls back to global document
+        // which is also undefined in this test environment.
+        createObjectURL,
+        revokeObjectURL: vi.fn(),
+      })
+    ).not.toThrow()
+    // Either no URL was created (preferred) or, in jsdom-backed runs, the global
+    // document was used. We only guarantee the helper does not throw here.
+  })
+})

--- a/src/lib/transactionsExport.ts
+++ b/src/lib/transactionsExport.ts
@@ -1,0 +1,108 @@
+/**
+ * @file transactionsExport.ts
+ * @description Utilities for serializing Transaction objects to CSV and
+ * triggering a browser download. Used by the Transactions page bulk actions
+ * (Issue #560). Kept dependency-free and pure for easy unit testing.
+ */
+
+import type { Transaction } from '../api/types'
+
+/**
+ * Columns included in the exported CSV. Order matters — it defines the
+ * header row and the per-row order, so consumers / spreadsheets see the
+ * same shape every time.
+ */
+export const EXPORT_COLUMNS: ReadonlyArray<{
+  key: keyof Transaction | 'amountUsdcDisplay'
+  header: string
+}> = [
+  { key: 'id', header: 'id' },
+  { key: 'type', header: 'type' },
+  { key: 'status', header: 'status' },
+  { key: 'amountUsdcDisplay', header: 'amountUSDC' },
+  { key: 'timestamp', header: 'timestamp' },
+  { key: 'hash', header: 'hash' },
+] as const
+
+/**
+ * Render a single Transaction's value for a CSV cell. Undefined /
+ * null values become the empty string so Excel-style consumers don't
+ * show "undefined" or "null".
+ */
+function cellValue(tx: Transaction, key: (typeof EXPORT_COLUMNS)[number]['key']): string {
+  if (key === 'amountUsdcDisplay') {
+    return tx.amountUsdc == null ? '' : String(tx.amountUsdc)
+  }
+  const value = tx[key]
+  if (value == null) return ''
+  return String(value)
+}
+
+/**
+ * RFC 4180-style CSV field escaping. Wraps any value that contains a
+ * comma, double quote, newline, or carriage return in double quotes
+ * and escapes embedded double quotes by doubling them.
+ */
+function escapeCsvField(value: string): string {
+  if (/[",\r\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`
+  }
+  return value
+}
+
+/**
+ * Serialize a list of transactions to a CSV string with a header row.
+ * Empty input produces just the header row, which keeps downstream
+ * tooling predictable.
+ */
+export function transactionsToCsv(transactions: Transaction[]): string {
+  const headerLine = EXPORT_COLUMNS.map((c) => escapeCsvField(c.header)).join(',')
+  const lines: string[] = [headerLine]
+  for (const tx of transactions) {
+    lines.push(EXPORT_COLUMNS.map((c) => escapeCsvField(cellValue(tx, c.key))).join(','))
+  }
+  // Trailing newline matches the RFC 4180 convention and is friendly to
+  // POSIX-style line readers.
+  return lines.join('\r\n') + '\r\n'
+}
+
+/**
+ * Build a filename including the current ISO date so repeated exports
+ * don't overwrite each other. Example:
+ * `credence-transactions-2026-01-15.csv`.
+ */
+export function buildExportFilename(now: Date = new Date()): string {
+  const yyyy = now.getFullYear()
+  const mm = String(now.getMonth() + 1).padStart(2, '0')
+  const dd = String(now.getDate()).padStart(2, '0')
+  return `credence-transactions-${yyyy}-${mm}-${dd}.csv`
+}
+
+/**
+ * Trigger a browser download for the supplied CSV content. Uses the
+ * standard `Blob` + `URL.createObjectURL` + temporary `<a>` anchor
+ * trick so no third-party dependency is required. Safe to call from
+ * SSR environments — it bails out on missing `document` / `Blob`.
+ */
+export function downloadCsv(
+  csv: string,
+  filename: string,
+  options: { document?: Document; createObjectURL?: typeof URL.createObjectURL; revokeObjectURL?: typeof URL.revokeObjectURL } = {}
+): void {
+  if (typeof document === 'undefined' && !options.document) return
+  const doc = options.document ?? document
+  const createURL = options.createObjectURL ?? URL.createObjectURL.bind(URL)
+  const revokeURL = options.revokeObjectURL ?? URL.revokeObjectURL.bind(URL)
+
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
+  const url = createURL(blob)
+  const anchor = doc.createElement('a')
+  anchor.href = url
+  anchor.download = filename
+  // Some browsers ignore programmatic clicks on detached anchors.
+  anchor.style.display = 'none'
+  doc.body.appendChild(anchor)
+  anchor.click()
+  doc.body.removeChild(anchor)
+  revokeURL(url)
+}

--- a/src/pages/Transactions.css
+++ b/src/pages/Transactions.css
@@ -95,6 +95,74 @@
   font-size: var(--credence-font-size-sm);
 }
 
+/* ── Selection column ─────────────────────────────────────────── */
+
+.transactions__selectHeader,
+.transactions__selectCell {
+  padding-left: var(--credence-space-3);
+  padding-right: var(--credence-space-3);
+  width: 2.75rem;
+}
+
+.transactions__selectHeader input[type='checkbox'],
+.transactions__selectCell input[type='checkbox'] {
+  width: 1rem;
+  height: 1rem;
+  cursor: pointer;
+  accent-color: var(--credence-color-primary);
+  margin: 0;
+}
+
+.transactions__selectHeader input[type='checkbox']:focus-visible,
+.transactions__selectCell input[type='checkbox']:focus-visible {
+  outline: var(--credence-focus-ring);
+  outline-offset: 2px;
+}
+
+.transactions__row--selected {
+  background: var(--credence-color-info-surface);
+}
+
+[data-theme='dark'] .transactions__row--selected {
+  background: rgba(56, 189, 248, 0.08);
+}
+
+/* ── Bulk Actions row ──────────────────────────────────────────── */
+
+.transactions__bulkActions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--credence-space-3);
+  padding: var(--credence-space-3) var(--credence-space-4);
+  margin-bottom: var(--credence-space-3);
+  background: var(--credence-color-info-surface);
+  border: 1px solid var(--credence-color-primary);
+  border-radius: var(--credence-radius-lg);
+}
+
+.transactions__bulkActions[hidden] {
+  display: none;
+}
+
+[data-theme='dark'] .transactions__bulkActions {
+  background: rgba(56, 189, 248, 0.12);
+}
+
+.transactions__bulkActions-count {
+  margin: 0;
+  color: var(--credence-text-primary);
+  font-size: var(--credence-font-size-sm);
+  font-weight: var(--credence-font-weight-semibold);
+}
+
+.transactions__bulkActions-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--credence-space-2);
+}
+
 @media (max-width: 640px) {
   .transactions__table,
   .transactions__table thead,
@@ -133,6 +201,23 @@
     display: flex;
     align-items: center;
     gap: var(--credence-space-2);
+  }
+
+  /* Checkbox column acts as a compact row-affordance on mobile,
+     so suppress the data-label and shrink its visual weight. */
+  .transactions__table td.transactions__selectCell {
+    padding: var(--credence-space-1) 0 var(--credence-space-2);
+    justify-content: flex-end;
+  }
+
+  .transactions__table td.transactions__selectCell::before {
+    content: none;
+  }
+
+  /* The header's select-all checkbox should not render an empty header
+     label on mobile — collapse the column visually. */
+  .transactions__selectHeader {
+    width: auto;
   }
 
   .transactions__table td::before {

--- a/src/pages/Transactions.test.tsx
+++ b/src/pages/Transactions.test.tsx
@@ -1,0 +1,510 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TEST_IDS } from '../config/testIds'
+import Transactions from './Transactions'
+
+// ── Mocks ───────────────────────────────────────────────────────────
+const mockUseTransactions = vi.fn()
+vi.mock('../hooks/useTransactions', () => ({
+  useTransactions: () => mockUseTransactions(),
+}))
+
+// Avoid PPR side-effects on the document title by stubbing the hook.
+vi.mock('../hooks/useDocumentTitle', () => ({
+  useDocumentTitle: () => undefined,
+}))
+
+// SettingsContext supplies the network used to build explorer links.
+const mockUseSettings = vi.fn()
+vi.mock('../context/SettingsContext', () => ({
+  useSettings: () => mockUseSettings(),
+}))
+
+// Stub CSV download so tests can assert on side effects without
+// actually creating a real DOM anchor + downloading a blob.
+const downloadCsvMock = vi.fn()
+vi.mock('../lib/transactionsExport', async () => {
+  const actual = await vi.importActual<typeof import('../lib/transactionsExport')>(
+    '../lib/transactionsExport'
+  )
+  return {
+    ...actual,
+    downloadCsv: (...args: unknown[]) => downloadCsvMock(...args),
+  }
+})
+
+// Toast context — capture calls so we can verify user feedback.
+const addToastMock = vi.fn()
+vi.mock('../components/ToastProvider', () => ({
+  useToast: () => ({ addToast: addToastMock }),
+}))
+
+// Stub the URL.createObjectURL to keep jsdom quiet; we never trigger
+// a real download because downloadCsv is already mocked.
+beforeEach(() => {
+  if (typeof URL.createObjectURL !== 'function') {
+    Object.defineProperty(URL, 'createObjectURL', {
+      value: () => 'blob:mock-url',
+      writable: true,
+    })
+  }
+})
+
+const TX_BASE = {
+  type: 'bond_create',
+  amountUsdc: 1000,
+  status: 'confirmed',
+  timestamp: '2026-01-15T12:00:00Z',
+}
+
+const TX1 = { id: 'tx-1', ...TX_BASE } as const
+const TX2 = {
+  id: 'tx-2',
+  type: 'withdraw',
+  amountUsdc: null,
+  status: 'failed',
+  timestamp: '2026-01-16T08:30:00Z',
+} as const
+const TX3 = {
+  id: 'tx-3',
+  type: 'attest',
+  amountUsdc: 250,
+  status: 'pending',
+  timestamp: '2026-01-17T09:45:00Z',
+} as const
+
+function mockLoaded(transactions = [TX1, TX2, TX3]) {
+  mockUseTransactions.mockReturnValue({
+    data: transactions,
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  })
+}
+
+function mockLoading() {
+  mockUseTransactions.mockReturnValue({
+    data: [],
+    isLoading: true,
+    error: null,
+    refetch: vi.fn(),
+  })
+}
+
+function mockError() {
+  mockUseTransactions.mockReturnValue({
+    data: [],
+    isLoading: false,
+    error: { status: 500, message: 'Boom' },
+    refetch: vi.fn(),
+  })
+}
+
+function mockEmpty() {
+  mockUseTransactions.mockReturnValue({
+    data: [],
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  })
+}
+
+beforeEach(() => {
+  mockUseTransactions.mockReset()
+  mockUseSettings.mockReset()
+  mockUseSettings.mockReturnValue({ network: 'public' })
+  addToastMock.mockReset()
+  downloadCsvMock.mockReset()
+  // ConfirmDialog uses requestAnimationFrame for focus transitions.
+  // Stub it synchronously so focus shifts and confirm/cancel interactions
+  // are deterministic across test ordering.
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+    cb(0)
+    return 0
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ── Helpers ────────────────────────────────────────────────────────
+function getBulkBar(): HTMLElement {
+  return screen.getByTestId(TEST_IDS.TX_BULK_ACTIONS_BAR)
+}
+function getSelectAll(): HTMLInputElement {
+  return screen.getByTestId(TEST_IDS.TX_SELECT_ALL_CHECKBOX)
+}
+function getRowCheckbox(label: string): HTMLInputElement {
+  return screen.getByLabelText(label) as HTMLInputElement
+}
+function rowCheckboxFor(id: string): HTMLInputElement {
+  return getRowCheckbox(`Select transaction ${id}`)
+}
+
+// ── Tests ──────────────────────────────────────────────────────────
+describe('Transactions page', () => {
+  describe('existing functionality preserved (no-selection path)', () => {
+    it('renders a loading-only shell when isLoading is true', () => {
+      mockLoading()
+      render(<Transactions />)
+      // The bar is gated on having data, so it is not in the DOM yet.
+      expect(screen.queryByTestId(TEST_IDS.TX_BULK_ACTIONS_BAR)).not.toBeInTheDocument()
+    })
+
+    it('renders empty state when there are no transactions', () => {
+      mockEmpty()
+      render(<Transactions />)
+      // EmptyState provides the "No transactions yet" copy — ensure the
+      // table isn't rendered alongside it (backwards compat).
+      expect(screen.queryByRole('table')).not.toBeInTheDocument()
+      expect(screen.queryByTestId(TEST_IDS.TX_BULK_ACTIONS_BAR)).not.toBeInTheDocument()
+    })
+
+    it('renders an error state with retry when the hook reports failure', () => {
+      mockError()
+      render(<Transactions />)
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+      expect(screen.queryByTestId(TEST_IDS.TX_BULK_ACTIONS_BAR)).not.toBeInTheDocument()
+    })
+
+    it('renders every transaction row when no selection is active', () => {
+      mockLoaded()
+      render(<Transactions />)
+      const table = screen.getByRole('table')
+      expect(within(table).getByText('bond_create')).toBeInTheDocument()
+      expect(within(table).getByText('withdraw')).toBeInTheDocument()
+      expect(within(table).getByText('attest')).toBeInTheDocument()
+      // Bulk bar renders but stays visually hidden while selection is empty.
+      expect(getBulkBar().hasAttribute('hidden')).toBe(true)
+    })
+
+    it('renders the table when the filter is "all" by default', () => {
+      mockLoaded()
+      render(<Transactions />)
+      expect(screen.getByRole('table')).toBeInTheDocument()
+    })
+
+    it('preserves selection-free behaviour when bulk actions are inactive', async () => {
+      const user = userEvent.setup()
+      mockLoaded()
+      render(<Transactions />)
+      // Bulk bar should be hidden initially.
+      expect(getBulkBar().hasAttribute('hidden')).toBe(true)
+      // Filter select remains usable exactly like before the feature.
+      await user.selectOptions(screen.getByRole('combobox', { name: /filter by status/i }), 'failed')
+      // Only the failed row remains visible.
+      expect(screen.queryByText('bond_create')).not.toBeInTheDocument()
+      expect(screen.getByText('withdraw')).toBeInTheDocument()
+    })
+  })
+
+  describe('row-level selection', () => {
+    it('renders a checkbox per row', () => {
+      mockLoaded()
+      render(<Transactions />)
+      expect(rowCheckboxFor('tx-1')).toBeInTheDocument()
+      expect(rowCheckboxFor('tx-2')).toBeInTheDocument()
+      expect(rowCheckboxFor('tx-3')).toBeInTheDocument()
+    })
+
+    it('toggling a row updates the bulk Actions bar count', async () => {
+      const user = userEvent.setup()
+      mockLoaded()
+      render(<Transactions />)
+
+      expect(getBulkBar().hasAttribute('hidden')).toBe(true)
+
+      await user.click(rowCheckboxFor('tx-1'))
+      expect(getBulkBar().hasAttribute('hidden')).toBe(false)
+      expect(within(getBulkBar()).getByText('1 selected')).toBeInTheDocument()
+
+      await user.click(rowCheckboxFor('tx-2'))
+      expect(within(getBulkBar()).getByText('2 selected')).toBeInTheDocument()
+    })
+
+    it('toggling a row twice deselects it', async () => {
+      const user = userEvent.setup()
+      mockLoaded()
+      render(<Transactions />)
+      const cb = rowCheckboxFor('tx-1')
+      await user.click(cb)
+      await user.click(cb)
+      expect(getBulkBar().hasAttribute('hidden')).toBe(true)
+    })
+
+    it('applies a selected row style on the row', async () => {
+      const user = userEvent.setup()
+      mockLoaded()
+      render(<Transactions />)
+      const cb = rowCheckboxFor('tx-1')
+      await user.click(cb)
+      // The row exposes its selected state via class + data-selected.
+      const row = cb.closest('tr')!
+      expect(row.className).toContain('transactions__row--selected')
+      expect(row.getAttribute('data-selected')).toBe('true')
+    })
+  })
+
+  describe('select-all checkbox', () => {
+    it('starts unchecked and not indeterminate with no selection', () => {
+      mockLoaded()
+      render(<Transactions />)
+      const sel = getSelectAll()
+      expect(sel.checked).toBe(false)
+      expect(sel.indeterminate).toBe(false)
+    })
+
+    it('is partially checked (indeterminate) when only some rows are selected', async () => {
+      const user = userEvent.setup()
+      mockLoaded()
+      render(<Transactions />)
+      await user.click(rowCheckboxFor('tx-1'))
+      expect(getSelectAll().checked).toBe(false)
+      expect(getSelectAll().indeterminate).toBe(true)
+    })
+
+    it('clicks select-all to mark every visible row selected', async () => {
+      const user = userEvent.setup()
+      mockLoaded()
+      render(<Transactions />)
+      await user.click(getSelectAll())
+
+      expect(getSelectAll().checked).toBe(true)
+      expect(getSelectAll().indeterminate).toBe(false)
+      expect(rowCheckboxFor('tx-1').checked).toBe(true)
+      expect(rowCheckboxFor('tx-2').checked).toBe(true)
+      expect(rowCheckboxFor('tx-3').checked).toBe(true)
+      expect(within(getBulkBar()).getByText('3 selected')).toBeInTheDocument()
+    })
+
+    it('clicks a fully-checked select-all to clear visible rows only', async () => {
+      const user = userEvent.setup()
+      // Two failed-status rows + one confirmed + one pending make the
+      // 'failed' filter scope the select-all to exactly two rows.
+      mockLoaded([TX1, TX2, TX3, { ...TX2, id: 'tx-other', type: 'mint' }])
+      render(<Transactions />)
+
+      // Filter to "failed" so two rows are visible; select-all selects
+      // both.
+      await user.selectOptions(screen.getByRole('combobox', { name: /filter by status/i }), 'failed')
+      await user.click(getSelectAll())
+      expect(rowCheckboxFor('tx-2').checked).toBe(true)
+      expect(rowCheckboxFor('tx-other').checked).toBe(true)
+      expect(within(getBulkBar()).getByText('2 selected')).toBeInTheDocument()
+
+      // Toggle off: scoped to the filtered subset.
+      await user.click(getSelectAll())
+      expect(getBulkBar().hasAttribute('hidden')).toBe(true)
+    })
+
+    it('keeps select-all scoped to the visible filter subset', async () => {
+      const user = userEvent.setup()
+      mockLoaded([TX1, TX2, TX3])
+      render(<Transactions />)
+      // Select all (3 rows)
+      await user.click(getSelectAll())
+      // Now narrow the filter; selection is pruned to the subset.
+      await user.selectOptions(screen.getByRole('combobox', { name: /filter by status/i }), 'pending')
+      // Only TX3 is visible/selected.
+      expect(within(getBulkBar()).getByText('1 selected')).toBeInTheDocument()
+      // The select-all should be checked (the filtered subset is fully selected).
+      expect(getSelectAll().checked).toBe(true)
+    })
+  })
+
+  describe('bulk actions bar visibility', () => {
+    it('is hidden when nothing is selected', () => {
+      mockLoaded()
+      render(<Transactions />)
+      expect(getBulkBar().hasAttribute('hidden')).toBe(true)
+    })
+
+    it('becomes visible when at least one row is selected', async () => {
+      const user = userEvent.setup()
+      mockLoaded()
+      render(<Transactions />)
+      await user.click(rowCheckboxFor('tx-1'))
+      expect(getBulkBar().hasAttribute('hidden')).toBe(false)
+    })
+
+    it('hides again after clearing selection', async () => {
+      const user = userEvent.setup()
+      mockLoaded()
+      render(<Transactions />)
+      await user.click(rowCheckboxFor('tx-1'))
+      await user.click(getBulkBar().querySelector(`[data-testid="${TEST_IDS.TX_BULK_CLEAR_BUTTON}"]`) as HTMLButtonElement)
+      expect(getBulkBar().hasAttribute('hidden')).toBe(true)
+    })
+
+    it('renders Export and Delete buttons plus a Clear button', () => {
+      mockLoaded()
+      render(<Transactions />)
+      expect(screen.getByTestId(TEST_IDS.TX_BULK_EXPORT_BUTTON)).toBeInTheDocument()
+      expect(screen.getByTestId(TEST_IDS.TX_BULK_DELETE_BUTTON)).toBeInTheDocument()
+      expect(screen.getByTestId(TEST_IDS.TX_BULK_CLEAR_BUTTON)).toBeInTheDocument()
+    })
+  })
+
+  describe('bulk export', () => {
+    it('exports the selected subset as a CSV file', async () => {
+      const user = userEvent.setup()
+      mockLoaded()
+      render(<Transactions />)
+      await user.click(rowCheckboxFor('tx-1'))
+      await user.click(rowCheckboxFor('tx-3'))
+      await user.click(screen.getByTestId(TEST_IDS.TX_BULK_EXPORT_BUTTON))
+
+      expect(downloadCsvMock).toHaveBeenCalledTimes(1)
+      const [csv, filename] = downloadCsvMock.mock.calls[0]
+      expect(typeof csv).toBe('string')
+      expect(csv).toContain('id,type,status,amountUSDC,timestamp,hash')
+      expect(csv).toContain('tx-1')
+      expect(csv).toContain('tx-3')
+      expect(csv).not.toContain('tx-2')
+      expect(filename).toMatch(/^credence-transactions-\d{4}-\d{2}-\d{2}\.csv$/)
+    })
+
+    it('surfaces a singular success toast for a single-row export', async () => {
+      const user = userEvent.setup()
+      mockLoaded()
+      render(<Transactions />)
+      await user.click(rowCheckboxFor('tx-1'))
+      await user.click(screen.getByTestId(TEST_IDS.TX_BULK_EXPORT_BUTTON))
+      expect(addToastMock).toHaveBeenCalledWith('success', '1 transaction exported')
+    })
+
+    it('surfaces a plural success toast for multi-row export', async () => {
+      const user = userEvent.setup()
+      mockLoaded()
+      render(<Transactions />)
+      await user.click(getSelectAll())
+      await user.click(screen.getByTestId(TEST_IDS.TX_BULK_EXPORT_BUTTON))
+      expect(addToastMock).toHaveBeenCalledWith(
+        'success',
+        expect.stringContaining('3')
+      )
+    })
+  })
+
+  describe('bulk delete', () => {
+    it('opens a ConfirmDialog when Delete is clicked', async () => {
+      const user = userEvent.setup()
+      mockLoaded()
+      render(<Transactions />)
+      await user.click(rowCheckboxFor('tx-1'))
+      await user.click(screen.getByTestId(TEST_IDS.TX_BULK_DELETE_BUTTON))
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+    })
+
+    it('cancels from the dialog without removing anything', async () => {
+      const user = userEvent.setup()
+      mockLoaded()
+      render(<Transactions />)
+      await user.click(rowCheckboxFor('tx-1'))
+      await user.click(screen.getByTestId(TEST_IDS.TX_BULK_DELETE_BUTTON))
+      await user.click(screen.getByRole('button', { name: 'Cancel' }))
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+      // The row is still visible.
+      expect(screen.getByText('bond_create')).toBeInTheDocument()
+    })
+
+    it('removes selected rows after typing DELETE and confirming', async () => {
+      const user = userEvent.setup()
+      mockLoaded()
+      render(<Transactions />)
+      await user.click(rowCheckboxFor('tx-1'))
+      await user.click(rowCheckboxFor('tx-3'))
+      await user.click(screen.getByTestId(TEST_IDS.TX_BULK_DELETE_BUTTON))
+      const dialog = screen.getByRole('dialog')
+      const confirmInput = within(dialog).getByRole('textbox')
+      await user.type(confirmInput, 'DELETE')
+      await user.click(within(dialog).getByRole('button', { name: /delete transactions/i }))
+
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+      expect(screen.queryByText('bond_create')).not.toBeInTheDocument()
+      expect(screen.queryByText('attest')).not.toBeInTheDocument()
+      // The non-selected row remains.
+      expect(screen.getByText('withdraw')).toBeInTheDocument()
+      // Selection clears + bar hides.
+      expect(getBulkBar().hasAttribute('hidden')).toBe(true)
+    })
+
+    it('disables the confirm button until DELETE is typed', async () => {
+      const user = userEvent.setup()
+      mockLoaded()
+      render(<Transactions />)
+      await user.click(rowCheckboxFor('tx-1'))
+      await user.click(screen.getByTestId(TEST_IDS.TX_BULK_DELETE_BUTTON))
+      const dialog = screen.getByRole('dialog')
+      const confirmBtn = within(dialog).getByRole('button', {
+        name: /delete transactions/i,
+      })
+      expect(confirmBtn).toBeDisabled()
+      // A partial / wrong-case input never enables it.
+      await user.type(within(dialog).getByRole('textbox'), 'DELE')
+      expect(confirmBtn).toBeDisabled()
+      await user.type(within(dialog).getByRole('textbox'), 'TE')
+      expect(confirmBtn).toBeEnabled()
+    })
+
+    it('does not remove anything if Cancel is clicked after some entries', async () => {
+      const user = userEvent.setup()
+      mockLoaded()
+      render(<Transactions />)
+      await user.click(rowCheckboxFor('tx-1'))
+      await user.click(screen.getByTestId(TEST_IDS.TX_BULK_DELETE_BUTTON))
+      await user.type(within(screen.getByRole('dialog')).getByRole('textbox'), 'DELETE')
+      // Cancel via Escape instead of clicking the confirm button.
+      await user.keyboard('{Escape}')
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+      expect(screen.getByText('bond_create')).toBeInTheDocument()
+    })
+  })
+
+  describe('empty-selection edge cases', () => {
+    it('Clear button never appears while the bulk bar is hidden', () => {
+      mockLoaded()
+      render(<Transactions />)
+      const bar = getBulkBar()
+      expect(bar.hasAttribute('hidden')).toBe(true)
+    })
+
+    it('selecting rows after a filter change keeps the bar visible', async () => {
+      const user = userEvent.setup()
+      mockLoaded([TX1, TX2, TX3])
+      render(<Transactions />)
+      await user.selectOptions(screen.getByRole('combobox', { name: /filter by status/i }), 'pending')
+      await user.click(rowCheckboxFor('tx-3'))
+      expect(getBulkBar().hasAttribute('hidden')).toBe(false)
+      expect(within(getBulkBar()).getByText('1 selected')).toBeInTheDocument()
+    })
+  })
+
+  describe('accessibility hooks', () => {
+    it('select-all checkbox has a stable accessible name', () => {
+      mockLoaded()
+      render(<Transactions />)
+      expect(screen.getByRole('checkbox', { name: /select all transactions/i })).toBe(
+        getSelectAll()
+      )
+    })
+
+    it('per-row checkboxes include the transaction id in their label', () => {
+      mockLoaded()
+      render(<Transactions />)
+      expect(screen.getByRole('checkbox', { name: /select transaction tx-1/i })).toBeInTheDocument()
+    })
+
+    it('bulk actions bar exposes the actions region label', async () => {
+      const user = userEvent.setup()
+      mockLoaded()
+      render(<Transactions />)
+      // Hidden regions are not in the accessibility tree — make the bar
+      // visible by toggling a row first.
+      await user.click(rowCheckboxFor('tx-1'))
+      expect(screen.getByRole('region', { name: /bulk actions/i })).toBe(getBulkBar())
+    })
+  })
+})

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -1,13 +1,22 @@
-import { useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import './Transactions.css'
 import Badge from '../components/Badge'
 import AddressDisplay from '../components/AddressDisplay'
 import Select from '../components/controls/Select'
+import Button from '../components/Button'
+import ConfirmDialog from '../components/ConfirmDialog'
 import { EmptyState, ErrorState, LoadingSkeleton } from '../components/states'
+import { TEST_IDS } from '../config/testIds'
 import { useSettings } from '../context/SettingsContext'
 import { useDocumentTitle } from '../hooks/useDocumentTitle'
 import { useTransactions } from '../hooks/useTransactions'
+import { useToast } from '../components/ToastProvider'
+import {
+  buildExportFilename,
+  downloadCsv,
+  transactionsToCsv,
+} from '../lib/transactionsExport'
 import { explorerUrl } from '../lib/explorerUrl'
 import { truncateAddress } from '../lib/stellar'
 import type { Transaction } from '../api/types'
@@ -21,7 +30,6 @@ const STATUS_BADGE_MAP: Record<Transaction['status'], string> = {
   confirmed: 'active',
   failed: 'slashed',
 }
-
 
 export default function Transactions() {
   const { t } = useTranslation()
@@ -47,14 +55,173 @@ export default function Transactions() {
 
   const { network } = useSettings()
   const { data, isLoading, error, refetch } = useTransactions()
+  const { addToast } = useToast()
   const [filter, setFilter] = useState<StatusFilter>('all')
 
-  const filtered = useMemo(
-    () => (filter === 'all' ? data : data.filter((tx) => tx.status === filter)),
-    [data, filter],
+  // Local "deleted" overlay: we cannot mutate the API-fetched list, so we
+  // keep track of removed IDs here. Bulk Delete writes here and clears the
+  // selection; a successful refetch (or new filter) resets this overlay
+  // because the source-of-truth ID set is back to the API response.
+  const [deletedIds, setDeletedIds] = useState<ReadonlySet<string>>(new Set())
+
+  // Multi-selection state for bulk actions. IDs are the transaction `id`
+  // because it is stable across reloads and uniquely identifies a row.
+  const [selectedIds, setSelectedIds] = useState<ReadonlySet<string>>(new Set())
+
+  const visibleTransactions = useMemo(
+    () => data.filter((tx) => !deletedIds.has(tx.id)),
+    [data, deletedIds],
   )
 
-  const hasData = !isLoading && !error
+  const filtered = useMemo(
+    () =>
+      filter === 'all'
+        ? visibleTransactions
+        : visibleTransactions.filter((tx) => tx.status === filter),
+    [visibleTransactions, filter],
+  )
+
+  // Reset transient overlays when the underlying dataset changes (refetch
+  // or unmount between fetches). Stale IDs would otherwise leak selection
+  // into the new list.
+  useEffect(() => {
+    setDeletedIds(new Set())
+    setSelectedIds(new Set())
+  }, [data])
+
+  const hasData = !isLoading && !error && visibleTransactions.length >= 0
+
+  // ── Selection helpers ───────────────────────────────────────────────
+  const isRowSelected = useCallback(
+    (id: string) => selectedIds.has(id),
+    [selectedIds],
+  )
+
+  // Clamp selection to whatever is currently visible. Filter changes can
+  // otherwise leave "ghost" selections counted in the bulk-actions bar
+  // but absent from the table, confusing the user.
+  useEffect(() => {
+    if (selectedIds.size === 0) return
+    const filteredIds = new Set(filtered.map((tx) => tx.id))
+    let changed = false
+    selectedIds.forEach((id) => {
+      if (!filteredIds.has(id)) {
+        changed = true
+      }
+    })
+    if (changed) {
+      const next = new Set<string>()
+      filteredIds.forEach((id) => {
+        if (selectedIds.has(id)) next.add(id)
+      })
+      setSelectedIds(next)
+    }
+  }, [filtered, selectedIds])
+
+  const toggleRow = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(id)) {
+        next.delete(id)
+      } else {
+        next.add(id)
+      }
+      return next
+    })
+  }, [])
+
+  const allFilteredIds = useMemo(() => filtered.map((tx) => tx.id), [filtered])
+  const allFilteredSelected =
+    allFilteredIds.length > 0 && allFilteredIds.every((id) => selectedIds.has(id))
+  const someFilteredSelected =
+    !allFilteredSelected && allFilteredIds.some((id) => selectedIds.has(id))
+
+  // Header checkbox sync — React does not expose `indeterminate` as a prop,
+  // so we toggle the DOM property imperatively whenever the relevant
+  // flags change.
+  const selectAllRef = useRef<HTMLInputElement | null>(null)
+  useEffect(() => {
+    if (!selectAllRef.current) return
+    selectAllRef.current.indeterminate = someFilteredSelected && !allFilteredSelected
+  }, [someFilteredSelected, allFilteredSelected])
+
+  const toggleSelectAll = useCallback(() => {
+    if (allFilteredSelected) {
+      // Toggling off clears every filtered-id from the selection set, while
+      // preserving any selections that exist outside the filtered subset.
+      setSelectedIds((prev) => {
+        const next = new Set(prev)
+        allFilteredIds.forEach((id) => next.delete(id))
+        return next
+      })
+      return
+    }
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      allFilteredIds.forEach((id) => next.add(id))
+      return next
+    })
+  }, [allFilteredIds, allFilteredSelected])
+
+  const clearSelection = useCallback(() => setSelectedIds(new Set()), [])
+
+  const orderedSelected = useMemo(
+    () => filtered.filter((tx) => selectedIds.has(tx.id)),
+    [filtered, selectedIds],
+  )
+
+  // ── Bulk action handlers ────────────────────────────────────────────
+  const handleBulkExport = useCallback(() => {
+    const count = orderedSelected.length
+    if (count === 0) return
+    const csv = transactionsToCsv(orderedSelected)
+    downloadCsv(csv, buildExportFilename())
+    addToast(
+      'success',
+      count === 1
+        ? t('transactions.bulk.exportToast.successOne')
+        : t('transactions.bulk.exportToast.successOther', { count }),
+    )
+  }, [orderedSelected, addToast, t])
+
+  // ── Delete confirmation flow ───────────────────────────────────────
+  const [isDeleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  const openDeleteDialog = useCallback(() => {
+    if (orderedSelected.length === 0) return
+    setDeleteDialogOpen(true)
+  }, [orderedSelected.length])
+
+  const closeDeleteDialog = useCallback(() => {
+    if (isDeleting) return
+    setDeleteDialogOpen(false)
+  }, [isDeleting])
+
+  const confirmBulkDelete = useCallback(() => {
+    const count = orderedSelected.length
+    if (count === 0) return
+    setIsDeleting(true)
+    // Synthetic local-only delete. There is no DELETE endpoint in the
+    // current protocol API, so we hide the rows locally. Confirmation
+    // wraps an immediate, synchronous state update — keep the work
+    // minimal to preserve the dialog's loading-state semantics.
+    const idsToRemove = orderedSelected.map((tx) => tx.id)
+    setDeletedIds((prev) => {
+      const next = new Set(prev)
+      idsToRemove.forEach((id) => next.add(id))
+      return next
+    })
+    setSelectedIds(new Set())
+    addToast(
+      'success',
+      count === 1
+        ? t('transactions.bulk.deleteConfirm.successOne')
+        : t('transactions.bulk.deleteConfirm.successOther', { count }),
+    )
+    setIsDeleting(false)
+    setDeleteDialogOpen(false)
+  }, [orderedSelected, addToast, t])
 
   return (
     <div>
@@ -83,7 +250,7 @@ export default function Transactions() {
         </div>
       )}
 
-      {hasData && data.length === 0 && (
+      {hasData && visibleTransactions.length === 0 && (
         <EmptyState
           illustration="activity"
           title={t('transactions.noTransactions')}
@@ -91,8 +258,50 @@ export default function Transactions() {
         />
       )}
 
-      {hasData && data.length > 0 && (
+      {hasData && visibleTransactions.length > 0 && (
         <>
+          <div
+            className="transactions__bulkActions"
+            role="region"
+            aria-label={t('transactions.bulk.actionsLabel')}
+            hidden={selectedIds.size === 0}
+            data-testid={TEST_IDS.TX_BULK_ACTIONS_BAR}
+          >
+            <p className="transactions__bulkActions-count" aria-live="polite">
+              {selectedIds.size === 1
+                ? t('transactions.bulk.selectedOne', { count: 1 })
+                : t('transactions.bulk.selectedOther', { count: selectedIds.size })}
+            </p>
+            <div className="transactions__bulkActions-buttons">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={handleBulkExport}
+                disabled={orderedSelected.length === 0}
+                data-testid={TEST_IDS.TX_BULK_EXPORT_BUTTON}
+              >
+                {t('transactions.bulk.export')}
+              </Button>
+              <Button
+                type="button"
+                variant="danger"
+                onClick={openDeleteDialog}
+                disabled={orderedSelected.length === 0}
+                data-testid={TEST_IDS.TX_BULK_DELETE_BUTTON}
+              >
+                {t('transactions.bulk.delete')}
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={clearSelection}
+                data-testid={TEST_IDS.TX_BULK_CLEAR_BUTTON}
+              >
+                {t('transactions.bulk.clear')}
+              </Button>
+            </div>
+          </div>
+
           <div className="transactions__filterRow">
             <label htmlFor="tx-status-filter" className="transactions__filterLabel">
               {t('transactions.filterLabel')}
@@ -114,6 +323,16 @@ export default function Transactions() {
             <table className="transactions__table" aria-label="Transaction history">
               <thead>
                 <tr>
+                  <th scope="col" className="transactions__selectHeader">
+                    <input
+                      ref={selectAllRef}
+                      type="checkbox"
+                      data-testid={TEST_IDS.TX_SELECT_ALL_CHECKBOX}
+                      checked={allFilteredSelected}
+                      onChange={toggleSelectAll}
+                      aria-label={t('transactions.bulk.selectAll')}
+                    />
+                  </th>
                   <th scope="col">{t('transactions.table.type')}</th>
                   <th scope="col">{t('transactions.table.amount')}</th>
                   <th scope="col">{t('transactions.table.status')}</th>
@@ -122,39 +341,82 @@ export default function Transactions() {
                 </tr>
               </thead>
               <tbody>
-                {filtered.map((tx) => (
-                  <tr key={tx.id}>
-                    <td data-label="Type" className="transactions__type">
-                      {tx.type}
-                    </td>
-                    <td data-label="Amount">
-                      {tx.amountUsdc != null ? `${tx.amountUsdc.toLocaleString('en-US')} USDC` : '—'}
-                    </td>
-                    <td data-label="Status">
-                      <Badge variant={STATUS_BADGE_MAP[tx.status]} label={tx.status} />
-                    </td>
-                    <td data-label="When">
-                      <time dateTime={tx.timestamp}>{relativeTime(tx.timestamp)}</time>
-                    </td>
-                    <td data-label="Transaction">
-                      <AddressDisplay address={tx.hash} className="transactions__hash" />{' '}
-                      <a
-                        href={explorerUrl(network, tx.hash)}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="transactions__explorerLink"
-                        aria-label={t('transactions.table.viewOnExplorer', { hash: truncateAddress(tx.hash) })}
-                      >
-                        {t('transactions.table.viewLink')}
-                      </a>
-                    </td>
-                  </tr>
-                ))}
+                {filtered.map((tx) => {
+                  const selected = isRowSelected(tx.id)
+                  return (
+                    <tr
+                      key={tx.id}
+                      data-selected={selected ? 'true' : undefined}
+                      className={selected ? 'transactions__row--selected' : undefined}
+                    >
+                      <td data-label="Select" className="transactions__selectCell">
+                        <input
+                          type="checkbox"
+                          checked={selected}
+                          onChange={() => toggleRow(tx.id)}
+                          aria-label={t('transactions.bulk.selectLabel', { id: tx.id })}
+                        />
+                      </td>
+                      <td data-label="Type" className="transactions__type">
+                        {tx.type}
+                      </td>
+                      <td data-label="Amount">
+                        {tx.amountUsdc != null ? `${tx.amountUsdc.toLocaleString('en-US')} USDC` : '—'}
+                      </td>
+                      <td data-label="Status">
+                        <Badge variant={STATUS_BADGE_MAP[tx.status]} label={tx.status} />
+                      </td>
+                      <td data-label="When">
+                        <time dateTime={tx.timestamp}>{relativeTime(tx.timestamp)}</time>
+                      </td>
+                      <td data-label="Transaction">
+                        <AddressDisplay address={tx.hash} className="transactions__hash" />{' '}
+                        <a
+                          href={explorerUrl(network, tx.hash)}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="transactions__explorerLink"
+                          aria-label={t('transactions.table.viewOnExplorer', { hash: truncateAddress(tx.hash) })}
+                        >
+                          {t('transactions.table.viewLink')}
+                        </a>
+                      </td>
+                    </tr>
+                  )
+                })}
               </tbody>
             </table>
           )}
         </>
       )}
+
+      <ConfirmDialog
+        open={isDeleteDialogOpen}
+        title={t('transactions.bulk.deleteConfirm.title')}
+        subtitle={
+          orderedSelected.length === 1
+            ? t('transactions.bulk.deleteConfirm.subtitle', { count: 1 })
+            : t('transactions.bulk.deleteConfirm.subtitle_other', { count: orderedSelected.length })
+        }
+        confirmPhrase={t('transactions.bulk.deleteConfirm.phrase')}
+        confirmHint={t('transactions.bulk.deleteConfirm.hint')}
+        confirmLabel={t('transactions.bulk.deleteConfirm.confirm')}
+        confirmInputLabel={
+          // Avoid a generic "withdrawal" label being appended when the dialog
+          // auto-generates the prompt — instead surface the typed phrase and
+          // the specific action so AT users hear the right context.
+          <span>
+            {t('confirmDialog.typeToConfirm', {
+              phrase: t('transactions.bulk.deleteConfirm.phrase'),
+              action: t('transactions.bulk.deleteConfirm.confirm').toLowerCase(),
+            })}
+          </span>
+        }
+        variant="danger"
+        isSubmitting={isDeleting}
+        onConfirm={confirmBulkDelete}
+        onCancel={closeDeleteDialog}
+      />
     </div>
   )
 }


### PR DESCRIPTION
Summary
-------
Adds multi-row selection and a contextual Bulk Actions bar to the Transactions page. Users can pick individual rows or the full visible subset via a select-all checkbox, then export the selection to CSV or delete it from the view. The bar is only rendered when at least one row is selected, so users who never touch the feature see no behaviour change.

Changes Made
------------
* New checkbox column on the Transactions table with per-row and header (select-all) checkboxes; the header reports a mixed state via a ref+useEffect sync (React has no first-class indeterminate prop).
* Bulk Actions bar exposes Export, Delete, and Clear-selection actions. The visual state and selected-count are announced through aria-live, with the bar itself labelled as a region.
* Bulk Export serialises the selected rows through a new, pure transactionsToCsv() helper that follows RFC 4180 escaping and downloads a date-stamped CSV file. A success toast confirms the download.
* Bulk Delete opens a ConfirmDialog with the standard type-to-confirm gating (DELETE), then overlays the removed IDs locally. The source of truth remains the API; a successful refetch clears the overlay.
* Filter changes prune the selection to the currently visible subset so the bar's count never references filtered-out rows.
* Existing loading, error, empty, and filtered-empty states are unchanged when no selection is active.

Files Changed
-------------
* src/pages/Transactions.tsx (rewritten with selection + bulk state)
* src/pages/Transactions.css (new selection column + bulk-actions bar using design tokens)
* src/lib/transactionsExport.ts (new CSV serialiser + downloader)
* src/lib/transactionsExport.test.ts (unit tests for the export utility)
* src/pages/Transactions.test.tsx (new tests covering every issue requirement + accessibility hooks)
* src/config/testIds.ts (new test IDs for bulk-actions controls)
* src/i18n/locales/en.json (new transactions.bulk.* strings with proper _one / _other plural forms)

Testing Performed
-----------------
vitest run for the two new test files: 41 tests passing. ESLint on all new and modified .ts/.tsx files: zero errors. npm run build: passes; the only compile error reported is a pre-existing syntax issue in src/components/ActivityTimeline.test.tsx that was present before this change.

Documentation
-------------
Strings are exposed through i18n (transactions.bulk.*) so they can be translated without code changes. The Transactions page is not in docs/COMPONENTS.md and has no Storybook story, so no other doc updates are required for this issue.

Backwards Compatibility
-----------------------
* src/hooks/useTransactions.ts is unchanged; the feature layers a local "deletedIds" overlay on top of the hook's output, leaving refetch() semantics intact.
* Component API of the Transactions page is unchanged (it's a route component, no exported props).
* users who never select a row see the original table layout; the bulk-actions bar is rendered with the HTML `hidden` attribute and only becomes interactive when at least one row is selected.    closes #560