### PR TITLE
test: add unit tests for AddressDisplay (Truncate) component

### DIFF
--- a/src/components/AddressDisplay.test.tsx
+++ b/src/components/AddressDisplay.test.tsx
@@ -1,0 +1,265 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import AddressDisplay from './AddressDisplay'
+import * as CopyHookModule from '../hooks/useCopyToClipboard'
+import * as ToastModule from './ToastProvider'
+
+vi.mock('../hooks/useCopyToClipboard', () => ({
+  default: vi.fn(),
+}))
+
+vi.mock('./ToastProvider', () => ({
+  useToast: vi.fn(),
+}))
+
+// Long Stellar address that gets truncated by truncateAddress (first 12 + … + last 8)
+const LONG_ADDR = 'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H'
+
+// Short address that truncateAddress returns as-is
+const SHORT_ADDR = 'GABC'
+
+describe('AddressDisplay', () => {
+  const mockCopy = vi.fn()
+  const mockAddToast = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockCopy.mockResolvedValue(true)
+    vi.mocked(CopyHookModule.default).mockReturnValue({
+      copy: mockCopy,
+      copied: false,
+      reset: vi.fn(),
+    })
+
+    vi.mocked(ToastModule.useToast).mockReturnValue({
+      addToast: mockAddToast,
+      removeToast: vi.fn(),
+      removeAllToasts: vi.fn(),
+      announce: vi.fn(),
+    })
+  })
+
+  // --- Rendering ---
+
+  describe('rendering', () => {
+    it('renders a truncated address by default for long addresses', () => {
+      render(<AddressDisplay address={LONG_ADDR} />)
+
+      const code = screen.getByText((content) => content.includes('...'))
+      expect(code).toBeInTheDocument()
+      // Should not show the full address
+      expect(code.textContent).not.toBe(LONG_ADDR)
+    })
+
+    it('renders the full address when it is short enough not to truncate', () => {
+      render(<AddressDisplay address={SHORT_ADDR} />)
+
+      expect(screen.getByText(SHORT_ADDR)).toBeInTheDocument()
+    })
+
+    it('sets the title attribute to the full address for native tooltips', () => {
+      render(<AddressDisplay address={LONG_ADDR} />)
+
+      const code = screen.getByText((content) => content.includes('...'))
+      expect(code).toHaveAttribute('title', LONG_ADDR)
+    })
+
+    it('renders a copy button by default', () => {
+      render(<AddressDisplay address={LONG_ADDR} />)
+
+      expect(screen.getByRole('button', { name: 'Copy address' })).toBeInTheDocument()
+    })
+
+    it('hides the copy button when showCopyButton is false', () => {
+      render(<AddressDisplay address={LONG_ADDR} showCopyButton={false} />)
+
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    })
+
+    it('applies a custom className', () => {
+      render(<AddressDisplay address={SHORT_ADDR} className="my-custom-class" />)
+
+      const container = screen.getByText(SHORT_ADDR).closest('.address-display')
+      expect(container).toHaveClass('my-custom-class')
+    })
+
+    it('renders an empty code element when given an empty address', () => {
+      const { container } = render(<AddressDisplay address="" />)
+
+      const code = container.querySelector('code.address-display__address')
+      expect(code).toBeInTheDocument()
+      expect(code?.textContent).toBe('')
+      // The copy button should still be present but copy should be a no-op
+      expect(screen.getByRole('button', { name: 'Copy address' })).toBeInTheDocument()
+    })
+
+    it('shows a checkmark icon and updated label when copied state is true', () => {
+      vi.mocked(CopyHookModule.default).mockReturnValue({
+        copy: mockCopy,
+        copied: true,
+        reset: vi.fn(),
+      })
+
+      render(<AddressDisplay address={LONG_ADDR} />)
+
+      expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument()
+      // The checkmark icon is an svg with a polyline
+      const btn = screen.getByRole('button', { name: 'Copied' })
+      expect(btn.querySelector('svg polyline')).toBeInTheDocument()
+    })
+  })
+
+  // --- Hover reveals ---
+
+  describe('hover reveals full address', () => {
+    it('shows full address on mouse enter and returns to truncated on mouse leave', async () => {
+      render(<AddressDisplay address={LONG_ADDR} />)
+
+      const code = screen.getByText((content) => content.includes('...'))
+      expect(code.textContent).not.toBe(LONG_ADDR)
+
+      // Hover: full address should be revealed
+      fireEvent.mouseEnter(code)
+      expect(code.textContent).toBe(LONG_ADDR)
+
+      // Leave: truncated again
+      fireEvent.mouseLeave(code)
+      expect(code.textContent).not.toBe(LONG_ADDR)
+      expect(code.textContent).toContain('...')
+    })
+
+    it('keeps full address visible while hovered even after a focus event blurs', async () => {
+      render(<AddressDisplay address={LONG_ADDR} />)
+
+      const code = screen.getByText((content) => content.includes('...'))
+
+      // Hover first
+      fireEvent.mouseEnter(code)
+      expect(code.textContent).toBe(LONG_ADDR)
+
+      // Focus while hovered — still full address
+      fireEvent.focus(code)
+      expect(code.textContent).toBe(LONG_ADDR)
+
+      // Blur while still hovered — still full address
+      fireEvent.blur(code)
+      expect(code.textContent).toBe(LONG_ADDR)
+
+      // Leave — truncated again
+      fireEvent.mouseLeave(code)
+      expect(code.textContent).not.toBe(LONG_ADDR)
+    })
+  })
+
+  // --- Keyboard focus reveals ---
+
+  describe('keyboard focus reveals full address', () => {
+    it('shows full address on focus and returns to truncated on blur', () => {
+      render(<AddressDisplay address={LONG_ADDR} />)
+
+      const code = screen.getByText((content) => content.includes('...'))
+      expect(code.textContent).not.toBe(LONG_ADDR)
+
+      // Focus via keyboard
+      fireEvent.focus(code)
+      expect(code.textContent).toBe(LONG_ADDR)
+
+      // Blur: truncated again
+      fireEvent.blur(code)
+      expect(code.textContent).not.toBe(LONG_ADDR)
+      expect(code.textContent).toContain('...')
+    })
+
+    it('has tabIndex={0} so the element is keyboard-focusable', () => {
+      render(<AddressDisplay address={LONG_ADDR} />)
+
+      const code = screen.getByText((content) => content.includes('...'))
+      expect(code).toHaveAttribute('tabindex', '0')
+    })
+
+    it('shows full address when focused via keyboard Tab navigation', async () => {
+      const user = userEvent.setup()
+      render(<AddressDisplay address={LONG_ADDR} />)
+
+      const code = screen.getByText((content) => content.includes('...'))
+
+      // Tab to focus the code element
+      await user.tab()
+      expect(document.activeElement).toBe(code)
+      expect(code.textContent).toBe(LONG_ADDR)
+
+      // Tab away — truncated again
+      await user.tab()
+      expect(code.textContent).not.toBe(LONG_ADDR)
+      expect(code.textContent).toContain('...')
+    })
+  })
+
+  // --- Right-to-left ---
+
+  describe('right-to-left support', () => {
+    it('renders truncated address and reveals full on hover and focus in RTL context', () => {
+      render(
+        <div dir="rtl">
+          <AddressDisplay address={LONG_ADDR} />
+        </div>
+      )
+
+      const code = screen.getByText((content) => content.includes('...'))
+      expect(code).toBeInTheDocument()
+      expect(code.textContent).not.toBe(LONG_ADDR)
+
+      // Hover reveals full address in RTL
+      fireEvent.mouseEnter(code)
+      expect(code.textContent).toBe(LONG_ADDR)
+      fireEvent.mouseLeave(code)
+      expect(code.textContent).toContain('...')
+
+      // Focus reveals full address in RTL
+      fireEvent.focus(code)
+      expect(code.textContent).toBe(LONG_ADDR)
+      fireEvent.blur(code)
+      expect(code.textContent).toContain('...')
+    })
+  })
+
+  // --- Copy button ---
+
+  describe('copy button', () => {
+    it('calls copy with the full address on click', async () => {
+      render(<AddressDisplay address={LONG_ADDR} />)
+
+      const btn = screen.getByRole('button', { name: 'Copy address' })
+      fireEvent.click(btn)
+
+      expect(mockCopy).toHaveBeenCalledWith(LONG_ADDR)
+    })
+
+    it('shows a success toast after a successful copy', async () => {
+      mockCopy.mockResolvedValue(true)
+
+      render(<AddressDisplay address={LONG_ADDR} />)
+
+      const btn = screen.getByRole('button', { name: 'Copy address' })
+      fireEvent.click(btn)
+
+      await waitFor(() => {
+        expect(mockAddToast).toHaveBeenCalledWith('success', 'Address copied to clipboard')
+      })
+    })
+
+    it('does not show a success toast when copy fails', () => {
+      mockCopy.mockResolvedValue(false)
+
+      render(<AddressDisplay address={LONG_ADDR} />)
+
+      const btn = screen.getByRole('button', { name: 'Copy address' })
+      fireEvent.click(btn)
+
+      expect(mockCopy).toHaveBeenCalledWith(LONG_ADDR)
+      expect(mockAddToast).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Closes #574

Adds comprehensive unit tests for the `AddressDisplay` component (the Truncate component), which renders Stellar addresses truncated by default and reveals the full address on hover or keyboard focus. This PR adds 17 unit tests covering all four behavioral areas described in the issue: **rendering, hover reveals, keyboard focus reveals, and right-to-left support**.


---

## Background

Test coverage for the `AddressDisplay` component was previously zero — no test file existed. This meant regressions in the truncation, hover-reveal, or focus-reveal behavior could land without a failing build. These tests lock in the current contract, document expected behavior through executable examples, and shorten review cycles when this code changes.

---

## Tests Added (17 total)

### Rendering (8 tests)
| # | Test | What It Verifies |
|---|------|-----------------|
| 1 | `renders a truncated address by default for long addresses` | Long (56-char) Stellar addresses are shown truncated with `…` ellipsis |
| 2 | `renders the full address when it is short enough not to truncate` | Short addresses (e.g. 4 chars) are shown in full, no truncation |
| 3 | `sets the title attribute to the full address for native tooltips` | The `title` attribute on the `<code>` element contains the full address |
| 4 | `renders a copy button by default` | Copy button with aria-label "Copy address" is present |
| 5 | `hides the copy button when showCopyButton is false` | No button rendered when `showCopyButton={false}` |
| 6 | `applies a custom className` | Custom CSS classes are forwarded to the container |
| 7 | `renders an empty code element when given an empty address` | **Sad path:** empty string address renders empty `<code>` element; copy button still present |
| 8 | `shows a checkmark icon and updated label when copied state is true` | "Copied" aria-label and checkmark SVG icon when `copied=true` |

### Hover Reveals (2 tests)
| # | Test | What It Verifies |
|---|------|-----------------|
| 9 | `shows full address on mouse enter and returns to truncated on mouse leave` | `mouseEnter` → full address; `mouseLeave` → truncated with ellipsis |
| 10 | `keeps full address visible while hovered even after a focus event blurs` | The `(isHovered \|\| isFocused)` OR-logic: hover prevents truncation even after focus+blur, until mouse leaves |

### Keyboard Focus Reveals (3 tests)
| # | Test | What It Verifies |
|---|------|-----------------|
| 11 | `shows full address on focus and returns to truncated on blur` | `focus` → full address; `blur` → truncated |
| 12 | `has tabIndex={0} so the element is keyboard-focusable` | The `<code>` element has `tabindex="0"` |
| 13 | `shows full address when focused via keyboard Tab navigation` | Real `userEvent.tab()` navigation: Tab into → full address; Tab out → truncated |

### Right-to-Left (1 test)
| # | Test | What It Verifies |
|---|------|-----------------|
| 14 | `renders truncated address and reveals full on hover and focus in RTL context` | Component inside `<div dir="rtl">`: renders truncated, hover reveals full, focus reveals full — all work correctly |

### Copy Button (3 tests)
| # | Test | What It Verifies |
|---|------|-----------------|
| 15 | `calls copy with the full address on click` | Click invokes `copy()` with the full (untruncated) address |
| 16 | `shows a success toast after a successful copy` | On successful copy, `addToast('success', 'Address copied to clipboard')` is called |
| 17 | `does not show a success toast when copy fails` | **Sad path:** on failed copy, no success toast is shown |

---

## Acceptance Criteria Checklist

- [x] **Matches the issue summary** — All four areas covered: rendering, hover reveals, keyboard focus reveals, right-to-left
- [x] **Happy path + sad paths** — Happy: truncated rendering, hover/focus reveal, copy. Sad: empty address, copy failure
- [x] **Tests run on every CI matrix entry** — File at `src/components/AddressDisplay.test.tsx`, picked up by vitest's default glob
- [x] **Lint, type-check, and tests all pass locally** — ESLint clean on the test file; 17/17 tests pass; any TS errors are pre-existing in other files (`ActivityTimeline.test.tsx`)
- [x] **PR description references issue** — Closes #574
- [x] **Unit test layer** — Co-located with the component (`src/components/`)
- [x] **Assertive test names** — Descriptive "renders/shows/does" style matching codebase conventions
- [x] **Deterministic** — No `Date.now()` or `Math.random()`; all external dependencies mocked (`useCopyToClipboard`, `useToast`)
- [x] **No unrelated refactors** — Only the test file was added; no adjacent file changes
- [x] **No stylistic-only changes** — Only new test code

---

## Implementation Notes

- **Mocking pattern** follows existing tests (`CopyableHash.test.tsx`, `AddressInput.test.tsx`): `useCopyToClipboard` and `useToast` are mocked via `vi.mock`
- **The "Truncate" component** in this codebase is the `AddressDisplay` component — it renders truncated addresses via `truncateAddress()`, reveals full on hover/focus, and provides a copy button
- **`truncateAddress`** itself is already tested in `src/lib/stellar.test.ts`; these tests focus on the component-level reveal/truncate state management
- **Node.js v22** is required to run tests (the environment had Node v16; tests were validated using the v22 installation at `/usr/local/share/nvm/versions/node/v22.22.1/bin/node`)

---

## How to Verify

```bash
# Run only the new tests
npx vitest run src/components/AddressDisplay.test.tsx

# Run all tests
npm test

# Lint the test file
npx eslint src/components/AddressDisplay.test.tsx
```

All 17 tests should pass with zero failures.

Closes #574