### PR TITLE
feat: add Currency component with locale-aware formatting

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -8,32 +8,33 @@ Related focused docs: [button system](./button-system.md), [notifications](./not
 
 ## Styling ownership snapshot
 
-| Component              | Styling owner                                                                       | Inline-style migration note                                                                                               |
-| ---------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| Button                 | `src/components/Button.css`                                                         | None.                                                                                                                     |
-| Badge                  | `src/components/Badge.css`                                                          | None.                                                                                                                     |
-| Banner                 | `src/components/Banner.css`                                                         | None.                                                                                                                     |
-| Toast / ToastProvider  | `src/components/Toast.css`                                                          | None.                                                                                                                     |
-| ConfirmDialog          | `src/components/ConfirmDialog.css`                                                  | None.                                                                                                                     |
-| AddressInput           | `src/components/AddressInput.css` + `FormField.css`                                 | None.                                                                                                                     |
-| AmountInput            | `src/components/AmountInput.css`                                                    | None.                                                                                                                     |
-| TrustGauge             | `src/components/TrustGauge.css`                                                     | Uses inline CSS custom properties for dynamic progress, marker, thumb, and legend-dot colors; keep scoped until migrated. |
-| TierLadder             | `src/components/TierLadder.css` + `Badge.css`                                       | None.                                                                                                                     |
-| ActivityTimeline       | `src/components/ActivityTimeline.css` + EmptyState inline styles for empty fallback | Empty fallback inherits `EmptyState` inline styles; migrate with states components.                                       |
-| FormField              | `src/components/forms/FormField.css`                                                | None.                                                                                                                     |
-| controls/Select        | `src/components/controls/controls.css`                                              | None.                                                                                                                     |
-| controls/Toggle        | `src/components/controls/controls.css`                                              | None.                                                                                                                     |
-| states/EmptyState      | Inline styles in `src/components/states/EmptyState.tsx`                             | Owns inline styles and should be migrated to CSS.                                                                         |
-| states/ErrorState      | Inline styles in `src/components/states/ErrorState.tsx`                             | Owns inline styles and should be migrated to CSS.                                                                         |
-| states/LoadingSkeleton | Inline styles in `src/components/states/LoadingSkeleton.tsx`                        | Owns inline styles and should be migrated to CSS.                                                                         |
-| SessionTimeoutModal    | Inline styles in `src/components/SessionTimeoutModal.tsx`                           | Uses `ConfirmDialog` primitive with internal warning styles.                                                              |
-| ActionCard             | Inline styles in `src/components/ActionCard.tsx`                                    | Owns all inline styles; migrate to a CSS file when a module is added.                                                    |
-| Disclaimer             | `src/components/Disclaimer.css`                                                     | None.                                                                                                                     |
-| ThemeToggle            | `src/components/ThemeToggle.css`                                                    | None.                                                                                                                     |
-| KeyboardShortcutsDialog | `src/components/KeyboardShortcutsDialog.css`                                       | None.                                                                                                                     |
-| AttestationForm        | Delegates to `AddressInput`, `Select`, `FormField`, `Button`                        | No dedicated CSS file; inherits from composing components.                                                                |
-| CreateBondFlow         | `src/components/CreateBondFlow.css`                                                 | None.                                                                                                                     |
-| ErrorBoundary          | Delegates to `states/ErrorState`                                                    | No dedicated CSS file.                                                                                                    |
+| Component               | Styling owner                                                                       | Inline-style migration note                                                                                               |
+| ----------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Button                  | `src/components/Button.css`                                                         | None.                                                                                                                     |
+| Badge                   | `src/components/Badge.css`                                                          | None.                                                                                                                     |
+| Banner                  | `src/components/Banner.css`                                                         | None.                                                                                                                     |
+| Toast / ToastProvider   | `src/components/Toast.css`                                                          | None.                                                                                                                     |
+| ConfirmDialog           | `src/components/ConfirmDialog.css`                                                  | None.                                                                                                                     |
+| AddressInput            | `src/components/AddressInput.css` + `FormField.css`                                 | None.                                                                                                                     |
+| AmountInput             | `src/components/AmountInput.css`                                                    | None.                                                                                                                     |
+| Currency                | `src/components/Currency.css`                                                       | None.                                                                                                                     |
+| TrustGauge              | `src/components/TrustGauge.css`                                                     | Uses inline CSS custom properties for dynamic progress, marker, thumb, and legend-dot colors; keep scoped until migrated. |
+| TierLadder              | `src/components/TierLadder.css` + `Badge.css`                                       | None.                                                                                                                     |
+| ActivityTimeline        | `src/components/ActivityTimeline.css` + EmptyState inline styles for empty fallback | Empty fallback inherits `EmptyState` inline styles; migrate with states components.                                       |
+| FormField               | `src/components/forms/FormField.css`                                                | None.                                                                                                                     |
+| controls/Select         | `src/components/controls/controls.css`                                              | None.                                                                                                                     |
+| controls/Toggle         | `src/components/controls/controls.css`                                              | None.                                                                                                                     |
+| states/EmptyState       | Inline styles in `src/components/states/EmptyState.tsx`                             | Owns inline styles and should be migrated to CSS.                                                                         |
+| states/ErrorState       | Inline styles in `src/components/states/ErrorState.tsx`                             | Owns inline styles and should be migrated to CSS.                                                                         |
+| states/LoadingSkeleton  | Inline styles in `src/components/states/LoadingSkeleton.tsx`                        | Owns inline styles and should be migrated to CSS.                                                                         |
+| SessionTimeoutModal     | Inline styles in `src/components/SessionTimeoutModal.tsx`                           | Uses `ConfirmDialog` primitive with internal warning styles.                                                              |
+| ActionCard              | Inline styles in `src/components/ActionCard.tsx`                                    | Owns all inline styles; migrate to a CSS file when a module is added.                                                     |
+| Disclaimer              | `src/components/Disclaimer.css`                                                     | None.                                                                                                                     |
+| ThemeToggle             | `src/components/ThemeToggle.css`                                                    | None.                                                                                                                     |
+| KeyboardShortcutsDialog | `src/components/KeyboardShortcutsDialog.css`                                        | None.                                                                                                                     |
+| AttestationForm         | Delegates to `AddressInput`, `Select`, `FormField`, `Button`                        | No dedicated CSS file; inherits from composing components.                                                                |
+| CreateBondFlow          | `src/components/CreateBondFlow.css`                                                 | None.                                                                                                                     |
+| ErrorBoundary           | Delegates to `states/ErrorState`                                                    | No dedicated CSS file.                                                                                                    |
 
 ## Shared vocabularies
 
@@ -172,23 +173,23 @@ function SaveButton() {
 
 Source: [`src/components/ConfirmDialog.tsx`](../src/components/ConfirmDialog.tsx). Focused docs: [focus patterns](./focus-patterns.md).
 
-| Prop                | Type                              | Default                          |
-| ------------------- | --------------------------------- | -------------------------------- |
-| `open`              | `boolean`                         | Required                         |
-| `title`             | `string`                          | Required                         |
-| `subtitle`          | `string`                          | `undefined`                      |
-| `breakdown`         | `ConfirmDialogPenaltyBreakdown`   | `undefined`                      |
-| `description`       | `React.ReactNode`                 | `undefined`                      |
-| `children`          | `React.ReactNode`                 | `undefined`                      |
-| `onConfirm`         | `() => void`                      | Required                         |
-| `onCancel`          | `() => void`                      | Required                         |
-| `returnFocusRef`    | `RefObject<HTMLElement \| null>`  | `undefined`                      |
-| `confirmLabel`      | `string`                          | `'Withdraw bond'`                |
-| `confirmInputLabel` | `React.ReactNode`                 | `undefined`                      |
-| `confirmInputHint`  | `React.ReactNode`                 | `undefined`                      |
-| `variant`           | `'danger' \| 'info'`              | `'danger'`                       |
-| `confirmPhrase`     | `string`                          | `'CONFIRM'`                      |
-| `confirmHint`       | `string`                          | Wallet/funds irreversibility hint |
+| Prop                | Type                             | Default                           |
+| ------------------- | -------------------------------- | --------------------------------- |
+| `open`              | `boolean`                        | Required                          |
+| `title`             | `string`                         | Required                          |
+| `subtitle`          | `string`                         | `undefined`                       |
+| `breakdown`         | `ConfirmDialogPenaltyBreakdown`  | `undefined`                       |
+| `description`       | `React.ReactNode`                | `undefined`                       |
+| `children`          | `React.ReactNode`                | `undefined`                       |
+| `onConfirm`         | `() => void`                     | Required                          |
+| `onCancel`          | `() => void`                     | Required                          |
+| `returnFocusRef`    | `RefObject<HTMLElement \| null>` | `undefined`                       |
+| `confirmLabel`      | `string`                         | `'Withdraw bond'`                 |
+| `confirmInputLabel` | `React.ReactNode`                | `undefined`                       |
+| `confirmInputHint`  | `React.ReactNode`                | `undefined`                       |
+| `variant`           | `'danger' \| 'info'`             | `'danger'`                        |
+| `confirmPhrase`     | `string`                         | `'CONFIRM'`                       |
+| `confirmHint`       | `string`                         | Wallet/funds irreversibility hint |
 
 `ConfirmDialogPenaltyBreakdown` is `{ bondAmount: string; penaltyAmount: string; penaltyPercent: number; resultingBalance: string }`. When `breakdown` is omitted, the `description` prop or `children` slot is rendered in its place.
 
@@ -263,6 +264,30 @@ Tokens: border, danger-border, slate, focus, font, motion, radius, spacing, surf
 ```
 
 Storybook: `Components/Forms/AmountInput` — **Default** · **Filled** · **OverBalance** · **Error** · **Disabled** · **Loading**.
+
+## Currency
+
+Source: [`src/components/Currency.tsx`](../src/components/Currency.tsx).
+
+| Prop                    | Type     | Default              |
+| ----------------------- | -------- | -------------------- |
+| `amount`                | `number` | Required             |
+| `currency`              | `string` | `'USD'`              |
+| `locale`                | `string` | Active i18n language |
+| `minimumFractionDigits` | `number` | CLDR per currency    |
+| `maximumFractionDigits` | `number` | CLDR per currency    |
+| `fallback`              | `string` | `'—'`                |
+| `className`             | `string` | `''`                 |
+
+Locale-aware currency display built on `Intl.NumberFormat` with `style: 'currency'`. Symbol placement, thousand separators, and decimal precision come from CLDR for the given locale/currency pair (e.g. `$1,234.50` in en-US, `1234,50 €` in es-ES, `￥1,235` in ja-JP). Non-finite amounts render the `fallback` with a `currency--invalid` class; unknown currency codes degrade to a plain grouped number plus the code instead of throwing.
+
+Tokens: numeric figures use tabular numbers; the invalid state uses the slate-500 text token.
+
+```tsx
+<Currency amount={total} currency="EUR" locale="es-ES" />
+```
+
+Storybook: `Components/Display/Currency` — **Default** · **EuroSpain** · **YenJapan** · **InvalidAmount**.
 
 ## TrustGauge
 
@@ -459,12 +484,12 @@ Tokens: inline styles consume `--credence-skeleton-gradient`, `--credence-motion
 
 Source: [`src/components/SessionTimeoutModal.tsx`](../src/components/SessionTimeoutModal.tsx).
 
-| Prop              | Type                   | Default  |
-| ----------------- | ---------------------- | -------- |
-| `open`            | `boolean`              | Required |
-| `onStayLoggedIn`  | `() => void`           | Required |
-| `onLogout`        | `() => void`           | Required |
-| `timeLeftSeconds` | `number`               | Required |
+| Prop              | Type         | Default  |
+| ----------------- | ------------ | -------- |
+| `open`            | `boolean`    | Required |
+| `onStayLoggedIn`  | `() => void` | Required |
+| `onLogout`        | `() => void` | Required |
+| `timeLeftSeconds` | `number`     | Required |
 
 Accessibility: uses `ConfirmDialog` primitive.
 
@@ -503,10 +528,10 @@ Tokens: `--credence-border-default`, `--credence-radius-xl`, `--credence-space-4
 
 Source: [`src/components/Disclaimer.tsx`](../src/components/Disclaimer.tsx).
 
-| Prop        | Type     | Default        |
-| ----------- | -------- | -------------- |
-| `context`   | `string` | `undefined`    |
-| `termsHref` | `string` | `LINKS.terms`  |
+| Prop        | Type     | Default       |
+| ----------- | -------- | ------------- |
+| `context`   | `string` | `undefined`   |
+| `termsHref` | `string` | `LINKS.terms` |
 
 Accessibility: renders as `<aside aria-label="Risk disclaimer">`. The terms link has an explicit `aria-label="Read full terms and conditions"`. When `termsHref` resolves to a placeholder (`'#'` or empty), a `<span aria-disabled="true">` is rendered instead of an anchor so the element is inert for keyboard and AT users.
 
@@ -534,10 +559,10 @@ Tokens: `--credence-focus-ring`, spacing, and icon sizing via `ThemeToggle.css`.
 
 Source: [`src/components/KeyboardShortcutsDialog.tsx`](../src/components/KeyboardShortcutsDialog.tsx). Focused docs: [keyboard interactions](./keyboard-interactions.md).
 
-| Prop             | Type                              | Default     |
-| ---------------- | --------------------------------- | ----------- |
-| `open`           | `boolean`                         | Required    |
-| `onClose`        | `() => void`                      | Required    |
+| Prop             | Type                                   | Default     |
+| ---------------- | -------------------------------------- | ----------- |
+| `open`           | `boolean`                              | Required    |
+| `onClose`        | `() => void`                           | Required    |
 | `returnFocusRef` | `React.RefObject<HTMLElement \| null>` | `undefined` |
 
 Accessibility: portal-rendered modal with `role="dialog"`, `aria-modal="true"`, and a generated `aria-labelledby`. Focus is trapped while open. Escape and backdrop click both call `onClose`. Focus is restored to `returnFocusRef` on close, or to the previously active element when `returnFocusRef` is omitted. Shortcuts are grouped by category with visible section headings.
@@ -555,10 +580,10 @@ const triggerRef = useRef<HTMLButtonElement>(null)
 
 Source: [`src/components/AttestationForm.tsx`](../src/components/AttestationForm.tsx).
 
-| Prop              | Type                                                                   | Default     |
-| ----------------- | ---------------------------------------------------------------------- | ----------- |
+| Prop              | Type                                                                     | Default     |
+| ----------------- | ------------------------------------------------------------------------ | ----------- |
 | `onSubmitSuccess` | `(payload: { subject: string; type: string; evidence: string }) => void` | `undefined` |
-| `disabled`        | `boolean`                                                              | `false`     |
+| `disabled`        | `boolean`                                                                | `false`     |
 
 Accessibility: all form fields are wrapped in `FormField` so each has a `<label>`, hint, and error wired through `aria-describedby` and `aria-invalid`. The type selector uses `controls/Select` (native `<select>`). The evidence textarea has a live character counter associated via `aria-describedby`. Submission is confirmed via `ConfirmDialog` before calling `onSubmitSuccess`; success is announced via a toast.
 
@@ -593,9 +618,9 @@ Tokens: `CreateBondFlow.css` consumes border, radius, spacing, surface, text, fo
 
 Source: [`src/components/ErrorBoundary.tsx`](../src/components/ErrorBoundary.tsx).
 
-| Prop       | Type                                         | Default                        |
-| ---------- | -------------------------------------------- | ------------------------------ |
-| `children` | `ReactNode`                                  | Required                       |
+| Prop       | Type                                             | Default                         |
+| ---------- | ------------------------------------------------ | ------------------------------- |
+| `children` | `ReactNode`                                      | Required                        |
 | `fallback` | `(error: Error, reset: () => void) => ReactNode` | `undefined` (uses `ErrorState`) |
 
 Class component that catches render and lifecycle errors in its subtree. The default fallback renders a branded `ErrorState` with a "Retry" action (re-mounts the subtree without a full reload) and a "Go home" link. Supply `fallback` to override with custom error UI.
@@ -607,12 +632,14 @@ Accessibility: no additional ARIA attributes; inherits accessibility from `Error
 Tokens: none directly; delegates to `ErrorState`.
 
 ```tsx
-<ErrorBoundary>
+;<ErrorBoundary>
   <BondPage />
 </ErrorBoundary>
 
-{/* Custom fallback */}
-<ErrorBoundary fallback={(err, reset) => <button onClick={reset}>Retry: {err.message}</button>}>
+{
+  /* Custom fallback */
+}
+;<ErrorBoundary fallback={(err, reset) => <button onClick={reset}>Retry: {err.message}</button>}>
   <TrustScorePage />
 </ErrorBoundary>
 ```

--- a/src/components/Currency.css
+++ b/src/components/Currency.css
@@ -1,0 +1,8 @@
+.currency {
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.currency--invalid {
+  color: var(--credence-color-slate-500);
+}

--- a/src/components/Currency.stories.tsx
+++ b/src/components/Currency.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import Currency from './Currency'
+
+const meta: Meta<typeof Currency> = {
+  title: 'Components/Display/Currency',
+  component: Currency,
+  tags: ['autodocs'],
+  args: {
+    amount: 1234.5,
+    currency: 'USD',
+    locale: 'en-US',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof Currency>
+
+export const Default: Story = {}
+
+export const EuroSpain: Story = {
+  args: {
+    currency: 'EUR',
+    locale: 'es-ES',
+  },
+}
+
+export const YenJapan: Story = {
+  args: {
+    currency: 'JPY',
+    locale: 'ja-JP',
+  },
+}
+
+export const InvalidAmount: Story = {
+  args: {
+    amount: Number.NaN,
+  },
+}

--- a/src/components/Currency.test.tsx
+++ b/src/components/Currency.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import Currency from './Currency'
+
+vi.mock('./Currency.css', () => ({}))
+
+const NBSP = ' '
+
+describe('Currency', () => {
+  describe('locale-specific formatting (CLDR)', () => {
+    it('formats USD in en-US with symbol prefix, comma grouping, and two decimals', () => {
+      render(<Currency amount={1234.5} currency="USD" locale="en-US" />)
+      expect(screen.getByText('$1,234.50')).toBeInTheDocument()
+    })
+
+    it('formats EUR in es-ES with symbol suffix, dot grouping, and comma decimals', () => {
+      const { container } = render(<Currency amount={1234.5} currency="EUR" locale="es-ES" />)
+      expect(container.textContent).toBe(`1234,50${NBSP}€`)
+    })
+
+    it('formats JPY in ja-JP with zero fraction digits per CLDR', () => {
+      render(<Currency amount={1234.5} currency="JPY" locale="ja-JP" />)
+      expect(screen.getByText('￥1,235')).toBeInTheDocument()
+    })
+
+    it('rounds JPY down when the fraction is below half a yen', () => {
+      render(<Currency amount={1234.4} currency="JPY" locale="ja-JP" />)
+      expect(screen.getByText('￥1,234')).toBeInTheDocument()
+    })
+
+    it('keeps symbol placement locale-dependent (de-DE renders the symbol after)', () => {
+      const { container } = render(<Currency amount={1234.5} currency="EUR" locale="de-DE" />)
+      expect(container.textContent).toBe(`1.234,50${NBSP}€`)
+    })
+
+    it('matches the Intl.NumberFormat reference for each supported locale', () => {
+      const cases = [
+        ['en-US', 'USD'],
+        ['es-ES', 'EUR'],
+        ['ja-JP', 'JPY'],
+      ] as const
+      for (const [locale, currency] of cases) {
+        const { container, unmount } = render(
+          <Currency amount={9876543.21} currency={currency} locale={locale} />
+        )
+        const expected = new Intl.NumberFormat(locale, {
+          style: 'currency',
+          currency,
+        }).format(9876543.21)
+        expect(container.textContent).toBe(expected)
+        unmount()
+      }
+    })
+
+    it('falls back to the active i18n language when no locale prop is given', () => {
+      // test-setup initializes i18next with lng: 'en'
+      render(<Currency amount={1000} currency="USD" />)
+      expect(screen.getByText('$1,000.00')).toBeInTheDocument()
+    })
+  })
+
+  describe('fraction digit overrides', () => {
+    it('respects explicit minimum/maximum fraction digits over CLDR defaults', () => {
+      render(
+        <Currency
+          amount={1234.5}
+          currency="JPY"
+          locale="ja-JP"
+          minimumFractionDigits={2}
+          maximumFractionDigits={2}
+        />
+      )
+      expect(screen.getByText('￥1,234.50')).toBeInTheDocument()
+    })
+  })
+
+  describe('sad paths', () => {
+    it('renders the fallback for NaN amounts', () => {
+      render(<Currency amount={Number.NaN} locale="en-US" />)
+      expect(screen.getByText('—')).toBeInTheDocument()
+    })
+
+    it('renders the fallback for infinite amounts', () => {
+      render(<Currency amount={Number.POSITIVE_INFINITY} locale="en-US" />)
+      expect(screen.getByText('—')).toBeInTheDocument()
+    })
+
+    it('uses a custom fallback when provided', () => {
+      render(<Currency amount={Number.NaN} locale="en-US" fallback="n/a" />)
+      expect(screen.getByText('n/a')).toBeInTheDocument()
+    })
+
+    it('marks invalid amounts with the currency--invalid class', () => {
+      const { container } = render(<Currency amount={Number.NaN} locale="en-US" />)
+      expect(container.querySelector('.currency--invalid')).not.toBeNull()
+    })
+
+    it('degrades to a plain number plus code for unknown currency codes', () => {
+      render(<Currency amount={1234.5} currency="NOTACODE" locale="en-US" />)
+      expect(screen.getByText('1,234.50 NOTACODE')).toBeInTheDocument()
+    })
+
+    it('formats negative amounts with a leading sign', () => {
+      render(<Currency amount={-42} currency="USD" locale="en-US" />)
+      expect(screen.getByText('-$42.00')).toBeInTheDocument()
+    })
+  })
+
+  describe('root element', () => {
+    it('appends a custom className to the root element', () => {
+      const { container } = render(<Currency amount={1} locale="en-US" className="price-tag" />)
+      const el = container.querySelector('.currency')
+      expect(el).not.toBeNull()
+      expect(el?.className).toContain('price-tag')
+    })
+  })
+})

--- a/src/components/Currency.tsx
+++ b/src/components/Currency.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from 'react-i18next'
+import './Currency.css'
+
+export interface CurrencyProps {
+  /** Amount in major units (dollars, not cents). */
+  amount: number
+  /** ISO 4217 currency code. Defaults to USD. */
+  currency?: string
+  /** BCP 47 locale. Defaults to the active i18n language. */
+  locale?: string
+  /** Overrides the currency's CLDR fraction digits when set. */
+  minimumFractionDigits?: number
+  maximumFractionDigits?: number
+  /** Rendered when `amount` is not a finite number. */
+  fallback?: string
+  /** Additional class names appended to the root element. */
+  className?: string
+}
+
+export default function Currency({
+  amount,
+  currency = 'USD',
+  locale,
+  minimumFractionDigits,
+  maximumFractionDigits,
+  fallback = '—',
+  className = '',
+}: CurrencyProps) {
+  const { i18n } = useTranslation()
+
+  if (!Number.isFinite(amount)) {
+    return <span className={`currency currency--invalid ${className}`.trim()}>{fallback}</span>
+  }
+
+  const resolvedLocale = locale ?? i18n.language
+
+  let formatted: string
+  try {
+    formatted = new Intl.NumberFormat(resolvedLocale, {
+      style: 'currency',
+      currency,
+      ...(minimumFractionDigits !== undefined ? { minimumFractionDigits } : {}),
+      ...(maximumFractionDigits !== undefined ? { maximumFractionDigits } : {}),
+    }).format(amount)
+  } catch {
+    // Unknown currency code or locale: render the plain number with the code
+    // suffix instead of throwing mid-render.
+    formatted = `${new Intl.NumberFormat('en-US', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(amount)} ${currency}`
+  }
+
+  return <span className={`currency ${className}`.trim()}>{formatted}</span>
+}


### PR DESCRIPTION
Closes #597
Closes #598

Component and its locale tests in one PR since the tests target the new component.

- `Currency` renders via `Intl.NumberFormat` with `style: 'currency'`, so symbol placement, grouping, and decimal precision come from CLDR (`$1,234.50` en-US, `1234,50 €` es-ES, `￥1,235` ja-JP). Locale defaults to the active i18n language.
- Non-finite amounts render a fallback (`—` by default) with a `currency--invalid` class. Unknown currency codes degrade to a grouped number plus the code instead of throwing mid-render.
- Story (`Components/Display/Currency`) and a `COMPONENTS.md` entry included, per the repo notes.

Verified locally: `npx vitest run src/components/Currency.test.tsx` 15/15. Full `npm test` shows the same 196 pre-existing failures as clean main (Badge.test.tsx etc. fail on a fresh clone too; my run adds the 15 new passes, no new failures). `npx eslint` on the touched files is clean. `npm run build` fails on a pre-existing syntax error in `ActivityTimeline.test.tsx:258` on main, untouched here; no errors from the new files.
