### PR TITLE
feat: prefetch lazy route chunks on nav link hover and focus

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,23 +6,36 @@ import ToastProvider from './components/ToastProvider'
 import ErrorBoundary from './components/ErrorBoundary'
 import Layout from './components/Layout'
 
-const Home = lazy(() => import('./pages/Home'))
-const Dashboard = lazy(() => import('./pages/Dashboard'))
-const Bond = lazy(() => import('./pages/Bond'))
-const CreateBondPage = lazy(() => import('./pages/CreateBondPage'))
-const BondDetail = lazy(() => import('./pages/BondDetail'))
-const TrustScore = lazy(() => import('./pages/TrustScore'));
-const TrustSummary = lazy(() => import('./pages/TrustSummary'))
-const Attestations = lazy(() => import('./pages/Attestations'))
-const Transactions = lazy(() => import('./pages/Transactions'))
-const Settings = lazy(() => import('./pages/Settings'))
-const AmountInputTestPage = lazy(() => import('./pages/AmountInputTestPage'))
-const SignIn = lazy(() => import('./pages/SignIn'))
-const NotFound = lazy(() => import('./pages/NotFound'))
+import {
+  preloadHome,
+  preloadDashboard,
+  preloadBond,
+  preloadCreateBond,
+  preloadBondDetail,
+  preloadTrustScore,
+  preloadTrustSummary,
+  preloadAttestations,
+  preloadTransactions,
+  preloadSettings,
+  preloadAmountInputTest,
+  preloadSignIn,
+  preloadNotFound,
+} from './config/routes'
 
-// import.meta.env.DEV is replaced with `false` at build time by Vite/Rollup,
-// so the dynamic import('./pages/ToastTest') reference is dead-code eliminated
-// from the production bundle.
+const Home = lazy(preloadHome)
+const Dashboard = lazy(preloadDashboard)
+const Bond = lazy(preloadBond)
+const CreateBondPage = lazy(preloadCreateBond)
+const BondDetail = lazy(preloadBondDetail)
+const TrustScore = lazy(preloadTrustScore)
+const TrustSummary = lazy(preloadTrustSummary)
+const Attestations = lazy(preloadAttestations)
+const Transactions = lazy(preloadTransactions)
+const Settings = lazy(preloadSettings)
+const AmountInputTestPage = lazy(preloadAmountInputTest)
+const SignIn = lazy(preloadSignIn)
+const NotFound = lazy(preloadNotFound)
+
 const ToastTest = import.meta.env.DEV ? lazy(() => import('./pages/ToastTest')) : null
 
 /**

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Outlet, NavLink } from 'react-router-dom'
+import { PrefetchNavLink } from './PrefetchNavLink'
+import { PRELOADS_BY_PATH } from '../config/routes'
 import { useTranslation } from 'react-i18next'
 import ThemeToggle from './ThemeToggle'
 import NetworkIndicator from './NetworkIndicator'
@@ -93,16 +95,17 @@ export default function Layout() {
         {/* Desktop: inline nav (hidden <640px via CSS) */}
         <nav aria-label="Main navigation" className="appNav">
           {NAV_LINKS.map(({ to, label }) => (
-            <NavLink
+            <PrefetchNavLink
               key={to}
               to={to}
               end
+              preload={PRELOADS_BY_PATH[to]}
               className={({ isActive }) =>
                 isActive ? 'appNav-link appNav-link--active' : 'appNav-link'
               }
             >
               {label}
-            </NavLink>
+            </PrefetchNavLink>
           ))}
         </nav>
 

--- a/src/components/PrefetchNavLink.test.tsx
+++ b/src/components/PrefetchNavLink.test.tsx
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { PrefetchNavLink } from './PrefetchNavLink'
+
+function renderInRouter(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>)
+}
+
+describe('PrefetchNavLink', () => {
+  it('renders as a NavLink with the given label', () => {
+    const preload = vi.fn().mockResolvedValue(undefined)
+
+    renderInRouter(
+      <PrefetchNavLink to="/dashboard" preload={preload}>
+        Dashboard
+      </PrefetchNavLink>,
+    )
+
+    expect(screen.getByRole('link', { name: 'Dashboard' })).toHaveAttribute('href', '/dashboard')
+  })
+
+  it('calls preload on mouse enter', async () => {
+    const preload = vi.fn().mockResolvedValue(undefined)
+    const user = userEvent.setup()
+
+    renderInRouter(
+      <PrefetchNavLink to="/dashboard" preload={preload}>
+        Dashboard
+      </PrefetchNavLink>,
+    )
+
+    await user.hover(screen.getByRole('link', { name: 'Dashboard' }))
+
+    expect(preload).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls preload on focus', async () => {
+    const preload = vi.fn().mockResolvedValue(undefined)
+    const user = userEvent.setup()
+
+    renderInRouter(
+      <PrefetchNavLink to="/dashboard" preload={preload}>
+        Dashboard
+      </PrefetchNavLink>,
+    )
+
+    await user.tab()
+    expect(screen.getByRole('link', { name: 'Dashboard' })).toHaveFocus()
+    expect(preload).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes through className prop', () => {
+    const preload = vi.fn().mockResolvedValue(undefined)
+
+    renderInRouter(
+      <PrefetchNavLink to="/dashboard" preload={preload} className="custom-link">
+        Dashboard
+      </PrefetchNavLink>,
+    )
+
+    expect(screen.getByRole('link', { name: 'Dashboard' })).toHaveClass('custom-link')
+  })
+
+  it('chains user-provided onMouseEnter handler', async () => {
+    const preload = vi.fn().mockResolvedValue(undefined)
+    const onMouseEnter = vi.fn()
+    const user = userEvent.setup()
+
+    renderInRouter(
+      <PrefetchNavLink to="/dashboard" preload={preload} onMouseEnter={onMouseEnter}>
+        Dashboard
+      </PrefetchNavLink>,
+    )
+
+    await user.hover(screen.getByRole('link', { name: 'Dashboard' }))
+
+    expect(onMouseEnter).toHaveBeenCalledTimes(1)
+  })
+
+  it('chains user-provided onFocus handler', async () => {
+    const preload = vi.fn().mockResolvedValue(undefined)
+    const onFocus = vi.fn()
+    const user = userEvent.setup()
+
+    renderInRouter(
+      <PrefetchNavLink to="/dashboard" preload={preload} onFocus={onFocus}>
+        Dashboard
+      </PrefetchNavLink>,
+    )
+
+    await user.tab()
+    expect(onFocus).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/PrefetchNavLink.tsx
+++ b/src/components/PrefetchNavLink.tsx
@@ -1,0 +1,29 @@
+import { NavLink, NavLinkProps } from 'react-router-dom'
+import { useRoutePrefetch } from '../hooks/useRoutePrefetch'
+
+interface PrefetchNavLinkProps extends NavLinkProps {
+  preload: () => Promise<unknown>
+}
+
+export function PrefetchNavLink({ preload, ...props }: PrefetchNavLinkProps) {
+  const handlers = useRoutePrefetch(preload)
+  const { onMouseEnter: originalMouseEnter, onFocus: originalFocus, onTouchStart: originalTouchStart } = props
+
+  return (
+    <NavLink
+      {...props}
+      onMouseEnter={(e) => {
+        handlers.onMouseEnter()
+        originalMouseEnter?.(e)
+      }}
+      onFocus={(e) => {
+        handlers.onFocus()
+        originalFocus?.(e)
+      }}
+      onTouchStart={(e) => {
+        handlers.onTouchStart()
+        originalTouchStart?.(e)
+      }}
+    />
+  )
+}

--- a/src/components/navigation/MobileNav.tsx
+++ b/src/components/navigation/MobileNav.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
-import { NavLink, useLocation } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
+import { PrefetchNavLink } from '../PrefetchNavLink'
+import { PRELOADS_BY_PATH } from '../../config/routes'
 import { useFocusTrap } from '../../hooks/useFocusTrap'
 import './MobileNav.css'
 
@@ -106,9 +108,10 @@ export default function MobileNav() {
         <ul className="mobileNav-links" role="list">
           {NAV_LINKS.map(({ to, label }) => (
             <li key={to}>
-              <NavLink
+              <PrefetchNavLink
                 to={to}
                 end={to === '/'}
+                preload={PRELOADS_BY_PATH[to]}
                 className={({ isActive }) =>
                   `mobileNav-link${isActive ? ' mobileNav-link--active' : ''}`
                 }
@@ -120,7 +123,7 @@ export default function MobileNav() {
                 onClick={close}
               >
                 {label}
-              </NavLink>
+              </PrefetchNavLink>
             </li>
           ))}
         </ul>

--- a/src/config/routes.ts
+++ b/src/config/routes.ts
@@ -1,0 +1,27 @@
+import { ComponentType } from 'react'
+
+type PreloadFn = () => Promise<{ default: ComponentType<unknown> }>
+
+export const preloadHome: PreloadFn = () => import('../pages/Home')
+export const preloadDashboard: PreloadFn = () => import('../pages/Dashboard')
+export const preloadBond: PreloadFn = () => import('../pages/Bond')
+export const preloadCreateBond: PreloadFn = () => import('../pages/CreateBondPage')
+export const preloadBondDetail: PreloadFn = () => import('../pages/BondDetail')
+export const preloadTrustScore: PreloadFn = () => import('../pages/TrustScore')
+export const preloadTrustSummary: PreloadFn = () => import('../pages/TrustSummary')
+export const preloadAttestations: PreloadFn = () => import('../pages/Attestations')
+export const preloadTransactions: PreloadFn = () => import('../pages/Transactions')
+export const preloadSettings: PreloadFn = () => import('../pages/Settings')
+export const preloadAmountInputTest: PreloadFn = () => import('../pages/AmountInputTestPage')
+export const preloadSignIn: PreloadFn = () => import('../pages/SignIn')
+export const preloadNotFound: PreloadFn = () => import('../pages/NotFound')
+
+export const PRELOADS_BY_PATH: Record<string, PreloadFn> = {
+  '/': preloadHome,
+  '/dashboard': preloadDashboard,
+  '/bond': preloadBond,
+  '/trust': preloadTrustScore,
+  '/attestations': preloadAttestations,
+  '/transactions': preloadTransactions,
+  '/settings': preloadSettings,
+}

--- a/src/hooks/useRoutePrefetch.test.ts
+++ b/src/hooks/useRoutePrefetch.test.ts
@@ -1,0 +1,81 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { useRoutePrefetch } from './useRoutePrefetch'
+
+describe('useRoutePrefetch', () => {
+  it('calls preload on first onMouseEnter', () => {
+    const preload = vi.fn().mockResolvedValue(undefined)
+    const { result } = renderHook(() => useRoutePrefetch(preload))
+
+    result.current.onMouseEnter()
+
+    expect(preload).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call preload again on second onMouseEnter', () => {
+    const preload = vi.fn().mockResolvedValue(undefined)
+    const { result } = renderHook(() => useRoutePrefetch(preload))
+
+    result.current.onMouseEnter()
+    result.current.onMouseEnter()
+
+    expect(preload).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls preload on onFocus', () => {
+    const preload = vi.fn().mockResolvedValue(undefined)
+    const { result } = renderHook(() => useRoutePrefetch(preload))
+
+    result.current.onFocus()
+
+    expect(preload).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls preload on onTouchStart', () => {
+    const preload = vi.fn().mockResolvedValue(undefined)
+    const { result } = renderHook(() => useRoutePrefetch(preload))
+
+    result.current.onTouchStart()
+
+    expect(preload).toHaveBeenCalledTimes(1)
+  })
+
+  it('deduplicates across onMouseEnter and onFocus', () => {
+    const preload = vi.fn().mockResolvedValue(undefined)
+    const { result } = renderHook(() => useRoutePrefetch(preload))
+
+    result.current.onMouseEnter()
+    result.current.onFocus()
+    result.current.onTouchStart()
+
+    expect(preload).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows retry when preload rejects', async () => {
+    const preload = vi.fn()
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce(undefined)
+    const { result } = renderHook(() => useRoutePrefetch(preload))
+
+    result.current.onMouseEnter()
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    result.current.onMouseEnter()
+
+    expect(preload).toHaveBeenCalledTimes(2)
+  })
+
+  it('returns stable handlers across renders', () => {
+    const preload = vi.fn().mockResolvedValue(undefined)
+    const { result, rerender } = renderHook(() => useRoutePrefetch(preload))
+
+    const first = result.current
+
+    rerender()
+
+    expect(result.current.onMouseEnter).toBe(first.onMouseEnter)
+    expect(result.current.onFocus).toBe(first.onFocus)
+    expect(result.current.onTouchStart).toBe(first.onTouchStart)
+  })
+})

--- a/src/hooks/useRoutePrefetch.ts
+++ b/src/hooks/useRoutePrefetch.ts
@@ -1,0 +1,19 @@
+import { useCallback, useRef } from 'react'
+
+export function useRoutePrefetch(preload: () => Promise<unknown>) {
+  const prefetched = useRef(false)
+
+  const handlePrefetch = useCallback(() => {
+    if (prefetched.current) return
+    prefetched.current = true
+    preload().catch(() => {
+      prefetched.current = false
+    })
+  }, [preload])
+
+  return {
+    onMouseEnter: handlePrefetch,
+    onFocus: handlePrefetch,
+    onTouchStart: handlePrefetch,
+  }
+}


### PR DESCRIPTION
Closes #509

## Summary

Prefetch lazy route chunks when the user hovers over or focuses a navigation link, so the chunk is already cached by the browser's module system before the click triggers `React.lazy` resolution. Navigation becomes instant after the first paint.

## What changed

### New files

- **`src/config/routes.ts`** — Single-source registry mapping route paths to preload (`import()`) functions. Used by both `React.lazy` (in `App.tsx`) and the prefetch mechanism in navigation components.

- **`src/hooks/useRoutePrefetch.ts`** — Hook that accepts a preload function, calls it once on the first interaction (`onMouseEnter` / `onFocus` / `onTouchStart`), and silently swallows failures (resetting the dedup flag so the user can retry).

- **`src/components/PrefetchNavLink.tsx`** — Thin `<NavLink>` wrapper that wires `useRoutePrefetch` to mouse-enter, focus, and touch-start. Preserves all existing `NavLink` props and chains any user-provided event handlers.

### Modified files

- **`src/App.tsx`** — Lazy component definitions now use the named preload functions from `src/config/routes.ts`, keeping import paths in one place.

- **`src/components/Layout.tsx`** — Desktop navigation `<NavLink>` replaced with `<PrefetchNavLink preload={PRELOADS_BY_PATH[to]}>`.

- **`src/components/navigation/MobileNav.tsx`** — Same replacement for mobile navigation links.

### Tests (7 hook + 6 component = 13 new tests)

| Test | What it covers |
|---|---|
| `useRoutePrefetch` | Calls preload once, deduplicates across events, resets on rejection, stable references |
| `PrefetchNavLink` | Renders as link, calls preload on hover/focus, passes `className` through, chains custom handlers |

## Design decisions

- **Hook over higher-order component** — The `useRoutePrefetch` hook is a standalone primitive; `PrefetchNavLink` is the React Router integration. If we ever want prefetch on non-`NavLink` elements, the hook works unchanged.

- **`.catch()` reset on failure** — If the network flakes, the user can retry by hovering again. Without this, a single failed prefetch would permanently skip prefetch for that link.

- **`NavLink` wrapper, not `Link`** — Navigation links use `NavLink` for active-state styling and `aria-current`; wrapping `Link` would lose those features.

- **No new dependencies** — Everything uses React built-ins (`useRef`, `useCallback`) and React Router's existing `NavLink`.

## Acceptance criteria checklist

- [x] Route-level code splitting was already implemented (all pages use `React.lazy`); this PR adds the prefetch-on-hover half
- [x] No regression in existing test suite (13 new tests pass; 3 pre-existing failures in `App.test.tsx` and `App.routing.test.tsx` are unrelated `SettingsContext` + `ActivityTimeline\) build bugs)
- [x] The route preload config lives in `src/config/routes.ts` and is documented via the config file itself
- [x] Lint, build pass for all changed files
- [x] PR description references `Closes #509`

## Test output

```
 ✓ src/hooks/useRoutePrefetch.test.ts (7 tests) 36ms
 ✓ src/components/PrefetchNavLink.test.tsx (6 tests) 256ms
```

No coverage thresholds were affected — the updated files (`Layout.tsx`, `MobileNav.tsx`, `App.tsx`) are not in the coverage include list.

## Note on issue scope

The issue title says "Split each top-level route bundle" — this was already done before this PR via `React.lazy()`. This PR implements the remaining "prefetch on hover" requirement.

## Follow-ups (out of scope)

- Add `v7_startTransition` and `v7_relativeSplatPath` future flags to `<BrowserRouter>` when upgrading to React Router v7
- Wire prefetch into any non-`NavLink` route links that appear in page content (CTA buttons, etc.)

## Security

No user input is involved. Preload functions call `import()` with hardcoded string-literals that Vite resolves at build time — no dynamic paths, no injection surface.