### PR TITLE
docs: add COPY_TONE.md for voice guidance on success, error, empty, loading states

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The link variable intent and legal handoff notes are also tracked in `docs/foote
 See the [docs/](docs/) directory for detailed project documentation, including:
 
 - [Accessibility Checklist](docs/ACCESSIBILITY.md) - Required axe, screen reader, keyboard, and contrast checks before merging UI changes.
+- [Copy Tone Guide](docs/COPY_TONE.md) — How we phrase success, error, empty, and loading UI copy with dos and don'ts.
 
 - [Architecture Overview](docs/ARCHITECTURE.md) — Runtime structure, provider tree, and data flow seams.
 - [Hooks & Utilities Reference](docs/HOOKS.md) — Catalog of reusable hooks (`src/hooks/`) and helpers (`src/lib/`) with signatures and usage.

--- a/docs/COPY_TONE.md
+++ b/docs/COPY_TONE.md
@@ -1,0 +1,353 @@
+# Copy Tone Guide
+
+How we phrase success, error, empty, and loading UI copy across the Credence frontend.
+Intended for **contributors** writing or reviewing user-facing strings.
+
+---
+
+## Voice Principles
+
+Every string in the app should feel like it comes from the same product. Four principles
+guide every decision:
+
+| Principle     | What it means                                                        |
+| ------------- | -------------------------------------------------------------------- |
+| **Friendly**  | Conversational human language. No jargon, no robot-speak.            |
+| **Clear**     | The user understands what happened and what to do next in one scan.  |
+| **Concise**   | Shorter is almost always better. Respect the user's time.            |
+| **Helpful**   | Every state tells the user what _they_ can do, not just what failed. |
+
+---
+
+## State-by-State Guidance
+
+### 1. Success States
+
+Success messages confirm that an action completed. They appear as **toasts** (transient)
+or **banners** (persistent). Use the `success` severity variant in both `addToast()` and
+`<Banner>`.
+
+**Pattern:** `[Action]` + `successfully.` — past tense, full stop.
+
+```tsx
+// ✅ Do — Toast: action-oriented, past tense, period at end
+addToast('success', 'Bond created successfully.')
+addToast('success', 'Settings saved successfully.')
+addToast('success', 'Bond withdrawn successfully.')
+
+// ✅ Do — Banner: contextual, explains the result
+<Banner severity="success">
+  Bond #4 has been withdrawn. 1,234.00 USDC returned to your wallet.
+</Banner>
+```
+
+```tsx
+// ❌ Don't — vague, no action context
+addToast('success', 'Done!')
+addToast('success', 'Success')
+
+// ❌ Don't — present tense, no period (toasts are sentences)
+addToast('success', 'Bond created')
+addToast('success', 'saved ok')
+```
+
+**Toast success conventions:**
+
+- Start with the noun/action: `"Bond created…"`, `"Settings saved…"`, `"Attestation submitted…"`
+- End with a period — toasts with `success` severity are full sentences.
+- Include context when relevant: `"Lock duration extended by +30 days."`
+
+---
+
+### 2. Error States
+
+Errors tell the user something went wrong and **how to recover**. They appear as:
+
+| Mechanism            | Use when…                                                       |
+| -------------------- | --------------------------------------------------------------- |
+| `addToast('danger')` | A discrete action fails (submit, withdraw, connect)             |
+| `<ErrorState>`       | An entire view or section fails to load                         |
+| `<Banner>`           | A persistent warning the user needs to see while they act       |
+| Inline `error` prop  | A form field fails validation                                   |
+
+**Pattern for toasts:** `[Action] failed.` + `[Recovery instruction].`
+
+```tsx
+// ✅ Do — Toast: what failed + what to do
+addToast('danger', 'Transaction failed. Please try again.')
+addToast('danger', 'Withdrawal failed. Please try again.')
+```
+
+```tsx
+// ❌ Don't — technical, no recovery
+addToast('danger', 'Error 500')
+addToast('danger', 'RPC timeout')
+addToast('danger', 'Something went wrong!') // exclamation, no guidance
+```
+
+**Pattern for `<ErrorState>`:** The component renders a branded panel with a title,
+message, and optional retry action. Use the built-in type presets when they match.
+
+```tsx
+// ✅ Do — use the preset types when appropriate
+<ErrorState type="network" action={{ label: 'Try again', onClick: refetch }} />
+// Renders: "Connection issue" / "Unable to connect…"
+
+<ErrorState type="backend" action={{ label: 'Retry', onClick: refetch }} />
+// Renders: "Service unavailable" / "Our service is temporarily unavailable…"
+```
+
+```tsx
+// ✅ Do — override title/message when the context is more specific
+<ErrorState
+  type="generic"
+  title="Unable to load trust score"
+  message={error.message}
+  action={{ label: 'Try again', onClick: refetch }}
+/>
+
+<ErrorState
+  title="Bond Not Found"
+  message={`The requested bond with ID #${id} does not exist or has been removed.`}
+/>
+```
+
+```tsx
+// ❌ Don't — expose raw technical details as the primary message
+<ErrorState
+  title="Error"
+  message="TypeError: Cannot read properties of undefined (reading 'amountUsdc')"
+/>
+```
+
+**Pattern for inline validation errors:**
+
+```tsx
+// ✅ Do — actionable, specific
+<AddressInput error="Invalid address. Stellar public keys are 56 characters starting with G." />
+<AmountInput error="Minimum bond is 10 USDC" />
+
+// ❌ Don't — vague
+<AddressInput error="Bad input" />
+<AmountInput error="Nope" />
+```
+
+**Error toast conventions:**
+
+- Use `'danger'` severity for all error toasts.
+- Two sentences: first says what failed, second says how to recover.
+- No exclamation marks — they read as alarmist, not helpful.
+- Never expose raw HTTP status codes or stack traces in user-facing copy.
+
+---
+
+### 3. Empty States
+
+Empty states appear when a list or section has no data. Use the `<EmptyState>` component
+from `src/components/states/`. They should be encouraging and, when possible, point to
+the next action.
+
+**Pattern:** `title` (3–6 words stating the fact) + `description` (1–2 sentences
+explaining the benefit or what will appear) + optional `action` (action-verb CTA).
+
+```tsx
+// ✅ Do — Title states the fact, description explains value, CTA is a clear next step
+<EmptyState
+  illustration="bond"
+  title="No active bonds"
+  description="You do not have any active bonds yet. Create your first bond to start building on-chain reputation."
+  action={{
+    label: 'Create your first bond',
+    onClick: () => scrollTo('#bond-amount'),
+  }}
+/>
+```
+
+```tsx
+// ✅ Do — No CTA when the empty state is informational
+<EmptyState
+  illustration="activity"
+  title="No recent activity"
+  description="New trust score events will appear here once bonds, attestations, or score updates occur."
+/>
+```
+
+```tsx
+// ❌ Don't — vague title, no explanation of what this section is for
+<EmptyState title="Nothing here" description="No data." />
+
+// ❌ Don't — too wordy
+<EmptyState
+  title="You have not created any bonds in the Credence protocol ecosystem yet"
+  description="The Credence protocol enables users to lock USDC into reputation bonds…"
+/>
+
+// ❌ Don't — generic CTA label
+<EmptyState
+  title="No active bonds"
+  description="…"
+  action={{ label: 'Click here', onClick: handleClick }}
+/>
+```
+
+**Empty state title conventions:**
+
+- Sentence case (only first word capitalized): `"No active bonds"`, not `"No Active Bonds"`.
+- State the fact, not a command: `"No recent activity"`, not `"View your activity"`.
+- 3–6 words.
+
+**Empty state CTA conventions:**
+
+- Action verb + object: `"Create your first bond"`, `"Request attestation"`.
+- Never `"Click here"`, `"Submit"`, `"OK"` as the sole label.
+
+---
+
+### 4. Loading States
+
+Loading states provide feedback while data fetches or an action processes. Use
+`<LoadingSkeleton>` for page/section loads and the `isLoading` prop on interactive
+components (`<Button>`, `<AmountInput>`, `<AddressInput>`, `<Toggle>`, `<Select>`).
+
+**No user-facing copy** is rendered by loading skeletons — they are purely visual.
+However, screen-reader announcements and `aria-*` attributes serve as the "copy" for
+assistive technology.
+
+```tsx
+// ✅ Do — match the skeleton variant to the content shape
+{isLoading && <LoadingSkeleton variant="card" />}
+{isLoading && <LoadingSkeleton variant="dashboard" rows={3} />}
+{isLoading && <LoadingSkeleton variant="table" rows={5} />}
+```
+
+```tsx
+// ✅ Do — isLoading on interactive elements disables and shows spinner
+<Button isLoading>Withdraw bond</Button>
+// Renders: spinner + "Sending…" sr-only text + disabled state
+```
+
+**When you need a text loading message** (e.g., for a status region), prefer the i18n key:
+
+```json
+"transactions": {
+  "loading": "Loading transactions…"
+}
+```
+
+```tsx
+// ✅ Do — if a text label is needed, use a single ellipsis character (…)
+<span aria-live="polite">Loading transactions…</span>
+
+// ❌ Don't — three dots, all-caps, or blinking text
+<span>LOADING...</span>
+<span>Please wait while we fetch your data.</span>
+```
+
+**Loading conventions:**
+
+- Show skeletons immediately — don't wait for a timeout.
+- Match skeleton layout to the content that will replace it.
+- Use `aria-busy="true"` on elements in a loading state.
+- Honor `prefers-reduced-motion` (the `LoadingSkeleton` already does this via
+  `useReducedMotion`).
+
+---
+
+## General Copy Conventions
+
+### Capitalization
+
+- **Sentence case** everywhere: titles, headings, button labels, toast messages,
+  empty state titles, error messages.
+- Only proper nouns (Credence, Stellar, USDC, Freighter) are capitalized mid-sentence.
+
+```tsx
+// ✅ Do
+'No active bonds'
+'Create your first bond'
+'Bond created successfully.'
+
+// ❌ Don't
+'No Active Bonds'
+'Create Your First Bond'
+'Bond Created Successfully.'
+```
+
+### Punctuation
+
+| Context              | Period? | Example                        |
+| -------------------- | ------- | ------------------------------ |
+| Toast message        | Yes     | `'Bond created successfully.'` |
+| Empty state title    | No      | `'No active bonds'`            |
+| Empty state desc     | Yes     | `'You do not have any…'`       |
+| Error state title    | No      | `'Connection issue'`           |
+| Error state message  | Yes     | `'Unable to connect…'`         |
+| Button label         | No      | `'Create your first bond'`     |
+| Inline error         | Yes     | `'Minimum bond is 10 USDC.'`   |
+| Banner body          | Yes     | Full sentence(s) with period   |
+| Banner title         | No      | `'Early Withdrawal Penalty'`   |
+
+### Word count
+
+| Element              | Max length                      |
+| -------------------- | ------------------------------- |
+| Toast message        | 2 short sentences (≈80 chars)   |
+| Empty state title    | 3–6 words                       |
+| Empty state desc     | 1–2 sentences (≈140 chars)      |
+| Error state title    | 2–5 words                       |
+| Error state message  | 1–2 sentences (≈140 chars)      |
+| Button / CTA label   | 2–4 words                       |
+| Banner body          | 1–3 sentences                   |
+
+### Internationalization (i18n)
+
+All user-facing strings must live in `src/i18n/locales/en.json` and be referenced via
+`useTranslation()`:
+
+```tsx
+// ✅ Do
+const { t } = useTranslation()
+;<h1>{t('bond.title')}</h1>
+;<EmptyState title={t('bond.noActiveBonds')} description={t('bond.noActiveBondsDescription')} />
+
+// ❌ Don't — hard-coded English strings
+;<h1>Bond USDC</h1>
+;<EmptyState title="No active bonds" description="You do not have any active bonds yet." />
+```
+
+Exception: toast messages currently use hard-coded English strings in the codebase
+(e.g., `addToast('success', 'Bond created successfully.')`). When adding new toast
+strings, follow the existing pattern, and prefer action-oriented past-tense sentences.
+
+---
+
+## Dos and Don'ts Summary
+
+| Do                                                       | Don't                                              |
+| -------------------------------------------------------- | -------------------------------------------------- |
+| Use sentence case for all UI copy                        | Use Title Case or ALL CAPS                         |
+| End toast messages with a period                         | Leave toasts unpunctuated                          |
+| Provide a recovery step in error messages                | Just say "Error" or "Failed"                       |
+| Match empty state titles to 3–6 words                    | Write verbose paragraphs as empty state titles     |
+| Use action-verb CTA labels (`"Create your first bond"`)  | Use `"Click here"`, `"OK"`, or `"Submit"`          |
+| Use `'danger'` severity for error toasts                 | Use `'warning'` or `'info'` for action failures    |
+| Reference i18n keys in components                        | Hard-code English strings (except toast messages)   |
+| Put user-facing copy in `src/i18n/locales/en.json`       | Scatter strings across `.tsx` files                |
+| Use the `<EmptyState>` / `<ErrorState>` / `<Banner>` components | Build ad-hoc state UIs per page              |
+| Honor `prefers-reduced-motion` for loading animations    | Ship unguarded skeleton shimmer animations         |
+
+---
+
+## Checklist for PR Review
+
+When reviewing a PR that adds or changes user-facing strings, verify:
+
+- [ ] All new strings follow sentence case.
+- [ ] Toast messages end with a period and describe the action + outcome.
+- [ ] Error messages explain recovery (not just what failed).
+- [ ] Empty states have a title ≤ 6 words and a description ≤ 140 characters.
+- [ ] CTAs use action-oriented labels (not "Click here").
+- [ ] Hard-coded English strings (outside toast messages) are in `en.json`.
+- [ ] No raw error codes, HTTP statuses, or stack traces in user-facing copy.
+- [ ] `aria-busy`, `aria-live`, and `role` attributes match the UI state.
+- [ ] Loading skeletons use the correct `variant` for their content shape.

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,21 +43,28 @@ This directory contains comprehensive design specifications and implementation g
    - When and how to use each state type
    - Validation checklist
 
-6. **[Form Inputs & Variants](./FORMS_AND_INPUTS.md)** ⭐ NEW
+6. **[Copy Tone Guide](./COPY_TONE.md)** ⭐ NEW
+   - How we phrase success, error, empty, and loading UI copy
+   - Voice principles (friendly, clear, concise, helpful)
+   - State-by-state dos and don'ts with real codebase examples
+   - Capitalization, punctuation, and i18n conventions
+   - PR review checklist for user-facing strings
+
+7. **[Form Inputs & Variants](./FORMS_AND_INPUTS.md)** ⭐ NEW
    - Standardized states (Default, Error, Disabled, Loading) for all input components
    - Usage guidelines and accessibility contracts for `AddressInput`, `AmountInput`, and controls
 
-7. **[Design Tokens](./DESIGN_TOKENS.md)**
+8. **[Design Tokens](./DESIGN_TOKENS.md)**
    - Canonical `--credence-*` CSS variable reference
    - Color, spacing, radius, typography, and motion scales
    - Guidance for replacing one-off hex values in components
 
-8. **[Motion Guidelines](./motion-guidelines.md)**
+9. **[Motion Guidelines](./motion-guidelines.md)**
    - Motion token strategy and reduced-motion defaults
    - Best practices for animation and transitions
    - Implementation examples for UI micro-interactions
 
-9. **[Figma Design Specs](./FIGMA_DESIGN_SPECS.md)**
+10. **[Figma Design Specs](./FIGMA_DESIGN_SPECS.md)**
    - Visual design specifications
    - Color palette and design tokens
    - Layout measurements and spacing
@@ -65,32 +72,32 @@ This directory contains comprehensive design specifications and implementation g
    - Responsive breakpoints
    - Component organization structure
 
-10. **[Implementation Examples](./IMPLEMENTATION_EXAMPLES.md)**
+11. **[Implementation Examples](./IMPLEMENTATION_EXAMPLES.md)**
     - Practical code examples for each page
     - Reusable hooks and patterns
     - Testing examples
     - Accessibility guidelines
     - Performance considerations
 
-11. **[Mobile Navigation Pattern](./mobile-navigation-pattern.md)** ⭐ NEW
+12. **[Mobile Navigation Pattern](./mobile-navigation-pattern.md)** ⭐ NEW
     - Hybrid responsive navigation (hamburger mobile + horizontal desktop)
     - Complete implementation guide with code examples
     - Accessibility requirements (WCAG 2.1 AA)
     - Testing guide and troubleshooting
     - [Decision Matrix](./mobile-navigation-DECISION.md) | [Reconnaissance Report](./mobile-nav-RECON.md) | [Figma Rules](./figma-nav-rules.md)
 
-12. **[Architecture Overview](./ARCHITECTURE.md)** ⭐ NEW
+13. **[Architecture Overview](./ARCHITECTURE.md)** ⭐ NEW
     - Provider tree and routing architecture
     - Context responsibilities
     - Theming flow and mock data boundaries
 
-13. [Keyboard Interactions Contract](./keyboard-interactions.md) ⭐ NEW
+14. [Keyboard Interactions Contract](./keyboard-interactions.md) ⭐ NEW
 
 - Developer-facing matrix of every interactive component and its expected keyboard behavior
 - Covers `ConfirmDialog`, `TierLadder`, `Banner`, `Toggle`, `AddressInput`, skip-link, and navigation
 - Focus-restore contract and checklist for new interactive components
 
-13. [Wallet Integration](./WALLET_INTEGRATION.md) ⭐ NEW
+15. [Wallet Integration](./WALLET_INTEGRATION.md) ⭐ NEW
     - `useWallet` API documentation
     - Connection state machine and UX contract for connection/network states
     - Usage guide and network mismatch handling

--- a/docs/UI_STATES_GUIDE.md
+++ b/docs/UI_STATES_GUIDE.md
@@ -6,6 +6,8 @@ This guide defines the empty states, error states, and loading patterns for the 
 
 ---
 
+See also: **[Copy Tone Guide](./COPY_TONE.md)** for dos and don'ts when phrasing success, error, empty, and loading copy.
+
 ## Empty States
 
 Empty states appear when there's no data to display. They should be encouraging and guide users toward their next action.


### PR DESCRIPTION
## Summary

Closes #587

Adds `docs/COPY_TONE.md` — a comprehensive copy tone guide for contributors covering how we phrase success, error, empty, and loading UI states with concrete dos and don'ts pulled from the real codebase.

## Background

We rely on this information internally but it is currently tribal knowledge. Writing it down lets reviewers verify behaviour against the documented intent, lets new contributors get productive without reading every commit, and lets the support team answer common questions without paging an engineer.

## What's in the guide

### Voice Principles
- **Friendly** — conversational human language, no jargon
- **Clear** — the user understands what happened and what to do next in one scan
- **Concise** — shorter is almost always better
- **Helpful** — every state tells the user what *they* can do, not just what failed

### State-by-State Guidance
Each section includes real codebase examples with ✅ Do and ❌ Don't annotations:

1. **Success States** — toast messages (`addToast('success', ...)`) and banners (`<Banner severity="success">`), with conventions for past tense, periods, and action context
2. **Error States** — covers `addToast('danger')`, `<ErrorState>` presets (network/backend/validation/generic), inline validation errors on form fields, and the rule: always explain recovery
3. **Empty States** — `<EmptyState>` with illustration tokens, title conventions (3–6 words, sentence case, state the fact), description conventions (1–2 sentences), and CTA conventions (action verb + object, never "Click here")
4. **Loading States** — `<LoadingSkeleton>` variants (card/dashboard/table/text/form), `isLoading` prop on interactive components, `aria-busy` guide, and text loading messages ("Loading transactions…" with ellipsis character)

### General Copy Conventions
- **Capitalization** — sentence case everywhere; only proper nouns (Credence, Stellar, USDC, Freighter) capitalized mid-sentence
- **Punctuation** — table mapping each context (toast, empty state title, error message, button label, banner body, etc.) to whether it takes a period
- **Word count** — max lengths for titles, descriptions, CTAs, and body copy
- **i18n** — all user-facing strings must live in `src/i18n/locales/en.json` and use `useTranslation()`; toast messages are a noted exception

### Dos and Don'ts Summary Table
10-row quick-reference table covering sentence case, periods, recovery steps, CTA labels, i18n, component reuse, and motion preferences.

### PR Review Checklist
A 9-item checklist for reviewers verifying user-facing string changes.

## Cross-Linking

- Linked from **README.md** (Documentation section)
- Linked from **docs/README.md** (entry #6 in Available Documents)
- Cross-referenced from **docs/UI_STATES_GUIDE.md** (related microcopy guide)

## Acceptance Criteria Checklist

- [x] Change matches the summary: "How we phrase success, error, empty, loading — with dos/don'ts"
- [x] Document linked from at least one existing top-level doc (README.md and docs/README.md)
- [x] Examples use real codebase APIs — no `foo()` placeholders
- [x] Audience explicitly set to **contributors**
- [x] Concrete examples over abstract definitions
- [x] Cross-linked from README and related docs
- [x] No unrelated refactors
- [x] No stylistic-only changes
- [x] Lint, type-check, and tests verified (pre-existing failures only, unrelated to docs)

## Out of Scope (per issue)

- Unrelated refactors in adjacent files
- Stylistic-only changes (formatting, renaming) not required by the fix
- Anything beyond the acceptance criteria

Closes #587