### PR TITLE
538 add eslint rule banning dangerouslySetInnerHTML (#538)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,7 @@
 import js from '@eslint/js'
 import globals from 'globals'
 import tseslint from 'typescript-eslint'
+import noDangerouslySetInnerHtml from './src/eslint-rules/no-dangerously-set-inner-html.js'
 
 export default tseslint.config({
   ignores: ['dist', 'node_modules', 'storybook-static'],
@@ -18,11 +19,24 @@ export default tseslint.config({
       ...globals.browser,
     },
   },
+  plugins: {
+    local: {
+      rules: {
+        'no-dangerously-set-inner-html': noDangerouslySetInnerHtml,
+      },
+    },
+  },
   rules: {
     '@typescript-eslint/no-unused-vars': [
       'error',
       {
         argsIgnorePattern: '^_',
+      },
+    ],
+    'local/no-dangerously-set-inner-html': [
+      'error',
+      {
+        allow: [],
       },
     ],
   },

--- a/src/eslint-rules/no-dangerously-set-inner-html.js
+++ b/src/eslint-rules/no-dangerously-set-inner-html.js
@@ -1,0 +1,64 @@
+const ALLOW_OPTION = {
+  type: 'array',
+  items: { type: 'string' },
+  uniqueItems: true,
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Ban dangerouslySetInnerHTML outside an explicit allowlist of wrapper components that have been reviewed for XSS safety.',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: { allow: ALLOW_OPTION },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      notAllowed:
+        'Using dangerouslySetInnerHTML is prohibited. If this component has been reviewed for XSS safety, add it to the `allow` list in eslint.config.js.',
+    },
+  },
+  create(context) {
+    const options = context.options[0] || {}
+    const allowList = new Set(options.allow || [])
+
+    const elementStack = []
+
+    return {
+      JSXOpeningElement(node) {
+        elementStack.push(node)
+      },
+      'JSXOpeningElement:exit'() {
+        elementStack.pop()
+      },
+      JSXAttribute(node) {
+        if (
+          !node.name ||
+          node.name.type !== 'JSXIdentifier' ||
+          node.name.name !== 'dangerouslySetInnerHTML'
+        ) {
+          return
+        }
+
+        const element = elementStack[elementStack.length - 1]
+        if (!element) return
+
+        let componentName
+        if (element.name.type === 'JSXIdentifier') {
+          componentName = element.name.name
+        } else if (element.name.type === 'JSXMemberExpression') {
+          componentName = `${element.name.object.name}.${element.name.property.name}`
+        }
+
+        if (!componentName || !allowList.has(componentName)) {
+          context.report({ node, messageId: 'notAllowed' })
+        }
+      },
+    }
+  },
+}

--- a/src/eslint-rules/no-dangerously-set-inner-html.test.js
+++ b/src/eslint-rules/no-dangerously-set-inner-html.test.js
@@ -1,0 +1,31 @@
+import { RuleTester } from 'eslint'
+import rule from './no-dangerously-set-inner-html.js'
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    parserOptions: {
+      ecmaFeatures: { jsx: true },
+    },
+  },
+})
+
+ruleTester.run('no-dangerously-set-inner-html', rule, {
+  valid: [
+    {
+      code: '<SafeHTML dangerouslySetInnerHTML={{ __html: "<p>hello</p>" }} />',
+      options: [{ allow: ['SafeHTML'] }],
+    },
+  ],
+  invalid: [
+    {
+      code: '<div dangerouslySetInnerHTML={{ __html: "<p>hi</p>" }} />',
+      errors: [{ messageId: 'notAllowed' }],
+    },
+    {
+      code: '<span dangerouslySetInnerHTML={{ __html: "text" }} />',
+      errors: [{ messageId: 'notAllowed' }],
+    },
+  ],
+})


### PR DESCRIPTION
Closes #538

## Threat being mitigated

Cross-site scripting (XSS) via `dangerouslySetInnerHTML`. If any component were to inject unsanitized user-controlled content, an attacker could execute arbitrary JavaScript in the context of the app. While the current codebase has zero usages of this API, a defence-in-depth rule prevents future introduction outside a review-gated allowlist.

## Implementation

- **Custom ESLint rule** `local/no-dangerously-set-inner-html` defined in `src/eslint-rules/no-dangerously-set-inner-html.js`
- The rule bans `dangerouslySetInnerHTML` on any JSX element whose tag name is **not** in an explicit `allow` list (currently empty)
- A whitelisted component (e.g., a future sanitized-HTML wrapper) can be added by editing the `allow` array in `eslint.config.js`
- The rule handles both simple (`<Component />`) and namespaced (`<ns.Component />`) JSX identifiers

## Testing

- **Positive test:** `SafeHTML` (a hypothetical whitelisted wrapper) using `dangerouslySetInnerHTML` passes with no error  
- **Negative test:** `<div>` and `<span>` using `dangerouslySetInnerHTML` correctly produce the `notAllowed` error
- Tests use ESLint's `RuleTester` and run as part of `npm test` via vitest

## Verification

- `npm run lint` — no new violations (0 existing usages of the banned API)
- `npm test` — all ESLint rule tests pass (3/3)
- Pre-existing `tsc` error in `ActivityTimeline.test.tsx` (TS1128) is unrelated and present on main