### PR TITLE
518 wire focus outline to semantic --color-focus-ring token (#518)

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -97,8 +97,9 @@
   --credence-color-attestation-surface: #d1fae5;
 
   /* Effects */
+  --credence-color-focus-ring: var(--credence-color-primary);
   --credence-shadow-toast: 0 4px 12px rgba(0, 0, 0, 0.1);
-  --credence-focus-ring: 2px solid var(--credence-color-primary);
+  --credence-focus-ring: 2px solid var(--credence-color-focus-ring);
   --credence-skeleton-gradient: linear-gradient(
     90deg,
     var(--credence-color-slate-100) 25%,
@@ -120,6 +121,7 @@
   --text-primary: var(--credence-text-primary);
   --text-secondary: var(--credence-text-secondary);
   --border-default: var(--credence-border-default);
+  --color-focus-ring: var(--credence-color-focus-ring);
   --color-primary: var(--credence-color-primary);
   --color-primary-hover: var(--credence-color-primary-strong);
   --primary-hover: var(--credence-color-primary-strong);


### PR DESCRIPTION
Closes #518

## Change

Extracts the focus-ring color into a dedicated semantic token `--credence-color-focus-ring` (with a backwards-compatible alias `--color-focus-ring`) so that the tab-key focus outline can be themed independently of the primary brand color.

**Before:** `--credence-focus-ring: 2px solid var(--credence-color-primary)`  
**After:** `--credence-focus-ring: 2px solid var(--credence-color-focus-ring)` where `--credence-color-focus-ring: var(--credence-color-primary)` by default

## Benefits

- **Theming consistency**: dark mode switches `--credence-color-primary` to `#38bdf8` → focus ring follows automatically via the token chain
- **Customisability**: a theme author can override `--credence-color-focus-ring` without affecting any other UI element
- **Backwards compatible**: all existing `:focus-visible` rules using `var(--credence-focus-ring)` continue to work unchanged

## Keyboard accessibility

The global `:focus-visible` rule at `src/index.css:212` applies `outline: var(--credence-focus-ring); outline-offset: 2px` to every keyboard-focused element, ensuring all interactive controls are reachable and visually indicated without a pointer. This is supplemented by 30+ component-level `:focus-visible` selectors across the codebase.

## Verification

- `npm run lint` — no new violations (30 pre-existing errors unchanged)
- `npm run build` — pre-existing tsc error in `ActivityTimeline.test.tsx` (TS1128) unchanged
- Relevant unit tests pass (14/14 in keyboard-walkthrough and eslint-rule test files)