### PR TITLE
test(isExternalUrl): lock in javascript:/https/mailto protocol contract

### DIFF
--- a/src/lib/isExternalUrl.test.ts
+++ b/src/lib/isExternalUrl.test.ts
@@ -2,49 +2,131 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { isExternalUrl } from './isExternalUrl';
 
 describe('isExternalUrl', () => {
-  const originalLocation = window.location;
-
   beforeAll(() => {
-    // Mock window.location for tests
-    delete (window as any).location;
-    window.location = {
-      ...originalLocation,
-      origin: 'https://app.credence.org',
-      href: 'https://app.credence.org/dashboard',
-      protocol: 'https:',
-    } as any;
+    // Pin the simulated app origin for all tests in this suite.
+    // Object.defineProperty avoids the `delete (window as any).location` anti-pattern.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: {
+        origin: 'https://app.credence.org',
+        href: 'https://app.credence.org/dashboard',
+        protocol: 'https:',
+      } satisfies Partial<Location>,
+    });
   });
 
   afterAll(() => {
-    window.location = originalLocation;
+    // Restore to original JSDOM location descriptor so other test files are unaffected.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      writable: true,
+      value: globalThis.location,
+    });
   });
 
-  it('returns true for external URLs', () => {
-    expect(isExternalUrl('https://google.com')).toBe(true);
-    expect(isExternalUrl('http://example.com')).toBe(true);
-    expect(isExternalUrl('https://sub.credence.org')).toBe(true);
+  // -------------------------------------------------------------------------
+  // Protocol-specific contract tests (the primary lock-in for this module)
+  // -------------------------------------------------------------------------
+
+  describe('javascript: protocol — always blocked', () => {
+    it('returns_false_for_javascript_colon_bare', () => {
+      expect(isExternalUrl('javascript:')).toBe(false);
+    });
+
+    it('returns_false_for_javascript_colon_void_expression', () => {
+      expect(isExternalUrl('javascript:void(0)')).toBe(false);
+    });
+
+    it('returns_false_for_javascript_colon_alert_xss_payload', () => {
+      expect(isExternalUrl('javascript:alert(1)')).toBe(false);
+    });
+
+    it('returns_false_for_javascript_colon_with_encoded_colon', () => {
+      // URL-encoding should not bypass the check — new URL() normalises it.
+      expect(isExternalUrl('javascript%3Aalert(1)')).toBe(false);
+    });
   });
 
-  it('returns false for in-app relative links', () => {
-    expect(isExternalUrl('/docs')).toBe(false);
-    expect(isExternalUrl('/dashboard/settings')).toBe(false);
-    expect(isExternalUrl('./relative')).toBe(false);
+  describe('https: protocol — allowed for cross-origin URLs', () => {
+    it('returns_true_for_https_url_on_different_domain', () => {
+      expect(isExternalUrl('https://example.com')).toBe(true);
+    });
+
+    it('returns_true_for_https_url_with_path', () => {
+      expect(isExternalUrl('https://example.com/some/path')).toBe(true);
+    });
+
+    it('returns_true_for_https_url_on_different_subdomain', () => {
+      expect(isExternalUrl('https://sub.credence.org')).toBe(true);
+    });
+
+    it('returns_false_for_https_url_on_same_origin', () => {
+      expect(isExternalUrl('https://app.credence.org/about')).toBe(false);
+    });
+
+    it('returns_false_for_https_url_on_same_origin_root', () => {
+      expect(isExternalUrl('https://app.credence.org/')).toBe(false);
+    });
   });
 
-  it('returns false for absolute same-origin URLs', () => {
-    expect(isExternalUrl('https://app.credence.org/about')).toBe(false);
-    expect(isExternalUrl('https://app.credence.org/')).toBe(false);
+  describe('http: protocol — allowed for cross-origin URLs', () => {
+    it('returns_true_for_http_url_on_different_domain', () => {
+      expect(isExternalUrl('http://example.com')).toBe(true);
+    });
   });
 
-  it('returns false for placeholder or empty', () => {
-    expect(isExternalUrl('#')).toBe(false);
-    expect(isExternalUrl('')).toBe(false);
-    expect(isExternalUrl(undefined)).toBe(false);
+  describe('mailto: protocol — allowed (opens system mail client)', () => {
+    it('returns_true_for_mailto_with_address', () => {
+      expect(isExternalUrl('mailto:support@credence.org')).toBe(true);
+    });
+
+    it('returns_true_for_mailto_with_subject_query', () => {
+      expect(isExternalUrl('mailto:support@credence.org?subject=Hello')).toBe(true);
+    });
+
+    it('returns_true_for_bare_mailto_colon', () => {
+      expect(isExternalUrl('mailto:')).toBe(true);
+    });
   });
 
-  it('returns false for malformed URLs safely', () => {
-    expect(isExternalUrl('not-a-real-url:something')).toBe(false);
-    expect(isExternalUrl('javascript:alert(1)')).toBe(false);
-    expect(isExternalUrl('mailto:test@example.com')).toBe(false);
+  // -------------------------------------------------------------------------
+  // Relative and in-app paths — never external
+  // -------------------------------------------------------------------------
+
+  describe('relative paths — always internal', () => {
+    it('returns_false_for_absolute_path', () => {
+      expect(isExternalUrl('/docs')).toBe(false);
+    });
+
+    it('returns_false_for_nested_absolute_path', () => {
+      expect(isExternalUrl('/dashboard/settings')).toBe(false);
+    });
+
+    it('returns_false_for_dot_relative_path', () => {
+      expect(isExternalUrl('./relative')).toBe(false);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge / safety cases
+  // -------------------------------------------------------------------------
+
+  describe('edge cases — safe fallbacks', () => {
+    it('returns_false_for_empty_string', () => {
+      expect(isExternalUrl('')).toBe(false);
+    });
+
+    it('returns_false_for_undefined', () => {
+      expect(isExternalUrl(undefined)).toBe(false);
+    });
+
+    it('returns_false_for_hash_placeholder', () => {
+      expect(isExternalUrl('#')).toBe(false);
+    });
+
+    it('returns_false_for_unparseable_string', () => {
+      expect(isExternalUrl('not-a-real-url:something')).toBe(false);
+    });
   });
 });

--- a/src/lib/isExternalUrl.ts
+++ b/src/lib/isExternalUrl.ts
@@ -1,17 +1,26 @@
 /**
- * Checks if a given URL is external (off-origin).
- * It returns true for valid absolute HTTP/HTTPS URLs that do not match the current origin.
- * Relative URLs, in-app links (like /docs), and same-origin absolute URLs are considered internal.
- * It also handles malformed URLs safely by returning false or true depending on the strictness,
- * but typical requirement: if it can't be parsed, it's not a valid external URL, return false.
- * Placeholder '#' should return false.
+ * Checks if a given URL is external (off-origin) or a safe non-HTTP scheme.
+ *
+ * Returns `true` for:
+ * - Absolute HTTP/HTTPS URLs whose origin differs from the current page origin.
+ * - `mailto:` URLs (safe, opens the system mail client).
+ *
+ * Returns `false` for:
+ * - Relative paths (`/docs`, `./relative`).
+ * - Same-origin absolute URLs.
+ * - Placeholder `#` or empty/undefined values.
+ * - `javascript:` and any other non-allow-listed scheme (blocked for security).
+ * - Malformed strings that cannot be parsed as a URL.
  *
  * @param href The URL string to check.
- * @returns boolean True if the URL is external, false otherwise.
+ * @returns `true` if the URL should be treated as external / leaving the app.
  */
 export function isExternalUrl(href: string | undefined): boolean {
   if (!href || href === '#') return false;
   if (href.startsWith('/') || href.startsWith('.')) return false;
+
+  // Allow mailto: links — they open the system mail client, not the browser.
+  if (href.startsWith('mailto:')) return true;
 
   try {
     const url = new URL(href, window.location.href);


### PR DESCRIPTION
 Locks in URL protocol contract for isExternalUrl
  
  Fixes thin test coverage around URL scheme handling — javascript: URLs could be silently
  misclassified with no failing test to catch it.
  
  Changes
  
  src/lib/isExternalUrl.ts
  
  - Added an explicit mailto: allow-list check so footer links using mailto: are correctly
  treated as external (opening the system mail client rather than being silently dropped as
  internal).
  
  src/lib/isExternalUrl.test.ts
  
  - Replaced the vague 'returns false for malformed URLs safely' catch-all — which buried
  javascript: and mailto: in a single assertion with the wrong expectation for mailto: — with
  four dedicated describe blocks, one per protocol:
    - javascript: protocol — always blocked (bare, void expression, XSS payload, percent-encoded
  colon)
    - https: protocol — allowed for cross-origin URLs (happy path + same-origin sad paths)
    - http: protocol — allowed for cross-origin URLs
    - mailto: protocol — allowed (with address, with query string, bare)
  
  - Switched the window.location mock from delete (window as any).location to
  Object.defineProperty to satisfy the @typescript-eslint/no-explicit-any lint rule.
  
  Testing
  
  All 20 new tests pass (npx vitest run src/lib/isExternalUrl.test.ts). Both changed files lint
  cleanly (npx eslint src/lib/isExternalUrl.ts src/lib/isExternalUrl.test.ts). Pre-existing
  failures in CreateBondFlow and ActivityTimeline are unrelated and present on main before this
  change.
closes #584