### PR TITLE
feat: Add view responsive breakpoints toggle in dev mode

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { WalletProvider } from './context/WalletContext'
 import ToastProvider from './components/ToastProvider'
 import ErrorBoundary from './components/ErrorBoundary'
 import Layout from './components/Layout'
+import BreakpointOverlay from './components/dev/BreakpointOverlay'
 
 const Home = lazy(() => import('./pages/Home'))
 const Dashboard = lazy(() => import('./pages/Dashboard'))
@@ -57,6 +58,7 @@ function App() {
                   </Route>
                 </Routes>
               </Suspense>
+              <BreakpointOverlay />
             </ErrorBoundary>
           </WalletProvider>
         </ToastProvider>

--- a/src/components/dev/BreakpointOverlay.css
+++ b/src/components/dev/BreakpointOverlay.css
@@ -1,0 +1,111 @@
+.breakpoint-overlay-container {
+  position: fixed;
+  bottom: var(--credence-space-4);
+  right: var(--credence-space-4);
+  z-index: 9999;
+  display: flex;
+  align-items: center;
+  gap: var(--credence-space-2);
+  pointer-events: auto;
+}
+
+.breakpoint-toggle-btn {
+  background-color: var(--credence-color-slate-900);
+  color: var(--credence-color-white);
+  border: 1px solid var(--credence-border-default);
+  border-radius: var(--credence-radius-full);
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--credence-font-size-xs);
+  font-weight: var(--credence-font-weight-bold);
+  cursor: pointer;
+  box-shadow: var(--credence-shadow-toast);
+  transition: opacity var(--credence-motion-duration-fast) var(--credence-motion-easing-standard);
+  opacity: 0.5;
+}
+
+.breakpoint-toggle-btn:hover,
+.breakpoint-toggle-btn:focus-visible {
+  opacity: 1;
+}
+
+.breakpoint-pill {
+  background-color: var(--credence-color-slate-900);
+  color: var(--credence-color-white);
+  padding: var(--credence-space-1) var(--credence-space-3);
+  border-radius: var(--credence-radius-full);
+  font-size: var(--credence-font-size-xs);
+  font-weight: var(--credence-font-weight-bold);
+  display: flex;
+  align-items: center;
+  gap: var(--credence-space-2);
+  box-shadow: var(--credence-shadow-toast);
+  border: 1px solid var(--credence-border-default);
+}
+
+.breakpoint-close-btn {
+  background: transparent;
+  border: none;
+  color: var(--credence-color-slate-400);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  width: 1rem;
+  height: 1rem;
+  border-radius: var(--credence-radius-full);
+}
+
+.breakpoint-close-btn:hover {
+  color: var(--credence-color-white);
+  background-color: var(--credence-color-slate-700);
+}
+
+[data-theme='dark'] .breakpoint-toggle-btn,
+[data-theme='dark'] .breakpoint-pill {
+  background-color: var(--credence-surface-card);
+  color: var(--credence-text-primary);
+}
+
+[data-theme='dark'] .breakpoint-close-btn:hover {
+  color: var(--credence-text-primary);
+  background-color: var(--credence-color-slate-700);
+}
+
+.breakpoint-indicator::after {
+  content: 'xs (<480px)';
+}
+
+@media (min-width: 480px) {
+  .breakpoint-indicator::after {
+    content: 'sm (≥480px)';
+  }
+}
+
+@media (min-width: 640px) {
+  .breakpoint-indicator::after {
+    content: 'md (≥640px)';
+  }
+}
+
+@media (min-width: 768px) {
+  .breakpoint-indicator::after {
+    content: 'lg (≥768px)';
+  }
+}
+
+@media (min-width: 900px) {
+  .breakpoint-indicator::after {
+    content: 'xl (≥900px)';
+  }
+}
+
+@media (min-width: 1280px) {
+  .breakpoint-indicator::after {
+    content: '2xl (≥1280px)';
+  }
+}

--- a/src/components/dev/BreakpointOverlay.test.tsx
+++ b/src/components/dev/BreakpointOverlay.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect, beforeEach } from 'vitest'
+import BreakpointOverlay from './BreakpointOverlay'
+import { LOCAL_STORAGE_KEYS } from '../../config/constants'
+
+describe('BreakpointOverlay', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('renders the overlay by default in dev mode', () => {
+    render(<BreakpointOverlay />)
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /hide breakpoints/i })).toBeInTheDocument()
+  })
+
+  it('toggles visibility and saves to localStorage', () => {
+    render(<BreakpointOverlay />)
+
+    // Default is visible
+    expect(screen.getByRole('status')).toBeInTheDocument()
+
+    // Click close button
+    const closeBtn = screen.getByRole('button', { name: /hide breakpoints/i })
+    fireEvent.click(closeBtn)
+
+    // Now the toggle button should be visible
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /show breakpoints/i })).toBeInTheDocument()
+    expect(localStorage.getItem(LOCAL_STORAGE_KEYS.DEV_BREAKPOINTS)).toBe('false')
+
+    // Click toggle button to show again
+    const showBtn = screen.getByRole('button', { name: /show breakpoints/i })
+    fireEvent.click(showBtn)
+
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(localStorage.getItem(LOCAL_STORAGE_KEYS.DEV_BREAKPOINTS)).toBe('true')
+  })
+
+  it('respects initial localStorage value', () => {
+    localStorage.setItem(LOCAL_STORAGE_KEYS.DEV_BREAKPOINTS, 'false')
+    render(<BreakpointOverlay />)
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /show breakpoints/i })).toBeInTheDocument()
+  })
+})

--- a/src/components/dev/BreakpointOverlay.tsx
+++ b/src/components/dev/BreakpointOverlay.tsx
@@ -1,0 +1,65 @@
+import { useState, useEffect } from 'react'
+import { LOCAL_STORAGE_KEYS } from '../../config/constants'
+import './BreakpointOverlay.css'
+
+export default function BreakpointOverlay() {
+  const [isVisible, setIsVisible] = useState(() => {
+    try {
+      const stored = localStorage.getItem(LOCAL_STORAGE_KEYS.DEV_BREAKPOINTS)
+      return stored !== 'false' // Default to true if not set
+    } catch {
+      return true
+    }
+  })
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(LOCAL_STORAGE_KEYS.DEV_BREAKPOINTS, String(isVisible))
+    } catch {
+      // ignore
+    }
+  }, [isVisible])
+
+  // Vite replaces import.meta.env.DEV with a boolean at build time.
+  if (!import.meta.env.DEV) return null
+
+  return (
+    <div className="breakpoint-overlay-container">
+      {isVisible ? (
+        <div className="breakpoint-pill" role="status" aria-live="polite">
+          <span className="breakpoint-indicator" />
+          <button
+            className="breakpoint-close-btn"
+            onClick={() => setIsVisible(false)}
+            aria-label="Hide breakpoints"
+            title="Hide breakpoints"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <line x1="18" y1="6" x2="6" y2="18"></line>
+              <line x1="6" y1="6" x2="18" y2="18"></line>
+            </svg>
+          </button>
+        </div>
+      ) : (
+        <button
+          className="breakpoint-toggle-btn"
+          onClick={() => setIsVisible(true)}
+          aria-label="Show breakpoints"
+          title="Show breakpoints"
+        >
+          BP
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,0 +1,3 @@
+export const LOCAL_STORAGE_KEYS = {
+  DEV_BREAKPOINTS: 'credence:dev:breakpoints',
+} as const


### PR DESCRIPTION
Summary
Overlays current breakpoint on the corner of the screen in development mode.

Background
This change improves the day-to-day experience for the people who consume this code (operators, downstream contracts, frontend engineers, support). It removes the need for workarounds by overlaying the active breakpoint strictly in dev mode.

Implementation Details
- Added BreakpointOverlay component
- Stored toggle state in localStorage
- Fully backwards-compatible API surface

Closes #600