### PR TITLE
feat: add StatusBadge and AnalyticsWidget components

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -13,6 +13,8 @@ Related focused docs: [button system](./button-system.md), [notifications](./not
 | Button                 | `src/components/Button.css`                                                         | None.                                                                                                                     |
 | LoadingSpinner         | `src/components/LoadingSpinner.css`                                                | None.                                                                                                                     |
 | Badge                  | `src/components/Badge.css`                                                          | None.                                                                                                                     |
+| StatusBadge            | `src/components/StatusBadge.css`                                                    | None.                                                                                                                     |
+| AnalyticsWidget        | `src/components/AnalyticsWidget.css`                                                | None.                                                                                                                     |
 | Banner                 | `src/components/Banner.css`                                                         | None.                                                                                                                     |
 | Toast / ToastProvider  | `src/components/Toast.css`                                                          | None.                                                                                                                     |
 | ConfirmDialog          | `src/components/ConfirmDialog.css`                                                  | None.                                                                                                                     |
@@ -47,6 +49,14 @@ Source: [`Badge.tsx`](../src/components/Badge.tsx)
 `'bronze' | 'silver' | 'gold' | 'platinum' | 'active' | 'locked' | 'slashed' | 'grace-period' | 'unknown'`
 
 Unknown runtime strings normalize to the `unknown` visual style while preserving the supplied string as a fallback label only when no known label exists.
+
+### `StatusBadgeVariant`
+
+Source: [`StatusBadge.tsx`](../src/components/StatusBadge.tsx)
+
+`'pending' | 'active' | 'completed' | 'failed'`
+
+Lifecycle status for bonds and operations. Each variant maps to a distinct semantic colour family via `--credence-*` design tokens.
 
 ### `BannerSeverity`
 
@@ -139,6 +149,126 @@ Tokens: tier/status color tokens, `--credence-font-size-xs`, `--credence-font-we
 <Badge variant="gold" />
 <Badge variant="grace-period" label="Grace" />
 <Badge variant="slashed" srPrefix="Bond status:" />
+```
+
+## StatusBadge
+
+Source: [`src/components/StatusBadge.tsx`](../src/components/StatusBadge.tsx). Storybook: `Components/StatusBadge`.
+
+Displays a bond or operation lifecycle status as a colour-coded pill. Each variant maps to a distinct semantic colour family sourced entirely from `--credence-*` design tokens — no hard-coded colour values.
+
+| Prop        | Type                  | Default              |
+| ----------- | --------------------- | -------------------- |
+| `variant`   | `StatusBadgeVariant`  | Required             |
+| `label`     | `string`              | Capitalised variant  |
+| `className` | `string`              | `''`                 |
+| `srPrefix`  | `string`              | —                    |
+| `ariaLabel` | `string`              | Display label        |
+
+### `StatusBadgeVariant`
+
+`'pending' | 'active' | 'completed' | 'failed'`
+
+| Variant     | Semantic intent | Token family                     |
+| ----------- | --------------- | -------------------------------- |
+| `pending`   | Neutral/waiting | `--credence-color-warning-*`     |
+| `active`    | In progress     | `--credence-color-success-*`     |
+| `completed` | Resolved        | `--credence-color-info-*`        |
+| `failed`    | Error/danger    | `--credence-color-danger-*`      |
+
+**`srPrefix`** renders an `.sr-only` `<span>` _before_ the visible label so assistive technology can announce the badge in context (e.g. `srPrefix="Bond status:"` causes a screen reader to read `"Bond status: Failed"` rather than just `"Failed"`). No extra DOM is inserted when the prop is omitted.
+
+Accessibility: renders text in a `<span>` with `aria-label` set to the display label (or the `ariaLabel` prop override). The visible label is always non-empty so meaning is never communicated by colour alone. Use `srPrefix` when a badge appears inside a list row or table cell where a screen reader needs additional context.
+
+Tokens: `--credence-color-warning-surface`, `--credence-color-warning-border`, `--credence-color-warning-text`, `--credence-color-success-surface`, `--credence-color-success-border`, `--credence-color-success-text`, `--credence-color-info-surface`, `--credence-color-info-border`, `--credence-color-info-text`, `--credence-color-danger-surface`, `--credence-color-danger-border`, `--credence-color-danger-text`, `--credence-font-size-xs`, `--credence-font-weight-semibold`, `--credence-radius-full`, `--credence-space-2`.
+
+```tsx
+<StatusBadge variant="pending" />
+<StatusBadge variant="active" />
+<StatusBadge variant="completed" label="Done" />
+<StatusBadge variant="failed" srPrefix="Bond status:" />
+```
+
+## AnalyticsWidget
+
+Source: [`src/components/AnalyticsWidget.tsx`](../src/components/AnalyticsWidget.tsx). Storybook: `Components/AnalyticsWidget`.
+
+Displays one or two periods of numeric metrics in a card layout. When `previousPeriod` is supplied a **Compare periods** toggle appears in the header; enabling it renders the previous period column alongside the current period so operators can do a quick side-by-side comparison without leaving the dashboard.
+
+The component supports both **uncontrolled** (default) and **controlled** modes:
+- **Uncontrolled**: omit `compareEnabled` / `onCompareChange`; the widget manages toggle state internally, optionally seeded by `defaultCompare`.
+- **Controlled**: supply both `compareEnabled` and `onCompareChange` to lift toggle state to the parent.
+
+### Props
+
+| Prop              | Type                        | Default     |
+| ----------------- | --------------------------- | ----------- |
+| `title`           | `string`                    | Required    |
+| `currentPeriod`   | `AnalyticsPeriodData`       | Required    |
+| `previousPeriod`  | `AnalyticsPeriodData`       | —           |
+| `defaultCompare`  | `boolean`                   | `false`     |
+| `compareEnabled`  | `boolean`                   | —           |
+| `onCompareChange` | `(next: boolean) => void`   | —           |
+| `className`       | `string`                    | `''`        |
+
+### `AnalyticsPeriodData`
+
+| Field     | Type                  | Notes                                        |
+| --------- | --------------------- | -------------------------------------------- |
+| `label`   | `string`              | Short period label shown in the column header (e.g. `"Jul 2026"`). |
+| `metrics` | `AnalyticsMetric[]`   | One or more metrics to display.              |
+
+### `AnalyticsMetric`
+
+| Field    | Type                        | Notes                                           |
+| -------- | --------------------------- | ----------------------------------------------- |
+| `label`  | `string`                    | Human-readable metric name (e.g. `"Trust Score"`). |
+| `value`  | `number`                    | Numeric value for the period.                   |
+| `format` | `(value: number) => string` | Optional formatter; defaults to `String(value)`. |
+| `unit`   | `string`                    | Optional suffix appended after the formatted value (e.g. `"USDC"`). |
+
+### Accessibility
+
+- Renders as a `<section>` with `aria-label` set to the `title` prop so it is a named landmark.
+- Title renders as an `<h2>`.
+- The compare toggle is a native `role="switch"` button with `aria-checked` and an `aria-label`. Its visible label (`"Compare periods"`) is linked via `<label htmlFor>`.
+- Each period column carries `aria-label="<period.label> metrics"`.
+- Metrics are structured as a `<dl>` (definition list) with `<dt>` for labels and `<dd>` for values, so assistive technology can navigate key/value pairs.
+
+### Tokens
+
+`--credence-border-default`, `--credence-color-primary`, `--credence-color-slate-50`, `--credence-font-family-base`, `--credence-font-size-lg`, `--credence-font-size-sm`, `--credence-font-size-xl`, `--credence-font-size-xs`, `--credence-font-weight-bold`, `--credence-font-weight-regular`, `--credence-font-weight-semibold`, `--credence-line-height-tight`, `--credence-motion-duration-base`, `--credence-motion-easing-standard`, `--credence-radius-lg`, `--credence-radius-xl`, `--credence-space-1`, `--credence-space-2`, `--credence-space-3`, `--credence-space-4`, `--credence-space-6`, `--credence-surface-card`, `--credence-text-primary`, `--credence-text-secondary`.
+
+```tsx
+// Uncontrolled — single period, no compare toggle
+<AnalyticsWidget
+  title="Analytics Overview"
+  currentPeriod={{
+    label: 'Jul 2026',
+    metrics: [
+      { label: 'Trust Score', value: 684 },
+      { label: 'Active Bonds', value: 3 },
+      { label: 'Total Bonded', value: 4250, format: (v) => v.toLocaleString(), unit: 'USDC' },
+    ],
+  }}
+/>
+
+// Uncontrolled — compare mode on by default
+<AnalyticsWidget
+  title="Analytics Overview"
+  currentPeriod={currentPeriod}
+  previousPeriod={previousPeriod}
+  defaultCompare
+/>
+
+// Controlled — parent owns toggle state
+<AnalyticsWidget
+  title="Analytics Overview"
+  currentPeriod={currentPeriod}
+  previousPeriod={previousPeriod}
+  compareEnabled={isComparing}
+  onCompareChange={setIsComparing}
+/>
 ```
 
 ## TooltipOnOverflow

--- a/src/components/ActivityTimeline.test.tsx
+++ b/src/components/ActivityTimeline.test.tsx
@@ -287,3 +287,5 @@ describe('ActivityTimeline', () => {
       expect(screen.queryByTestId('copyable-hash')).toBeNull()
     })
   })
+})
+})

--- a/src/components/AnalyticsWidget.css
+++ b/src/components/AnalyticsWidget.css
@@ -1,0 +1,140 @@
+/* AnalyticsWidget — compare-periods analytics card.
+   All colours, spacing, radii, and motion are sourced exclusively from
+   --credence-* design tokens; no hard-coded values. */
+
+/* ── Root ──────────────────────────────────────────────────────────────────── */
+
+.analytics-widget {
+  background: var(--credence-surface-card);
+  border: 1px solid var(--credence-border-default);
+  border-radius: var(--credence-radius-xl);
+  padding: var(--credence-space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--credence-space-4);
+}
+
+/* ── Header ────────────────────────────────────────────────────────────────── */
+
+.analytics-widget__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--credence-space-3);
+}
+
+.analytics-widget__title {
+  font-family: var(--credence-font-family-base);
+  font-size: var(--credence-font-size-lg);
+  font-weight: var(--credence-font-weight-semibold);
+  line-height: var(--credence-line-height-tight);
+  color: var(--credence-text-primary);
+  margin: 0;
+}
+
+/* ── Toggle row ────────────────────────────────────────────────────────────── */
+
+.analytics-widget__toggle-row {
+  display: flex;
+  align-items: center;
+  gap: var(--credence-space-2);
+}
+
+.analytics-widget__toggle-label {
+  font-family: var(--credence-font-family-base);
+  font-size: var(--credence-font-size-sm);
+  font-weight: var(--credence-font-weight-semibold);
+  color: var(--credence-text-secondary);
+  cursor: pointer;
+  user-select: none;
+}
+
+/* ── Body ──────────────────────────────────────────────────────────────────── */
+
+.analytics-widget__body {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--credence-space-4);
+  transition: grid-template-columns var(--credence-motion-duration-base) var(--credence-motion-easing-standard);
+}
+
+/* When comparison is active, render two equal-width columns side by side. */
+.analytics-widget__body--comparing {
+  grid-template-columns: 1fr 1fr;
+}
+
+@media (max-width: 480px) {
+  /* Stack columns vertically on very small viewports even in compare mode. */
+  .analytics-widget__body--comparing {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ── Period column ─────────────────────────────────────────────────────────── */
+
+.analytics-widget__period {
+  display: flex;
+  flex-direction: column;
+  gap: var(--credence-space-3);
+  padding: var(--credence-space-4);
+  border-radius: var(--credence-radius-lg);
+  border: 1px solid var(--credence-border-default);
+  background: var(--credence-surface-default, var(--credence-color-slate-50));
+}
+
+/* Current period gets a subtle primary accent border to distinguish it. */
+.analytics-widget__period--current {
+  border-color: var(--credence-color-primary);
+}
+
+/* Previous period uses the default neutral border. */
+.analytics-widget__period--previous {
+  border-color: var(--credence-border-default);
+}
+
+/* ── Period label ──────────────────────────────────────────────────────────── */
+
+.analytics-widget__period-label {
+  font-family: var(--credence-font-family-base);
+  font-size: var(--credence-font-size-xs);
+  font-weight: var(--credence-font-weight-semibold);
+  line-height: var(--credence-line-height-tight);
+  color: var(--credence-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+/* ── Metrics list ──────────────────────────────────────────────────────────── */
+
+.analytics-widget__metrics {
+  display: flex;
+  flex-direction: column;
+  gap: var(--credence-space-3);
+  margin: 0;
+  padding: 0;
+}
+
+.analytics-widget__metric {
+  display: flex;
+  flex-direction: column;
+  gap: var(--credence-space-1);
+}
+
+.analytics-widget__metric-label {
+  font-family: var(--credence-font-family-base);
+  font-size: var(--credence-font-size-xs);
+  font-weight: var(--credence-font-weight-regular);
+  line-height: var(--credence-line-height-tight);
+  color: var(--credence-text-secondary);
+}
+
+.analytics-widget__metric-value {
+  font-family: var(--credence-font-family-base);
+  font-size: var(--credence-font-size-xl);
+  font-weight: var(--credence-font-weight-bold);
+  line-height: var(--credence-line-height-tight);
+  color: var(--credence-text-primary);
+  margin: 0;
+}

--- a/src/components/AnalyticsWidget.stories.tsx
+++ b/src/components/AnalyticsWidget.stories.tsx
@@ -1,0 +1,197 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import AnalyticsWidget from './AnalyticsWidget'
+import type { AnalyticsPeriodData } from './AnalyticsWidget'
+
+// ── Fixture data ─────────────────────────────────────────────────────────────
+
+const currentPeriod: AnalyticsPeriodData = {
+  label: 'Jul 2026',
+  metrics: [
+    { label: 'Trust Score', value: 684 },
+    { label: 'Active Bonds', value: 3 },
+    {
+      label: 'Total Bonded',
+      value: 4250,
+      format: (v) => v.toLocaleString(),
+      unit: 'USDC',
+    },
+    { label: 'Attestations', value: 12 },
+  ],
+}
+
+const previousPeriod: AnalyticsPeriodData = {
+  label: 'Jun 2026',
+  metrics: [
+    { label: 'Trust Score', value: 612 },
+    { label: 'Active Bonds', value: 2 },
+    {
+      label: 'Total Bonded',
+      value: 3100,
+      format: (v) => v.toLocaleString(),
+      unit: 'USDC',
+    },
+    { label: 'Attestations', value: 8 },
+  ],
+}
+
+// ── Meta ─────────────────────────────────────────────────────────────────────
+
+const meta: Meta<typeof AnalyticsWidget> = {
+  title: 'Components/AnalyticsWidget',
+  component: AnalyticsWidget,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'padded',
+  },
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Heading text displayed at the top of the widget.',
+    },
+    defaultCompare: {
+      control: 'boolean',
+      description: 'Whether the compare-periods view is on by default (uncontrolled mode).',
+    },
+    compareEnabled: {
+      control: 'boolean',
+      description: 'Controlled toggle state (supply alongside onCompareChange).',
+    },
+    className: {
+      control: 'text',
+      description: 'Additional CSS class names appended to the widget root.',
+    },
+  },
+  args: {
+    title: 'Analytics Overview',
+    currentPeriod,
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof AnalyticsWidget>
+
+// ── Stories ──────────────────────────────────────────────────────────────────
+
+/** Default: current period only, no compare toggle. */
+export const Default: Story = {
+  args: {
+    currentPeriod,
+  },
+}
+
+/** With a previous period available but compare toggled off (default). */
+export const WithPreviousPeriodOff: Story = {
+  args: {
+    currentPeriod,
+    previousPeriod,
+    defaultCompare: false,
+  },
+}
+
+/** With compare toggled on by default so both periods are visible immediately. */
+export const ComparePeriods: Story = {
+  args: {
+    currentPeriod,
+    previousPeriod,
+    defaultCompare: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Both the current and previous period columns are rendered side by side when `defaultCompare` is `true`.',
+      },
+    },
+  },
+}
+
+/** Controlled: toggle state is owned by the parent story. */
+export const Controlled: Story = {
+  args: {
+    currentPeriod,
+    previousPeriod,
+    compareEnabled: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Provide `compareEnabled` and `onCompareChange` to lift state outside the component. ' +
+          'The story keeps `compareEnabled` static so you can see the compare layout immediately.',
+      },
+    },
+  },
+}
+
+/** Single metric per period (minimal usage). */
+export const SingleMetric: Story = {
+  args: {
+    title: 'Trust Score',
+    currentPeriod: {
+      label: 'Jul 2026',
+      metrics: [{ label: 'Score', value: 684 }],
+    },
+    previousPeriod: {
+      label: 'Jun 2026',
+      metrics: [{ label: 'Score', value: 612 }],
+    },
+    defaultCompare: true,
+  },
+}
+
+/** With a custom format function and unit suffix. */
+export const FormattedValues: Story = {
+  args: {
+    title: 'USDC Activity',
+    currentPeriod: {
+      label: 'Jul 2026',
+      metrics: [
+        {
+          label: 'Volume',
+          value: 128750.5,
+          format: (v) =>
+            v.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+          unit: 'USDC',
+        },
+        {
+          label: 'Transactions',
+          value: 47,
+        },
+      ],
+    },
+    previousPeriod: {
+      label: 'Jun 2026',
+      metrics: [
+        {
+          label: 'Volume',
+          value: 95200.0,
+          format: (v) =>
+            v.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 }),
+          unit: 'USDC',
+        },
+        {
+          label: 'Transactions',
+          value: 31,
+        },
+      ],
+    },
+    defaultCompare: true,
+  },
+}
+
+/** No previousPeriod — the toggle is hidden entirely. */
+export const NoPreviousPeriod: Story = {
+  args: {
+    title: 'This Month',
+    currentPeriod,
+    previousPeriod: undefined,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When `previousPeriod` is not supplied, the compare toggle is not rendered.',
+      },
+    },
+  },
+}

--- a/src/components/AnalyticsWidget.test.tsx
+++ b/src/components/AnalyticsWidget.test.tsx
@@ -1,0 +1,506 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import AnalyticsWidget from './AnalyticsWidget'
+import type { AnalyticsPeriodData } from './AnalyticsWidget'
+
+// CSS modules are not processed in the test environment.
+vi.mock('./AnalyticsWidget.css', () => ({}))
+vi.mock('./controls/Toggle.css', () => ({}))
+vi.mock('./controls/controls.css', () => ({}))
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const currentPeriod: AnalyticsPeriodData = {
+  label: 'Jul 2026',
+  metrics: [
+    { label: 'Trust Score', value: 684 },
+    { label: 'Active Bonds', value: 3 },
+    {
+      label: 'Total Bonded',
+      value: 4250,
+      format: (v) => v.toLocaleString(),
+      unit: 'USDC',
+    },
+  ],
+}
+
+const previousPeriod: AnalyticsPeriodData = {
+  label: 'Jun 2026',
+  metrics: [
+    { label: 'Trust Score', value: 612 },
+    { label: 'Active Bonds', value: 2 },
+    {
+      label: 'Total Bonded',
+      value: 3100,
+      format: (v) => v.toLocaleString(),
+      unit: 'USDC',
+    },
+  ],
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('AnalyticsWidget', () => {
+  // ── Rendering ──────────────────────────────────────────────────────────────
+
+  describe('rendering', () => {
+    it('renders the widget title', () => {
+      render(<AnalyticsWidget title="Analytics Overview" currentPeriod={currentPeriod} />)
+      expect(screen.getByRole('heading', { name: 'Analytics Overview' })).toBeInTheDocument()
+    })
+
+    it('renders the current period label', () => {
+      render(<AnalyticsWidget title="Test" currentPeriod={currentPeriod} />)
+      expect(screen.getByText('Jul 2026')).toBeInTheDocument()
+    })
+
+    it('renders metric labels and values for the current period', () => {
+      render(<AnalyticsWidget title="Test" currentPeriod={currentPeriod} />)
+      expect(screen.getByText('Trust Score')).toBeInTheDocument()
+      expect(screen.getByText('684')).toBeInTheDocument()
+      expect(screen.getByText('Active Bonds')).toBeInTheDocument()
+      expect(screen.getByText('3')).toBeInTheDocument()
+    })
+
+    it('formats metric values using the format function', () => {
+      render(<AnalyticsWidget title="Test" currentPeriod={currentPeriod} />)
+      // 4250 with .toLocaleString() + unit 'USDC'
+      expect(screen.getByText(/4,250 USDC/)).toBeInTheDocument()
+    })
+
+    it('renders the unit suffix after the formatted value', () => {
+      render(<AnalyticsWidget title="Test" currentPeriod={currentPeriod} />)
+      expect(screen.getByText(/USDC/)).toBeInTheDocument()
+    })
+
+    it('uses String(value) as fallback when no format function is given', () => {
+      render(<AnalyticsWidget title="Test" currentPeriod={currentPeriod} />)
+      // Active Bonds — value 3 with no format
+      expect(screen.getByText('3')).toBeInTheDocument()
+    })
+
+    it('renders as a <section> landmark with an accessible name', () => {
+      render(<AnalyticsWidget title="Analytics Overview" currentPeriod={currentPeriod} />)
+      expect(screen.getByRole('region', { name: 'Analytics Overview' })).toBeInTheDocument()
+    })
+  })
+
+  // ── Compare toggle absent when no previousPeriod ───────────────────────────
+
+  describe('no previousPeriod', () => {
+    it('does not render the compare toggle when previousPeriod is omitted', () => {
+      render(<AnalyticsWidget title="Test" currentPeriod={currentPeriod} />)
+      expect(screen.queryByRole('switch')).toBeNull()
+      expect(screen.queryByText('Compare periods')).toBeNull()
+    })
+
+    it('does not render the previous period label', () => {
+      render(<AnalyticsWidget title="Test" currentPeriod={currentPeriod} />)
+      expect(screen.queryByText('Jun 2026')).toBeNull()
+    })
+  })
+
+  // ── Compare toggle present when previousPeriod is provided ─────────────────
+
+  describe('with previousPeriod', () => {
+    it('renders the compare toggle when previousPeriod is provided', () => {
+      render(
+        <AnalyticsWidget
+          title="Test"
+          currentPeriod={currentPeriod}
+          previousPeriod={previousPeriod}
+        />,
+      )
+      expect(screen.getByRole('switch', { name: /compare/i })).toBeInTheDocument()
+    })
+
+    it('renders a visible "Compare periods" label next to the toggle', () => {
+      render(
+        <AnalyticsWidget
+          title="Test"
+          currentPeriod={currentPeriod}
+          previousPeriod={previousPeriod}
+        />,
+      )
+      expect(screen.getByText('Compare periods')).toBeInTheDocument()
+    })
+
+    it('toggle is off by default (uncontrolled)', () => {
+      render(
+        <AnalyticsWidget
+          title="Test"
+          currentPeriod={currentPeriod}
+          previousPeriod={previousPeriod}
+        />,
+      )
+      expect(screen.getByRole('switch')).not.toBeChecked()
+    })
+
+    it('previous period column is hidden when toggle is off', () => {
+      render(
+        <AnalyticsWidget
+          title="Test"
+          currentPeriod={currentPeriod}
+          previousPeriod={previousPeriod}
+        />,
+      )
+      expect(screen.queryByText('Jun 2026')).toBeNull()
+    })
+
+    it('current period column is always visible', () => {
+      render(
+        <AnalyticsWidget
+          title="Test"
+          currentPeriod={currentPeriod}
+          previousPeriod={previousPeriod}
+        />,
+      )
+      expect(screen.getByText('Jul 2026')).toBeInTheDocument()
+    })
+  })
+
+  // ── Uncontrolled toggle behaviour ──────────────────────────────────────────
+
+  describe('uncontrolled toggle', () => {
+    it('shows previous period column after toggling on', async () => {
+      const user = userEvent.setup()
+      render(
+        <AnalyticsWidget
+          title="Test"
+          currentPeriod={currentPeriod}
+          previousPeriod={previousPeriod}
+        />,
+      )
+
+      await user.click(screen.getByRole('switch'))
+
+      expect(screen.getByText('Jun 2026')).toBeInTheDocument()
+      expect(screen.getByText('Jul 2026')).toBeInTheDocument()
+    })
+
+    it('hides previous period column after toggling back off', async () => {
+      const user = userEvent.setup()
+      render(
+        <AnalyticsWidget
+          title="Test"
+          currentPeriod={currentPeriod}
+          previousPeriod={previousPeriod}
+          defaultCompare
+        />,
+      )
+
+      // Start with comparison on — previous period should be visible
+      expect(screen.getByText('Jun 2026')).toBeInTheDocument()
+
+      await user.click(screen.getByRole('switch'))
+
+      expect(screen.queryByText('Jun 2026')).toBeNull()
+    })
+
+    it('respects defaultCompare=true by showing both columns immediately', () => {
+      render(
+        <AnalyticsWidget
+          title="Test"
+          currentPeriod={currentPeriod}
+          previousPeriod={previousPeriod}
+          defaultCompare
+        />,
+      )
+      expect(screen.getByText('Jun 2026')).toBeInTheDocument()
+      expect(screen.getByText('Jul 2026')).toBeInTheDocument()
+    })
+
+    it('toggle is checked when defaultCompare=true', () => {
+      render(
+        <AnalyticsWidget
+          title="Test"
+          currentPeriod={currentPeriod}
+          previousPeriod={previousPeriod}
+          defaultCompare
+        />,
+      )
+      expect(screen.getByRole('switch')).toBeChecked()
+    })
+
+    it('both period metric values are visible when comparing', async () => {
+      const user = userEvent.setup()
+      render(
+        <AnalyticsWidget
+          title="Test"
+          currentPeriod={currentPeriod}
+          previousPeriod={previousPeriod}
+        />,
+      )
+
+      await user.click(screen.getByRole('switch'))
+
+      // Current period values
+      expect(screen.getByText('684')).toBeInTheDocument()
+      // Previous period values
+      expect(screen.getByText('612')).toBeInTheDocument()
+    })
+
+    it('calls onCompareChange with true when toggling on', async () => {
+      const user = userEvent.setup()
+      const handleChange = vi.fn()
+      render(
+        <AnalyticsWidget
+          title="Test"
+          currentPeriod={currentPeriod}
+          previousPeriod={previousPeriod}
+          onCompareChange={handleChange}
+        />,
+      )
+
+      await user.click(screen.getByRole('switch'))
+
+      expect(handleChange).toHaveBeenCalledOnce()
+      expect(handleChange).toHaveBeenCalledWith(true)
+    })
+
+    it('calls onCompareChange with false when toggling off', async () => {
+      const user = userEvent.setup()
+      const handleChange = vi.fn()
+      render(
+        <AnalyticsWidget
+          title="Test"
+          currentPeriod={currentPeriod}
+          previousPeriod={previousPeriod}
+          defaultCompare
+          onCompareChange={handleChange}
+        />,
+      )
+
+      await user.click(screen.getByRole('switch'))
+
+      expect(handleChange).toHaveBeenCalledOnce()
+      expect(handleChange).toHaveBeenCalledWith(false)
+    })
+  })
+
+  // ── Controlled toggle behaviour ────────────────────────────────────────────
+
+  describe('controlled toggle', () => {
+    it('shows previous period when compareEnabled=true', () => {
+      render(
+        <AnalyticsWidget
+          title="Test"
+          currentPeriod={currentPeriod}
+          previousPeriod={previousPeriod}
+          compareEnabled
+          onCompareChange={vi.fn()}
+        />,
+      )
+      expect(screen.getByText('Jun 2026')).toBeInTheDocument()
+    })
+
+    it('hides previous period when compareEnabled=false', () => {
+      render(
+        <AnalyticsWidget
+          title="Test"
+          currentPeriod={currentPeriod}
+          previousPeriod={previousPeriod}
+          compareEnabled={false}
+          onCompareChange={vi.fn()}
+        />,
+      )
+      expect(screen.queryByText('Jun 2026')).toBeNull()
+    })
+
+    it('toggle reflects the compareEnabled prop value', () => {
+      render(
+        <AnalyticsWidget
+          title="Test"
+          currentPeriod={currentPeriod}
+          previousPeriod={previousPeriod}
+          compareEnabled
+          onCompareChange={vi.fn()}
+        />,
+      )
+      expect(screen.getByRole('switch')).toBeChecked()
+    })
+
+    it('fires onCompareChange with the next value when toggled', async () => {
+      const user = userEvent.setup()
+      const handleChange = vi.fn()
+      render(
+        <AnalyticsWidget
+          title="Test"
+          currentPeriod={currentPeriod}
+          previousPeriod={previousPeriod}
+          compareEnabled
+          onCompareChange={handleChange}
+        />,
+      )
+
+      await user.click(screen.getByRole('switch'))
+
+      expect(handleChange).toHaveBeenCalledOnce()
+      expect(handleChange).toHaveBeenCalledWith(false)
+    })
+
+    it('does not change internal state when toggle is clicked in controlled mode', async () => {
+      const user = userEvent.setup()
+      // onCompareChange is a no-op — the parent decides not to update the prop.
+      render(
+        <AnalyticsWidget
+          title="Test"
+          currentPeriod={currentPeriod}
+          previousPeriod={previousPeriod}
+          compareEnabled={false}
+          onCompareChange={vi.fn()}
+        />,
+      )
+
+      await user.click(screen.getByRole('switch'))
+
+      // Previous period should remain hidden because compareEnabled is still false.
+      expect(screen.queryByText('Jun 2026')).toBeNull()
+    })
+  })
+
+  // ── className prop ─────────────────────────────────────────────────────────
+
+  describe('className prop', () => {
+    it('appends extra class names to the root element', () => {
+      render(
+        <AnalyticsWidget
+          title="Test"
+          currentPeriod={currentPeriod}
+          className="my-custom-class"
+        />,
+      )
+      expect(document.querySelector('.analytics-widget')).toHaveClass('my-custom-class')
+    })
+
+    it('does not add trailing whitespace to className when empty', () => {
+      render(<AnalyticsWidget title="Test" currentPeriod={currentPeriod} />)
+      const root = document.querySelector('.analytics-widget')
+      expect(root?.className).not.toMatch(/^\s|\s$/)
+    })
+  })
+
+  // ── Accessibility ──────────────────────────────────────────────────────────
+
+  describe('accessibility', () => {
+    it('toggle has a descriptive accessible name', () => {
+      render(
+        <AnalyticsWidget
+          title="Test"
+          currentPeriod={currentPeriod}
+          previousPeriod={previousPeriod}
+        />,
+      )
+      const toggle = screen.getByRole('switch')
+      expect(toggle).toHaveAttribute('aria-label')
+      expect(toggle.getAttribute('aria-label')?.length).toBeGreaterThan(0)
+    })
+
+    it('toggle label is associated with the toggle via htmlFor/id', () => {
+      render(
+        <AnalyticsWidget
+          title="Test"
+          currentPeriod={currentPeriod}
+          previousPeriod={previousPeriod}
+        />,
+      )
+      const label = screen.getByText('Compare periods').closest('label')
+      const toggle = screen.getByRole('switch')
+      expect(label).not.toBeNull()
+      expect(label?.htmlFor).toBe(toggle.id)
+    })
+
+    it('period columns have aria-label for assistive technology', async () => {
+      const user = userEvent.setup()
+      render(
+        <AnalyticsWidget
+          title="Test"
+          currentPeriod={currentPeriod}
+          previousPeriod={previousPeriod}
+        />,
+      )
+
+      await user.click(screen.getByRole('switch'))
+
+      const currentCol = screen.getByLabelText('Jul 2026 metrics')
+      const previousCol = screen.getByLabelText('Jun 2026 metrics')
+      expect(currentCol).toBeInTheDocument()
+      expect(previousCol).toBeInTheDocument()
+    })
+
+    it('metrics use a <dl> definition list', () => {
+      render(<AnalyticsWidget title="Test" currentPeriod={currentPeriod} />)
+      expect(document.querySelector('dl.analytics-widget__metrics')).not.toBeNull()
+    })
+
+    it('metric labels render as <dt> elements', () => {
+      render(<AnalyticsWidget title="Test" currentPeriod={currentPeriod} />)
+      const terms = document.querySelectorAll('dt.analytics-widget__metric-label')
+      expect(terms.length).toBeGreaterThan(0)
+    })
+
+    it('metric values render as <dd> elements', () => {
+      render(<AnalyticsWidget title="Test" currentPeriod={currentPeriod} />)
+      const defs = document.querySelectorAll('dd.analytics-widget__metric-value')
+      expect(defs.length).toBeGreaterThan(0)
+    })
+
+    it('title is an <h2> element', () => {
+      render(<AnalyticsWidget title="Analytics Overview" currentPeriod={currentPeriod} />)
+      const heading = screen.getByRole('heading', { name: 'Analytics Overview', level: 2 })
+      expect(heading).toBeInTheDocument()
+    })
+  })
+
+  // ── Edge cases ─────────────────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('renders multiple metrics correctly', () => {
+      render(<AnalyticsWidget title="Test" currentPeriod={currentPeriod} />)
+      expect(screen.getByText('Trust Score')).toBeInTheDocument()
+      expect(screen.getByText('Active Bonds')).toBeInTheDocument()
+      expect(screen.getByText('Total Bonded')).toBeInTheDocument()
+    })
+
+    it('renders with a single metric', () => {
+      render(
+        <AnalyticsWidget
+          title="Single"
+          currentPeriod={{ label: 'Jul', metrics: [{ label: 'Score', value: 100 }] }}
+        />,
+      )
+      expect(screen.getByText('Score')).toBeInTheDocument()
+      expect(screen.getByText('100')).toBeInTheDocument()
+    })
+
+    it('renders zero value metrics', () => {
+      render(
+        <AnalyticsWidget
+          title="Zero"
+          currentPeriod={{ label: 'Jul', metrics: [{ label: 'Bonds', value: 0 }] }}
+        />,
+      )
+      expect(screen.getByText('0')).toBeInTheDocument()
+    })
+
+    it('renders large numbers', () => {
+      render(
+        <AnalyticsWidget
+          title="Big"
+          currentPeriod={{
+            label: 'Jul',
+            metrics: [
+              {
+                label: 'Volume',
+                value: 1000000,
+                format: (v) => v.toLocaleString(),
+              },
+            ],
+          }}
+        />,
+      )
+      expect(screen.getByText('1,000,000')).toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/AnalyticsWidget.tsx
+++ b/src/components/AnalyticsWidget.tsx
@@ -1,0 +1,168 @@
+import { useState } from 'react'
+import Toggle from './controls/Toggle'
+import './AnalyticsWidget.css'
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/** A single numeric metric shown in the analytics widget. */
+export interface AnalyticsMetric {
+  /** Human-readable label for the metric (e.g. "Trust Score"). */
+  label: string
+  /** Numeric value for the period. */
+  value: number
+  /**
+   * Optional formatter applied to `value` before display.
+   * Defaults to `String(value)` when omitted.
+   */
+  format?: (value: number) => string
+  /** Optional unit suffix appended after the formatted value (e.g. "USDC"). */
+  unit?: string
+}
+
+/** Data bundle describing one time period. */
+export interface AnalyticsPeriodData {
+  /** Short period label shown in the header (e.g. "Jul 2026"). */
+  label: string
+  /** Metrics to display for this period. */
+  metrics: AnalyticsMetric[]
+}
+
+export interface AnalyticsWidgetProps {
+  /** Widget heading displayed at the top of the card. */
+  title: string
+  /** Data for the most-recent / "current" period. */
+  currentPeriod: AnalyticsPeriodData
+  /**
+   * Data for the preceding / "previous" period.
+   * When supplied the compare-periods toggle is rendered.
+   * When omitted the toggle is hidden and only the current period is shown.
+   */
+  previousPeriod?: AnalyticsPeriodData
+  /**
+   * Whether the compare-periods view is on by default.
+   * Only relevant when `previousPeriod` is provided.
+   * @default false
+   */
+  defaultCompare?: boolean
+  /**
+   * Controlled value for the compare-periods toggle.
+   * Supply alongside `onCompareChange` to lift state up.
+   */
+  compareEnabled?: boolean
+  /**
+   * Callback fired when the compare toggle is flipped.
+   * If supplied, the component becomes controlled (the caller owns toggle state).
+   */
+  onCompareChange?: (next: boolean) => void
+  /** Additional CSS class names appended to the widget root. */
+  className?: string
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatMetricValue(metric: AnalyticsMetric): string {
+  const formatted = metric.format ? metric.format(metric.value) : String(metric.value)
+  return metric.unit ? `${formatted} ${metric.unit}` : formatted
+}
+
+// ── Sub-components ───────────────────────────────────────────────────────────
+
+interface PeriodColumnProps {
+  period: AnalyticsPeriodData
+  /** When true the column is highlighted as the primary / focal period. */
+  isCurrent?: boolean
+}
+
+function PeriodColumn({ period, isCurrent = false }: PeriodColumnProps) {
+  return (
+    <div
+      className={`analytics-widget__period ${isCurrent ? 'analytics-widget__period--current' : 'analytics-widget__period--previous'}`}
+      aria-label={`${period.label} metrics`}
+    >
+      <p className="analytics-widget__period-label">{period.label}</p>
+      <dl className="analytics-widget__metrics">
+        {period.metrics.map((metric) => (
+          <div className="analytics-widget__metric" key={metric.label}>
+            <dt className="analytics-widget__metric-label">{metric.label}</dt>
+            <dd className="analytics-widget__metric-value">{formatMetricValue(metric)}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  )
+}
+
+// ── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * AnalyticsWidget
+ *
+ * Displays one or two periods of numeric metrics.  When `previousPeriod` is
+ * supplied a "Compare periods" toggle appears; flipping it slides the previous
+ * period column into view alongside the current period so operators can do a
+ * quick side-by-side comparison without leaving the dashboard.
+ *
+ * The component can be used in both uncontrolled (default) and controlled modes:
+ * - **Uncontrolled**: omit `compareEnabled` / `onCompareChange`; the widget
+ *   manages toggle state internally using `defaultCompare`.
+ * - **Controlled**: supply both `compareEnabled` and `onCompareChange` to lift
+ *   toggle state to the parent.
+ */
+export default function AnalyticsWidget({
+  title,
+  currentPeriod,
+  previousPeriod,
+  defaultCompare = false,
+  compareEnabled,
+  onCompareChange,
+  className = '',
+}: AnalyticsWidgetProps) {
+  // Internal state used only in uncontrolled mode.
+  const [internalCompare, setInternalCompare] = useState(defaultCompare)
+
+  const isControlled = compareEnabled !== undefined
+  const isComparing = isControlled ? compareEnabled : internalCompare
+
+  const handleToggle = (next: boolean) => {
+    if (!isControlled) {
+      setInternalCompare(next)
+    }
+    onCompareChange?.(next)
+  }
+
+  const toggleId = 'analytics-widget-compare-toggle'
+
+  return (
+    <section
+      className={`analytics-widget ${className}`.trim()}
+      aria-label={title}
+    >
+      <header className="analytics-widget__header">
+        <h2 className="analytics-widget__title">{title}</h2>
+
+        {previousPeriod && (
+          <div className="analytics-widget__toggle-row">
+            <label htmlFor={toggleId} className="analytics-widget__toggle-label">
+              Compare periods
+            </label>
+            <Toggle
+              id={toggleId}
+              checked={isComparing}
+              onChange={handleToggle}
+              ariaLabel="Compare current and previous periods"
+            />
+          </div>
+        )}
+      </header>
+
+      <div
+        className={`analytics-widget__body ${isComparing && previousPeriod ? 'analytics-widget__body--comparing' : ''}`}
+      >
+        {isComparing && previousPeriod && (
+          <PeriodColumn period={previousPeriod} isCurrent={false} />
+        )}
+        <PeriodColumn period={currentPeriod} isCurrent />
+      </div>
+    </section>
+  )
+}

--- a/src/components/StatusBadge.css
+++ b/src/components/StatusBadge.css
@@ -1,0 +1,46 @@
+/* StatusBadge — lifecycle status indicator (pending / active / completed / failed).
+   All colours are sourced from --credence-* design tokens; no hard-coded values. */
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.125rem var(--credence-space-2);
+  border-radius: var(--credence-radius-full);
+  font-size: var(--credence-font-size-xs);
+  font-weight: var(--credence-font-weight-semibold);
+  line-height: 1;
+  border: 1px solid transparent;
+  white-space: nowrap;
+
+  background: var(--status-badge-bg);
+  color: var(--status-badge-color);
+  border-color: var(--status-badge-border);
+}
+
+/* pending — neutral / informational */
+.status-badge--pending {
+  --status-badge-bg: var(--credence-color-warning-surface);
+  --status-badge-color: var(--credence-color-warning-text);
+  --status-badge-border: var(--credence-color-warning-border);
+}
+
+/* active — success / in-progress */
+.status-badge--active {
+  --status-badge-bg: var(--credence-color-success-surface);
+  --status-badge-color: var(--credence-color-success-text);
+  --status-badge-border: var(--credence-color-success-border);
+}
+
+/* completed — info / resolved */
+.status-badge--completed {
+  --status-badge-bg: var(--credence-color-info-surface);
+  --status-badge-color: var(--credence-color-info-text);
+  --status-badge-border: var(--credence-color-info-border);
+}
+
+/* failed — danger */
+.status-badge--failed {
+  --status-badge-bg: var(--credence-color-danger-surface);
+  --status-badge-color: var(--credence-color-danger-text);
+  --status-badge-border: var(--credence-color-danger-border);
+}

--- a/src/components/StatusBadge.stories.tsx
+++ b/src/components/StatusBadge.stories.tsx
@@ -1,0 +1,103 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import StatusBadge from './StatusBadge'
+
+const meta: Meta<typeof StatusBadge> = {
+  title: 'Components/StatusBadge',
+  component: StatusBadge,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['pending', 'active', 'completed', 'failed'],
+      description: 'Lifecycle status variant.',
+    },
+    label: {
+      control: 'text',
+      description: 'Optional display label override. Defaults to the capitalised variant name.',
+    },
+    srPrefix: {
+      control: 'text',
+      description:
+        'Screen-reader-only prefix rendered before the visible label (e.g. "Bond status:").',
+    },
+    ariaLabel: {
+      control: 'text',
+      description:
+        'Accessible label for the badge element. Defaults to the display label.',
+    },
+    className: {
+      control: 'text',
+      description: 'Additional CSS class names appended to the badge root.',
+    },
+  },
+  args: {
+    variant: 'pending',
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof StatusBadge>
+
+export const Default: Story = {
+  args: {
+    variant: 'pending',
+  },
+}
+
+export const Pending: Story = {
+  args: {
+    variant: 'pending',
+  },
+}
+
+export const Active: Story = {
+  args: {
+    variant: 'active',
+  },
+}
+
+export const Completed: Story = {
+  args: {
+    variant: 'completed',
+  },
+}
+
+export const Failed: Story = {
+  args: {
+    variant: 'failed',
+  },
+}
+
+export const CustomLabel: Story = {
+  args: {
+    variant: 'pending',
+    label: 'Awaiting review',
+  },
+}
+
+export const WithSrPrefix: Story = {
+  args: {
+    variant: 'failed',
+    srPrefix: 'Bond status:',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The `srPrefix` prop injects an `.sr-only` span before the visible label so screen readers announce "Bond status: Failed" rather than just "Failed".',
+      },
+    },
+  },
+}
+
+/** All four variants side-by-side for quick visual comparison. */
+export const AllVariants: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap', alignItems: 'center' }}>
+      <StatusBadge variant="pending" />
+      <StatusBadge variant="active" />
+      <StatusBadge variant="completed" />
+      <StatusBadge variant="failed" />
+    </div>
+  ),
+}

--- a/src/components/StatusBadge.test.tsx
+++ b/src/components/StatusBadge.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import StatusBadge from './StatusBadge'
+import type { StatusBadgeVariant } from './StatusBadge'
+
+vi.mock('./StatusBadge.css', () => ({}))
+
+const ALL_VARIANTS: [StatusBadgeVariant, string][] = [
+  ['pending', 'Pending'],
+  ['active', 'Active'],
+  ['completed', 'Completed'],
+  ['failed', 'Failed'],
+]
+
+describe('StatusBadge', () => {
+  describe('default labels', () => {
+    it.each(ALL_VARIANTS)('variant "%s" renders label "%s"', (variant, expectedLabel) => {
+      render(<StatusBadge variant={variant} />)
+      expect(screen.getByText(expectedLabel)).toBeInTheDocument()
+    })
+  })
+
+  describe('variant class names', () => {
+    it.each(ALL_VARIANTS)('variant "%s" has .status-badge--%s class', (variant) => {
+      render(<StatusBadge variant={variant} />)
+      const el = document.querySelector(`.status-badge--${variant}`)
+      expect(el).not.toBeNull()
+    })
+
+    it.each(ALL_VARIANTS)('root element always carries .status-badge base class', (variant) => {
+      render(<StatusBadge variant={variant} />)
+      expect(document.querySelector('.status-badge')).not.toBeNull()
+    })
+  })
+
+  describe('label override', () => {
+    it('renders the custom label instead of the default', () => {
+      render(<StatusBadge variant="pending" label="Awaiting review" />)
+      expect(screen.getByText('Awaiting review')).toBeInTheDocument()
+      expect(screen.queryByText('Pending')).toBeNull()
+    })
+
+    it('custom label applies to completed variant', () => {
+      render(<StatusBadge variant="completed" label="Done" />)
+      expect(screen.getByText('Done')).toBeInTheDocument()
+      expect(screen.queryByText('Completed')).toBeNull()
+    })
+
+    it.each(ALL_VARIANTS)('custom label on variant "%s" is rendered', (variant) => {
+      render(<StatusBadge variant={variant} label="Custom" />)
+      expect(screen.getByText('Custom')).toBeInTheDocument()
+    })
+  })
+
+  describe('className prop', () => {
+    it('appends extra class names to the badge root', () => {
+      render(<StatusBadge variant="active" className="my-extra-class" />)
+      const badge = document.querySelector('.status-badge')
+      expect(badge).toHaveClass('my-extra-class')
+    })
+
+    it('does not produce a trailing space in className when no className is given', () => {
+      render(<StatusBadge variant="active" />)
+      const badge = document.querySelector('.status-badge')
+      expect(badge?.className).not.toMatch(/^\s|\s$/)
+    })
+
+    it('both base and variant class are present alongside custom className', () => {
+      render(<StatusBadge variant="failed" className="extra" />)
+      const badge = document.querySelector('.status-badge')
+      expect(badge).toHaveClass('status-badge', 'status-badge--failed', 'extra')
+    })
+  })
+
+  describe('srPrefix — screen-reader-only context prefix', () => {
+    it('is absent from the DOM when srPrefix is not supplied', () => {
+      render(<StatusBadge variant="pending" />)
+      expect(document.querySelector('.sr-only')).toBeNull()
+    })
+
+    it('renders a .sr-only span when srPrefix is provided', () => {
+      render(<StatusBadge variant="failed" srPrefix="Bond status:" />)
+      const srSpan = document.querySelector('.sr-only')
+      expect(srSpan).not.toBeNull()
+      expect(srSpan).toHaveTextContent('Bond status:')
+    })
+
+    it('full text content includes both prefix and visible label', () => {
+      render(<StatusBadge variant="completed" srPrefix="Transaction status:" />)
+      const badge = document.querySelector('.status-badge')
+      expect(badge?.textContent).toContain('Transaction status:')
+      expect(badge?.textContent).toContain('Completed')
+    })
+
+    it('srPrefix still applies when a custom label is used', () => {
+      render(<StatusBadge variant="active" label="Running" srPrefix="Status:" />)
+      expect(document.querySelector('.sr-only')).toHaveTextContent('Status:')
+      expect(screen.getByText('Running')).toBeInTheDocument()
+    })
+
+    it.each(ALL_VARIANTS)('srPrefix renders on variant "%s"', (variant) => {
+      render(<StatusBadge variant={variant} srPrefix="Step:" />)
+      expect(document.querySelector('.sr-only')).toHaveTextContent('Step:')
+    })
+  })
+
+  describe('aria-label', () => {
+    it.each(ALL_VARIANTS)('variant "%s" defaults aria-label to its display label "%s"', (variant, expectedLabel) => {
+      render(<StatusBadge variant={variant} />)
+      const badge = document.querySelector('.status-badge')
+      expect(badge).toHaveAttribute('aria-label', expectedLabel)
+    })
+
+    it('custom ariaLabel overrides the default', () => {
+      render(<StatusBadge variant="pending" ariaLabel="Bond status: Pending review" />)
+      const badge = document.querySelector('.status-badge')
+      expect(badge).toHaveAttribute('aria-label', 'Bond status: Pending review')
+    })
+
+    it('ariaLabel applies alongside a custom label', () => {
+      render(<StatusBadge variant="completed" label="Done" ariaLabel="Transaction completed" />)
+      const badge = document.querySelector('.status-badge')
+      expect(badge).toHaveAttribute('aria-label', 'Transaction completed')
+    })
+
+    it('aria-label reflects custom label when ariaLabel is not provided', () => {
+      render(<StatusBadge variant="failed" label="Error" />)
+      const badge = document.querySelector('.status-badge')
+      expect(badge).toHaveAttribute('aria-label', 'Error')
+    })
+
+    it('aria-label is present on every variant', () => {
+      for (const [variant] of ALL_VARIANTS) {
+        const { unmount } = render(<StatusBadge variant={variant} />)
+        const badge = document.querySelector('.status-badge')
+        expect(badge?.getAttribute('aria-label')).toBeTruthy()
+        unmount()
+      }
+    })
+
+    it('aria-label is present when srPrefix is also provided', () => {
+      render(<StatusBadge variant="active" srPrefix="Status:" ariaLabel="Active bond" />)
+      const badge = document.querySelector('.status-badge')
+      expect(badge).toHaveAttribute('aria-label', 'Active bond')
+    })
+  })
+
+  describe('color-only regression — visible label is always non-empty', () => {
+    it.each(ALL_VARIANTS)('variant "%s" always has a non-empty text label', (variant) => {
+      render(<StatusBadge variant={variant} />)
+      const badge = document.querySelector('.status-badge')
+      const visibleText = badge?.querySelector('.sr-only')
+        ? badge.textContent
+            ?.replace(badge.querySelector('.sr-only')!.textContent ?? '', '')
+            .trim()
+        : badge?.textContent?.trim()
+      expect(visibleText?.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('renders as a <span>', () => {
+    it.each(ALL_VARIANTS)('root element is a <span> for variant "%s"', (variant) => {
+      render(<StatusBadge variant={variant} />)
+      const badge = document.querySelector('.status-badge')
+      expect(badge?.tagName.toLowerCase()).toBe('span')
+    })
+  })
+})

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -1,0 +1,54 @@
+import './StatusBadge.css'
+
+/** The four lifecycle states a bond or operation can occupy. */
+export type StatusBadgeVariant = 'pending' | 'active' | 'completed' | 'failed'
+
+export interface StatusBadgeProps {
+  /** Lifecycle status variant. */
+  variant: StatusBadgeVariant
+  /** Optional display label override. Defaults to the capitalised variant name. */
+  label?: string
+  /** Additional class names appended to the badge root. */
+  className?: string
+  /**
+   * Optional screen-reader-only prefix rendered before the visible label so
+   * assistive technology can announce the badge in context (e.g. `"Bond status:"`
+   * produces `"Bond status: Pending"` when read aloud). No extra DOM is added
+   * when this prop is omitted.
+   */
+  srPrefix?: string
+  /**
+   * Accessible label for the badge element. Defaults to the display label.
+   * Provide this prop when the badge appears in a context where screen readers
+   * need a more descriptive label than the visible text alone.
+   */
+  ariaLabel?: string
+}
+
+const DEFAULT_LABELS: Record<StatusBadgeVariant, string> = {
+  pending: 'Pending',
+  active: 'Active',
+  completed: 'Completed',
+  failed: 'Failed',
+}
+
+export default function StatusBadge({
+  variant,
+  label,
+  className = '',
+  srPrefix,
+  ariaLabel,
+}: StatusBadgeProps) {
+  const displayLabel = label ?? DEFAULT_LABELS[variant]
+  const accessibleLabel = ariaLabel ?? displayLabel
+
+  return (
+    <span
+      className={`status-badge status-badge--${variant} ${className}`.trim()}
+      aria-label={accessibleLabel}
+    >
+      {srPrefix && <span className="sr-only">{srPrefix} </span>}
+      {displayLabel}
+    </span>
+  )
+}


### PR DESCRIPTION
Closes #585 — StatusBadge component with pending/active/completed/failed variants, each mapped to a semantic --credence-* colour token family. Includes CSS, Storybook stories, and full unit test coverage.

Closes #591 — AnalyticsWidget with compare-periods toggle. Supports current/previous period side-by-side view via a role=switch toggle. Works in both uncontrolled (defaultCompare) and controlled (compareEnabled + onCompareChange) modes. Includes CSS, Storybook stories (7 variants), and full unit test coverage.

Also fixes a pre-existing missing closing brace in ActivityTimeline.test.tsx that broke the TypeScript compiler.

docs/COMPONENTS.md updated with entries for both new components.

closes #585 
closes #591 