### PR TITLE
fix: update html lang attribute on i18n locale change (closes #523)

### DIFF
--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -21,4 +21,10 @@ i18n
     },
   })
 
+i18n.on('languageChanged', (lng) => {
+  document.documentElement.lang = lng
+})
+
+document.documentElement.lang = i18n.language || 'en'
+
 export default i18n


### PR DESCRIPTION
Description:

   Closes #523

   This PR ensures that screen readers (VoiceOver, NVDA, TalkBack) use the correct pronunciation engine when users switch languages in the UI, bringing the app into compliance with WCAG 2.1 AA.

   **Changes:**
   - Subscribed to the `languageChanged` event in `src/i18n/config.ts`.
   - Dynamically updates `document.documentElement.lang` whenever the locale changes.
   - Automatically assigns the initially detected fallback language to the `<html>` root on app load.
   - Verified with Axe checks showing zero violations for the HTML `lang` attribute.