### PR TITLE
docs: add design tokens overview (closes #544)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ See the [docs/](docs/) directory for detailed project documentation, including:
 
 - [Accessibility Checklist](docs/ACCESSIBILITY.md) - Required axe, screen reader, keyboard, and contrast checks before merging UI changes.
 - [Copy Tone Guide](docs/COPY_TONE.md) — How we phrase success, error, empty, and loading UI copy with dos and don'ts.
+- [Design Tokens Overview](docs/DESIGN_TOKENS.md) — Exhaustive list of CSS custom properties and semantic roles.
 
 - [Architecture Overview](docs/ARCHITECTURE.md) — Runtime structure, provider tree, and data flow seams.
 - [Cookie-Secret Rotation Runbook](docs/COOKIE_SECRETS.md) — Rotation cadence, blast radius, and step-by-step procedure for backend session/CSRF cookie secrets.

--- a/docs/DESIGN_TOKENS.md
+++ b/docs/DESIGN_TOKENS.md
@@ -1,106 +1,96 @@
-```tsx
-import React from 'react'
-import { Badge } from './Badge'
-import { ActionCard, ConfirmDialog } from './ActionCard'
+# Design Tokens
 
-const BondDetail = () => {
-  const [activeBond, setActiveBond] = React.useState(null)
-  const [confirmWithdrawFunds, setConfirmWithdrawFunds] = React.useState(false)
+This document lists all CSS custom properties (design tokens) used in the Credence Frontend and explains their semantic roles. By using these tokens rather than hardcoding values, we ensure consistent theming, accessibility (like dark mode and reduced motion), and maintainability.
 
-  const handleSelectBond = (bond) => {
-    setActiveBond(bond)
-    setConfirmWithdrawFunds(false) // Reset confirm dialog on bond selection
-  }
+**Audience**: Contributors (Frontend Engineers)
 
-  const handleExtendLockTerm = () => {
-    console.log('Extend Lock Term clicked')
-    // Extend lock term logic here
-  }
+## Usage Example
 
-  const handleWithdrawFunds = () => {
-    setConfirmWithdrawFunds(true)
-  }
+Always prefer tokens over hard-coded values when writing custom CSS. This ensures that features like Dark Mode automatically adapt your UI without needing extra media queries.
 
-  const handleTopUpFunds = () => {
-    console.log('Top Up Funds clicked')
-    // Top up funds logic here
-  }
-
-  return (
-    <div>
-      {activeBond && (
-        <>
-          <h2>Bond Details</h2>
-          <p>Amount: ${activeBond.amount}</p>
-          <p>
-            Status: <Badge status={activeBond.status} />
-          </p>
-
-          {/* Lock start/end and time remaining */}
-          <p>
-            Lock Start/End: {new Date(activeBond.lockStart).toLocaleDateString()} -{' '}
-            {new Date(activeBond.lockEnd).toLocaleTimeString()}
-          </p>
-          <p>
-            Time Remaining: {(new Date(activeBond.lockEnd) - new Date()) / (1000 * 60 * 60 * 24)}{' '}
-            days
-          </p>
-
-          {/* Slash penalty % */}
-          <p>Slash Penalty (%): {activeBond.slashPenalty}%</p>
-
-          {/* Inspection of lock end date and time remaining */}
-          <p>Lock End Date: {new Date(activeBond.lockEnd).toLocaleDateString()}</p>
-          <p>
-            Time Remaining Until Lock End:{' '}
-            {(new Date(activeBond.lockEnd) - new Date()) / (1000 * 60 * 60 * 24)} days
-          </p>
-
-          {/* Manage actions */}
-          <ActionCard
-            actionType="extend"
-            label="Extend Lock Term"
-            description="Extend the lock term by 30 days"
-            onClick={handleExtendLockTerm}
-          />
-          <ActionCard
-            actionType="withdraw"
-            label="Withdraw Funds"
-            description="Withdraw funds and close the bond"
-            onClick={handleWithdrawFunds}
-          />
-          <ActionCard
-            actionType="top-up"
-            label="Top Up Funds"
-            description="Deposit additional funds into the bond"
-            onClick={handleTopUpFunds}
-          />
-
-          {/* 30-day lock and slash warning */}
-          <div className="warning">
-            You have{' '}
-            <span className="warning-count">
-              {new Date(activeBond.lockEnd).getDate()} of{' '}
-              {new Date(activeBond.lockEnd).getMonth() + 1}/
-              {new Date(activeBond.lockEnd).getFullYear()}
-            </span>
-            left before the lock period expires. If you don't make a
-          </div>
-
-          {/* Confirm dialog for withdraw funds */}
-          {confirmWithdrawFunds && (
-            <ConfirmDialog
-              title="Confirm Withdrawal"
-              message="Are you sure you want to withdraw your funds?"
-              onConfirm={handleConfirmWithdraw}
-              onCancel={handleCancelWithdraw}
-            />
-          )}
-        </>
-      )}
-    </div>
-  )
+### Do:
+```css
+.myComponent {
+  padding: var(--credence-space-4);
+  color: var(--credence-text-secondary);
+  background-color: var(--credence-surface-card);
+  border-radius: var(--credence-radius-md);
+  transition: background-color var(--credence-motion-duration-fast) var(--credence-motion-easing-standard);
 }
-
-export default BondDetail
 ```
+
+### Don't:
+```css
+/* Avoid hard-coded hex colors, px sizing, or generic easing */
+.myComponent {
+  padding: 16px;
+  color: #64748b;
+  background-color: #ffffff;
+  border-radius: 6px;
+  transition: background-color 150ms ease;
+}
+```
+
+## Tokens Overview
+
+### Typography
+These control font families, sizing, weights, and line heights.
+- `--credence-font-family-base`: The primary system font stack.
+- `--credence-font-size-xs` to `--credence-font-size-xl`: Font scales (e.g. `xs` is `0.75rem`, `base` is `1rem`).
+- `--credence-font-weight-regular`, `-semibold`, `-bold`: Font weights (400, 600, 700).
+- `--credence-line-height-tight`, `-base`, `-relaxed`: Line heights (1.25, 1.5, 1.6).
+
+### Spacing
+Use these for padding, margins, and gaps.
+- `--credence-space-1` to `--credence-space-12`: Consistent spacing scale (`-1` is `0.25rem`, `-4` is `1rem`, `-12` is `3rem`).
+
+### Radius
+Used for border-radius on containers and inputs.
+- `--credence-radius-sm` to `--credence-radius-full`: Rounding options (`-sm` is `0.25rem`, `-full` is `9999px`).
+
+### Motion
+Timing and easing functions for animations and transitions. Automatically overridden to `0ms` when a user prefers reduced motion.
+- `--credence-motion-duration-instant`, `-fast`, `-base`, `-slow`: Transition durations (0ms to 400ms).
+- `--credence-motion-easing-standard`, `-decelerate`, `-accelerate`, `-linear`: Easing curves.
+- `--credence-motion-skeleton`: Pre-defined animation for shimmer loading states.
+
+### Overlays & Backdrops
+Controls the transparency of modal backdrops. These automatically switch to opaque equivalents when users prefer reduced transparency.
+- `--credence-backdrop-light`, `-dark`, `-mobile`: Context-aware backdrop overlays.
+
+### Layout
+Container restraints.
+- `--credence-container-max`: Maximum width of the main layout (`72rem`).
+- `--credence-container-padding`: Responsive padding for edges (`clamp(1rem, 2vw, 2rem)`).
+
+### Colors & Theming
+Our application features a robust token system that automatically flips to dark mode equivalents when `data-theme="dark"` is active.
+
+**Neutrals**: 
+- `--credence-color-white`, `--credence-color-black`
+- `--credence-color-slate-50` through `--credence-color-slate-900`: Structural grays.
+
+**Brand & Semantics**: 
+These indicate state or primary actions.
+- `--credence-color-primary`, `-primary-strong`, `-primary-soft`: Brand blue for primary interactive elements.
+- `--credence-color-info-surface`, `-border`, `-text`: Blue informational messaging.
+- `--credence-color-success-surface`, `-border`, `-text`: Green success indicators.
+- `--credence-color-warning-surface`, `-border`, `-text`: Yellow warning indicators.
+- `--credence-color-danger-surface`, `-surface-strong`, `-border`, `-action`, `-text`, `-text-muted`: Red error and destructive actions.
+
+**Tier & Accent Colors**: 
+Specific colors for user trust tiers or illustration highlights.
+- `--credence-color-bronze-*`, `--credence-color-silver-*`, `--credence-color-gold-*`, `--credence-color-platinum-*`
+- `--credence-color-grace-*`, `--credence-color-trust-*`, `--credence-color-attestation-*`
+
+### Surface Aliases
+These aliases abstract away the raw color tokens. Always try to use these first for components.
+- `--credence-surface-page`: Background color of the main application (light gray, flips to dark slate).
+- `--credence-surface-card`: Background for elevated containers (white, flips to dark navy).
+- `--credence-text-primary`, `--credence-text-secondary`: Main and muted text colors.
+- `--credence-border-default`: Default subtle border.
+
+### Effects
+- `--credence-color-focus-ring`, `--credence-focus-ring`: Standardized `2px` focus outline for accessibility.
+- `--credence-shadow-toast`: Drop-shadow for floating notifications.
+- `--credence-skeleton-gradient`: Gradient background used for loading skeletons.


### PR DESCRIPTION
Description:

   Closes #544

   This PR adds an exhaustive breakdown of the CSS custom properties (design tokens) used across the application to replace tribal knowledge with clear documentation.

   **Changes:**
   - Documented all `--credence-*` tokens in `docs/DESIGN_TOKENS.md` (Typography, Spacing, Radius, Motion, Overlays, Layout, Colors, and Effects).
   - Included concrete `Do` and `Don't` code examples tailored for frontend contributors to encourage using tokens instead of hard-coded values.
   - Cross-linked the new reference document from the main `README.md` to ensure it stays discoverable.