### PR TITLE
feat: centralize USDC formatting via formatUsdc helper

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -562,6 +562,11 @@ Framework-free helpers — pure functions and a wallet SDK wrapper. No React req
 
 Source: [`src/lib/format.ts`](../src/lib/format.ts) · Single source of truth for USDC display.
 
+> **Canonical rule (closes #558):** Always use `formatUsdc(amount)` to display a USDC
+> amount in the UI. Never inline `amount.toLocaleString('en-US') + ' USDC'`,
+> `amount.toFixed(2) + ' USDC'`, or any other ad-hoc pattern. All monetary display
+> helpers live in `format.ts` so every surface shows consistent numbers.
+
 ```ts
 formatUsdc(amount: number): string        // 1234.5      → "1,234.5 USDC"
 normalizeUSDC(rawValue: string): string   // "1,234.5"   → "1234.50"  (clamps <0 to "0.00"; invalid → "")
@@ -578,7 +583,15 @@ can correct it. SSR-safe (pure functions, no globals).
 ```ts
 import { formatUsdc, sanitizeUSDCInput } from '@/lib/format'
 
-formatUsdc(1000) // "1,000 USDC"
+// ✅ Correct — always use formatUsdc for display
+formatUsdc(1000)          // "1,000 USDC"
+formatUsdc(1234.5)        // "1,234.5 USDC"
+formatUsdc(Number(str))   // when amount comes from a string state value
+
+// ❌ Avoid — do not use ad-hoc patterns
+// `${amount.toLocaleString('en-US')} USDC`
+// `${amount.toFixed(2)} USDC`
+
 sanitizeUSDCInput('12.345') // "12.34"
 ```
 

--- a/src/components/CreateBondFlow.test.tsx
+++ b/src/components/CreateBondFlow.test.tsx
@@ -279,7 +279,7 @@ describe('CreateBondFlow – step 3 review', () => {
 
   it('shows bond amount row', async () => {
     await reachStep3('1000', 30)
-    expect(screen.getByTestId('review-bond-amount')).toHaveTextContent('1000 USDC')
+    expect(screen.getByTestId('review-bond-amount')).toHaveTextContent('1,000 USDC')
   })
 
   it('shows duration row', async () => {

--- a/src/components/CreateBondFlow.tsx
+++ b/src/components/CreateBondFlow.tsx
@@ -322,7 +322,7 @@ export default function CreateBondFlow({ onComplete, onCancel }: CreateBondFlowP
             <div className="createBondFlow__reviewRow">
               <span className="createBondFlow__reviewLabel">Bond Amount:</span>
               <strong className="createBondFlow__reviewValue" data-testid="review-bond-amount">
-                {amount} USDC
+                {formatUsdc(Number(amount))}
               </strong>
             </div>
 

--- a/src/pages/AmountInputTestPage.tsx
+++ b/src/pages/AmountInputTestPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import AmountInput from '../components/AmountInput'
+import { formatUsdc } from '../lib/format'
 
 export default function AmountInputTestPage() {
   const [value, setValue] = useState('')
@@ -19,7 +20,7 @@ export default function AmountInputTestPage() {
 
       <section style={{ marginBottom: '2rem' }}>
         <h2>Basic Test (Default Presets)</h2>
-        <p>Balance: {balance.toFixed(2)} USDC</p>
+        <p>Balance: {formatUsdc(balance)}</p>
         <AmountInput value={value} onChange={handleValueChange} balance={balance} error={error} />
         <div style={{ marginTop: '1rem' }}>
           <strong>Current value:</strong> {value || '(empty)'}

--- a/src/pages/Transactions.tsx
+++ b/src/pages/Transactions.tsx
@@ -19,8 +19,8 @@ import {
 } from '../lib/transactionsExport'
 import { explorerUrl } from '../lib/explorerUrl'
 import { truncateAddress } from '../lib/stellar'
+import { formatUsdc } from '../lib/format'
 import type { Transaction } from '../api/types'
-import { truncateAddress } from '@/lib/stellar'
 
 type StatusFilter = 'all' | 'pending' | 'confirmed' | 'failed'
 
@@ -361,7 +361,7 @@ export default function Transactions() {
                         {tx.type}
                       </td>
                       <td data-label="Amount">
-                        {tx.amountUsdc != null ? `${tx.amountUsdc.toLocaleString('en-US')} USDC` : '—'}
+                        {tx.amountUsdc != null ? formatUsdc(tx.amountUsdc) : '—'}
                       </td>
                       <td data-label="Status">
                         <Badge variant={STATUS_BADGE_MAP[tx.status]} label={tx.status} />

--- a/src/pages/TrustScore.tsx
+++ b/src/pages/TrustScore.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState, useMemo } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import ActivityTimeline from '../components/ActivityTimeline'
 import './TrustScore.css'
 import Banner from '../components/Banner'
 import Disclaimer from '../components/Disclaimer'
@@ -55,7 +54,6 @@ function trustScoreErrorType(error: ApiError): 'network' | 'backend' | 'validati
 }
 
 export default function TrustScore() {
-  const { t } = useTranslation()
   useSeo({
     title: 'Trust Score',
     description:


### PR DESCRIPTION
Replace all ad-hoc USDC amount formatting with the canonical formatUsdc() from src/lib/format.ts.

Changes:
- Transactions.tsx: replace tx.amountUsdc.toLocaleString('en-US') + ' USDC' with formatUsdc(tx.amountUsdc); also remove duplicate truncateAddress import
- AmountInputTestPage.tsx: replace balance.toFixed(2) + ' USDC' with formatUsdc(balance)
- CreateBondFlow.tsx step 3: replace raw {amount} USDC template literal with formatUsdc(Number(amount)) so the review panel uses locale-safe thousand-separator formatting (e.g. '1,000 USDC' not '1000 USDC')
- TrustScore.tsx: remove duplicate ActivityTimeline import and duplicate const { t } = useTranslation() declaration (compile errors that masked the test suite)
- CreateBondFlow.test.tsx: update review-bond-amount assertion to expect '1,000 USDC' (the correctly formatted output)
- docs/HOOKS.md: add canonical-rule callout explaining that formatUsdc must be used for all USDC display; anti-patterns explicitly documented

Closes #558