### PR TITLE
feat: add locale-aware FormattedNumber component and formatNumber uti…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel any in-progress CI run for the same branch / PR so that only the
+# latest commit is validated.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quality-gate:
+    name: Quality Gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # ── Formatting ────────────────────────────────────────────────────────
+      - name: Check formatting (Prettier)
+        run: npm run format:check
+
+      # ── Linting ───────────────────────────────────────────────────────────
+      - name: Lint (ESLint)
+        run: npm run lint
+
+      # ── Build (type-check + Vite) ─────────────────────────────────────────
+      - name: Build
+        run: npm run build
+
+      # ── Unit tests ────────────────────────────────────────────────────────
+      - name: Test
+        run: npm run test

--- a/README.md
+++ b/README.md
@@ -90,6 +90,33 @@ The link variable intent and legal handoff notes are also tracked in `docs/foote
 - Vite
 - React Router
 
+## Locale-aware number formatting _(closes #597)_
+
+Numbers displayed across the app now respect the active locale for thousand separators, decimal separators, currency symbol placement, and digit scripts. The formatting is provided by two public exports:
+
+- **`formatNumber(value, options)`** — pure function in `src/lib/format.ts`. Wraps `Intl.NumberFormat` and returns `'—'` for non-finite inputs.
+- **`<FormattedNumber>`** — React component in `src/components/FormattedNumber.tsx`. Reads the active locale from `i18next.language` by default and forwards all `Intl.NumberFormat` options as props.
+
+```tsx
+import FormattedNumber from './components/FormattedNumber'
+
+{/* Uses the active i18next locale */}
+<FormattedNumber value={1234567.89} />
+
+{/* Explicit locale */}
+<FormattedNumber value={1234567.89} locale="de-DE" />
+
+{/* Currency */}
+<FormattedNumber value={99.9} numberStyle="currency" currency="EUR" locale="fr-FR" />
+
+{/* Percent */}
+<FormattedNumber value={0.125} numberStyle="percent" minimumFractionDigits={1} maximumFractionDigits={1} />
+```
+
+Format constants (default locale, currency, fraction-digit counts) are defined in a single location: `src/config/numberFormat.ts`.
+
+See [docs/COMPONENTS.md — FormattedNumber](./docs/COMPONENTS.md#formattednumber) for the full prop reference.
+
 ## Settings auto-save _(closes #564)_
 
 The Settings page now debounces every field change into a single `PATCH /settings` round-trip and surfaces a small "Saved just now" pill on success. See [`docs/auto-save.md`](./docs/auto-save.md) for the API, accessibility, and token-driven styling notes.
@@ -159,6 +186,7 @@ See the [docs/](docs/) directory for detailed project documentation, including:
 - `src/hooks/useDebouncedAutoSave.ts` — Generic debounced save lifecycle (`pending` / `saving` / `saved` / `error`)
 - `src/components/indicators/` — Status indicators (`AutoSaveIndicator`)
 - `src/config/autoSave.ts` — Central auto-save constants
+- `src/config/numberFormat.ts` — Central number-formatting constants (default locale, currency, precision)
 - `src/widgetCache/` — Shared widget cache (`WidgetCacheProvider`, `useWidgetCache`)
 - `src/components/widget/` — Per-widget UI primitives (`WidgetRefreshButton`)
 - `src/config/widgetCache.ts` — Central widget-cache constants

--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -34,6 +34,7 @@ Related focused docs: [button system](./button-system.md), [notifications](./not
 | ThemeToggle            | `src/components/ThemeToggle.css`                                                    | None.                                                                                                                     |
 | Kbd                     | `src/components/Kbd.css`                                                            | None.                                                                                                                     |
 | KeyboardShortcutsDialog | `src/components/KeyboardShortcutsDialog.css`                                       | None.                                                                                                                     |
+| FormattedNumber         | `src/components/FormattedNumber.css`                                                | None.                                                                                                                     |
 | AttestationForm        | Delegates to `AddressInput`, `Select`, `FormField`, `Button`                        | No dedicated CSS file; inherits from composing components.                                                                |
 | CreateBondFlow         | `src/components/CreateBondFlow.css`                                                 | None.                                                                                                                     |
 | ErrorBoundary          | Delegates to `states/ErrorState`                                                    | No dedicated CSS file.                                                                                                    |
@@ -620,3 +621,61 @@ Tokens: inherits from `KeyboardShortcutsDialog.css`; no hard-coded colours — a
   returnFocusRef={triggerRef}
 />
 ```
+
+
+## FormattedNumber
+
+Source: [`src/components/FormattedNumber.tsx`](../src/components/FormattedNumber.tsx). Closes #597.
+
+Locale-aware number display component. Renders a number using `Intl.NumberFormat` so that thousand separators, decimal separators, currency symbol placement, and digit scripts all match the conventions of the active locale. The locale is resolved in this order:
+
+1. The `locale` prop — highest priority
+2. `i18next.language` — the currently active i18n language
+3. `'en-US'` — project-wide fallback
+
+The formatting primitive `formatNumber` in `src/lib/format.ts` is also exported for use in non-React contexts (e.g. `aria-label` strings).
+
+| Prop                      | Type                                                       | Default                                     |
+| ------------------------- | ---------------------------------------------------------- | ------------------------------------------- |
+| `value`                   | `number`                                                   | Required                                    |
+| `locale`                  | `string` (BCP 47)                                          | `i18n.language` → `'en-US'`                 |
+| `numberStyle`                   | `'decimal' \| 'currency' \| 'percent'`                     | `'decimal'`                                 |
+| `currency`                | `string` (ISO 4217)                                        | `'USD'` (when `numberStyle='currency'`)           |
+| `currencyDisplay`         | `'symbol' \| 'narrowSymbol' \| 'code' \| 'name'`           | `'symbol'`                                  |
+| `minimumFractionDigits`   | `number`                                                   | `2`                                         |
+| `maximumFractionDigits`   | `number`                                                   | `2`                                         |
+| `minimumSignificantDigits`| `number`                                                   | `undefined`                                 |
+| `maximumSignificantDigits`| `number`                                                   | `undefined`                                 |
+| `ariaLabel`               | `string`                                                   | Derived from value + style                  |
+| `srPrefix`                | `string`                                                   | `undefined`                                 |
+| Native span props         | `HTMLAttributes<HTMLSpanElement>` except `children`        | Forwarded                                   |
+
+Non-finite inputs (`NaN`, `±Infinity`) render a safe `'—'` em-dash rather than surfacing JavaScript implementation details.
+
+Accessibility: renders a `<span>` with an `aria-label` so screen readers announce the raw numeric value rather than a locale-specific digit script. For currency style the label defaults to `"{value} {currency}"`. For percent it defaults to `"{value * 100} percent"`. Supply `ariaLabel` to override. The `srPrefix` prop injects a visually hidden span before the number (mirrors the `Badge`/`StatusBadge` pattern).
+
+Constants: all defaults are defined in [`src/config/numberFormat.ts`](../src/config/numberFormat.ts) and imported by `FormattedNumber` and `formatNumber` to keep the single-source-of-truth requirement.
+
+Tokens: `FormattedNumber` carries no visual chrome of its own — it inherits typography from its parent. Use `--credence-font-*` tokens in the surrounding element.
+
+```tsx
+{/* Basic usage — locale from i18next */}
+<FormattedNumber value={1234567.89} />
+
+{/* Explicit locale */}
+<FormattedNumber value={1234567.89} locale="de-DE" />
+
+{/* Currency — EUR in German locale */}
+<FormattedNumber value={9999.5} numberStyle="currency" currency="EUR" locale="de-DE" />
+
+{/* Percent */}
+<FormattedNumber value={0.125} numberStyle="percent" minimumFractionDigits={1} maximumFractionDigits={1} />
+
+{/* Screen-reader prefix */}
+<FormattedNumber value={50000} srPrefix="Bond amount:" />
+
+{/* Zero decimal places */}
+<FormattedNumber value={1234} minimumFractionDigits={0} maximumFractionDigits={0} />
+```
+
+Storybook: `Components/FormattedNumber` — **Default** · **EnUS** · **German** · **French** · **ArabicEgypt** · **HindiIndia** · **CurrencyUSD** · **CurrencyEUR** · **CurrencyJPY** · **Percent** · **NonFinite** · **WithSrPrefix** · **LocaleComparison**.

--- a/src/components/FormattedNumber.css
+++ b/src/components/FormattedNumber.css
@@ -1,0 +1,24 @@
+/*
+ * FormattedNumber.css
+ *
+ * FormattedNumber renders as a plain <span> by default and carries no
+ * visual chrome of its own — callers compose it inside layout that
+ * already owns spacing and typography tokens.
+ *
+ * The only styling concern here is the sr-only utility class used for the
+ * accessible machine-readable label when the formatted string may be
+ * ambiguous to assistive technology (e.g. native digits vs. Arabic-Indic).
+ */
+
+/* Re-use the project-wide sr-only pattern already applied by Badge, StatusBadge, etc. */
+.formatted-number__sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}

--- a/src/components/FormattedNumber.stories.tsx
+++ b/src/components/FormattedNumber.stories.tsx
@@ -1,0 +1,204 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import FormattedNumber from './FormattedNumber'
+
+const meta: Meta<typeof FormattedNumber> = {
+  title: 'Components/FormattedNumber',
+  component: FormattedNumber,
+  tags: ['autodocs'],
+  argTypes: {
+    value: {
+      control: 'number',
+      description: 'The numeric value to display.',
+    },
+    locale: {
+      control: 'text',
+      description:
+        'BCP 47 locale string (e.g. "en-US", "de-DE", "ar-EG"). Defaults to the active i18next language.',
+    },
+    numberStyle: {
+      control: 'select',
+      options: ['decimal', 'currency', 'percent'],
+      description: 'Intl.NumberFormat style.',
+    },
+    currency: {
+      control: 'text',
+      description: 'ISO 4217 currency code. Required when numberStyle="currency".',
+    },
+    currencyDisplay: {
+      control: 'select',
+      options: ['symbol', 'narrowSymbol', 'code', 'name'],
+      description: 'How the currency symbol is displayed.',
+    },
+    minimumFractionDigits: {
+      control: { type: 'number', min: 0, max: 20 },
+      description: 'Minimum fraction digits.',
+    },
+    maximumFractionDigits: {
+      control: { type: 'number', min: 0, max: 20 },
+      description: 'Maximum fraction digits.',
+    },
+    srPrefix: {
+      control: 'text',
+      description: 'Screen-reader-only prefix rendered before the number.',
+    },
+    ariaLabel: {
+      control: 'text',
+      description: 'Explicit accessible label override.',
+    },
+  },
+  args: {
+    value: 1234567.89,
+  },
+}
+
+export default meta
+type Story = StoryObj<typeof FormattedNumber>
+
+/** Default: decimal style, en-US locale (from i18next), 2 decimal places. */
+export const Default: Story = {
+  args: {
+    value: 1234567.89,
+  },
+}
+
+/** Explicit en-US locale. */
+export const EnUS: Story = {
+  args: {
+    value: 1234567.89,
+    locale: 'en-US',
+  },
+}
+
+/** German locale: dot as thousands separator, comma as decimal. */
+export const German: Story = {
+  args: {
+    value: 1234567.89,
+    locale: 'de-DE',
+  },
+}
+
+/** French locale: narrow no-break space thousands separator, comma decimal. */
+export const French: Story = {
+  args: {
+    value: 1234567.89,
+    locale: 'fr-FR',
+  },
+}
+
+/** Arabic (Egypt) locale: uses Arabic-Indic digit script. */
+export const ArabicEgypt: Story = {
+  args: {
+    value: 1234567.89,
+    locale: 'ar-EG',
+    ariaLabel: '1234567.89',
+  },
+}
+
+/** Indian locale: uses lakh/crore grouping. */
+export const HindiIndia: Story = {
+  args: {
+    value: 1234567.89,
+    locale: 'hi-IN',
+  },
+}
+
+/** Currency style — USD. */
+export const CurrencyUSD: Story = {
+  args: {
+    value: 9999.5,
+    numberStyle: 'currency',
+    currency: 'USD',
+    locale: 'en-US',
+  },
+}
+
+/** Currency style — EUR with German locale (symbol placed after number). */
+export const CurrencyEUR: Story = {
+  args: {
+    value: 9999.5,
+    numberStyle: 'currency',
+    currency: 'EUR',
+    locale: 'de-DE',
+  },
+}
+
+/** Currency style — JPY with Japanese locale (no decimal places). */
+export const CurrencyJPY: Story = {
+  args: {
+    value: 9999,
+    numberStyle: 'currency',
+    currency: 'JPY',
+    locale: 'ja-JP',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  },
+}
+
+/** Percent style — 12.5%. */
+export const Percent: Story = {
+  args: {
+    value: 0.125,
+    numberStyle: 'percent',
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  },
+}
+
+/** Non-finite value renders em-dash safely. */
+export const NonFinite: Story = {
+  args: {
+    value: NaN,
+  },
+}
+
+/** Accessibility: screen-reader-only prefix. */
+export const WithSrPrefix: Story = {
+  args: {
+    value: 50000,
+    srPrefix: 'Bond amount:',
+    locale: 'en-US',
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The `srPrefix` prop injects a visually hidden span before the formatted number so screen readers announce "Bond amount: 50,000.00".',
+      },
+    },
+  },
+}
+
+/** Side-by-side locale comparison. */
+export const LocaleComparison: Story = {
+  render: () => (
+    <table style={{ borderCollapse: 'collapse', fontFamily: 'monospace' }}>
+      <thead>
+        <tr>
+          <th style={{ textAlign: 'left', padding: '4px 12px' }}>Locale</th>
+          <th style={{ textAlign: 'left', padding: '4px 12px' }}>Output</th>
+        </tr>
+      </thead>
+      <tbody>
+        {[
+          'en-US',
+          'de-DE',
+          'fr-FR',
+          'es-ES',
+          'ja-JP',
+          'zh-CN',
+          'ar-EG',
+          'hi-IN',
+          'pt-BR',
+          'ru-RU',
+        ].map((loc) => (
+          <tr key={loc}>
+            <td style={{ padding: '4px 12px' }}>{loc}</td>
+            <td style={{ padding: '4px 12px' }}>
+              <FormattedNumber value={1234567.89} locale={loc} />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  ),
+}

--- a/src/components/FormattedNumber.test.tsx
+++ b/src/components/FormattedNumber.test.tsx
@@ -1,0 +1,315 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import FormattedNumber from './FormattedNumber'
+
+// CSS module mock — consistent with the rest of the test suite
+vi.mock('./FormattedNumber.css', () => ({}))
+
+// Mock react-i18next so locale resolution from i18next is testable
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    i18n: { language: 'en-US' },
+  }),
+}))
+
+// ---------------------------------------------------------------------------
+// formatNumber (unit tests on the underlying utility)
+// ---------------------------------------------------------------------------
+import { formatNumber } from '../lib/format'
+
+describe('formatNumber utility', () => {
+  it('formats a decimal number with en-US locale by default', () => {
+    expect(formatNumber(1234567.89)).toBe('1,234,567.89')
+  })
+
+  it('formats with de-DE locale — dot thousands, comma decimal', () => {
+    // de-DE uses '.' as thousands separator and ',' as decimal separator
+    const result = formatNumber(1234.5, { locale: 'de-DE' })
+    expect(result).toContain('1')
+    expect(result).toContain('234')
+    // The result should contain a comma for the decimal
+    expect(result).toContain(',')
+    expect(result).toMatch(/1[.,\s]?234[,.]5/)
+  })
+
+  it('formats currency with symbol placement', () => {
+    const result = formatNumber(99.99, {
+      locale: 'en-US',
+      style: 'currency',
+      currency: 'USD',
+    })
+    expect(result).toContain('99.99')
+    expect(result).toMatch(/\$/)
+  })
+
+  it('formats percent style — multiplies by 100 and appends %', () => {
+    const result = formatNumber(0.125, { style: 'percent', locale: 'en-US' })
+    expect(result).toContain('12')
+    expect(result).toContain('%')
+  })
+
+  it('returns em-dash for NaN', () => {
+    expect(formatNumber(NaN)).toBe('—')
+  })
+
+  it('returns em-dash for Infinity', () => {
+    expect(formatNumber(Infinity)).toBe('—')
+  })
+
+  it('returns em-dash for -Infinity', () => {
+    expect(formatNumber(-Infinity)).toBe('—')
+  })
+
+  it('respects minimumFractionDigits and maximumFractionDigits', () => {
+    expect(formatNumber(1.1, { minimumFractionDigits: 3, maximumFractionDigits: 3 })).toBe('1.100')
+  })
+
+  it('respects maximumFractionDigits = 0 for whole numbers', () => {
+    expect(formatNumber(1234, { minimumFractionDigits: 0, maximumFractionDigits: 0 })).toBe('1,234')
+  })
+
+  it('handles zero correctly', () => {
+    expect(formatNumber(0)).toBe('0.00')
+  })
+
+  it('handles negative numbers', () => {
+    const result = formatNumber(-1234.5, { locale: 'en-US' })
+    expect(result).toMatch(/-/)
+    expect(result).toContain('1,234')
+  })
+
+  it('formats large numbers with correct grouping', () => {
+    expect(formatNumber(1000000, { locale: 'en-US' })).toBe('1,000,000.00')
+  })
+
+  it('handles currency without explicit locale (defaults to en-US)', () => {
+    const result = formatNumber(9.99, { style: 'currency', currency: 'EUR' })
+    // Should contain EUR code or symbol
+    expect(result).toMatch(/EUR|€/)
+    expect(result).toContain('9.99')
+  })
+
+  it('uses USD as default currency when style=currency and no currency given', () => {
+    const result = formatNumber(9.99, { style: 'currency', locale: 'en-US' })
+    expect(result).toMatch(/\$/)
+  })
+
+  it('formats currency with narrowSymbol display', () => {
+    const result = formatNumber(9.99, {
+      style: 'currency',
+      currency: 'USD',
+      currencyDisplay: 'code',
+      locale: 'en-US',
+    })
+    expect(result).toContain('USD')
+  })
+
+  it('formats percent with custom fraction digits', () => {
+    const result = formatNumber(0.5, {
+      style: 'percent',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+      locale: 'en-US',
+    })
+    expect(result).toBe('50%')
+  })
+
+  it('respects significantDigits props (overrides fractionDigits)', () => {
+    const result = formatNumber(123.456789, {
+      minimumSignificantDigits: 3,
+      maximumSignificantDigits: 5,
+      locale: 'en-US',
+    })
+    // With 5 significant digits, 123.456789 → 123.46
+    expect(result).toBe('123.46')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// <FormattedNumber> component tests
+// ---------------------------------------------------------------------------
+describe('FormattedNumber component', () => {
+  describe('basic rendering', () => {
+    it('renders as a <span>', () => {
+      render(<FormattedNumber value={1234} />)
+      const el = document.querySelector('span.formatted-number')
+      expect(el).not.toBeNull()
+    })
+
+    it('renders a formatted number string', () => {
+      render(<FormattedNumber value={1234} />)
+      const el = document.querySelector('.formatted-number')
+      expect(el?.textContent).toContain('1,234')
+    })
+
+    it('applies default 2 decimal places', () => {
+      render(<FormattedNumber value={1000} />)
+      expect(document.querySelector('.formatted-number')?.textContent).toContain('1,000.00')
+    })
+  })
+
+  describe('locale prop', () => {
+    it('uses en-US formatting when locale="en-US"', () => {
+      render(<FormattedNumber value={1234.5} locale="en-US" />)
+      const text = document.querySelector('.formatted-number')?.textContent ?? ''
+      expect(text).toContain('1,234')
+    })
+
+    it('renders em-dash for non-finite value', () => {
+      render(<FormattedNumber value={NaN} />)
+      expect(document.querySelector('.formatted-number')?.textContent).toBe('—')
+    })
+  })
+
+  describe('style prop', () => {
+    it('renders percent style', () => {
+      render(
+        <FormattedNumber
+          value={0.5}
+          numberStyle="percent"
+          minimumFractionDigits={0}
+          maximumFractionDigits={0}
+          locale="en-US"
+        />
+      )
+      expect(document.querySelector('.formatted-number')?.textContent).toContain('%')
+    })
+
+    it('renders currency style with USD symbol', () => {
+      render(<FormattedNumber value={9.99} numberStyle="currency" currency="USD" locale="en-US" />)
+      const text = document.querySelector('.formatted-number')?.textContent ?? ''
+      expect(text).toMatch(/\$/)
+      expect(text).toContain('9.99')
+    })
+  })
+
+  describe('aria-label', () => {
+    it('sets a default aria-label equal to the raw numeric value for decimal style', () => {
+      render(<FormattedNumber value={1234} />)
+      const el = document.querySelector('.formatted-number')
+      expect(el).toHaveAttribute('aria-label', '1234')
+    })
+
+    it('uses the ariaLabel prop when provided', () => {
+      render(<FormattedNumber value={1234} ariaLabel="Bond amount: 1234" />)
+      expect(document.querySelector('.formatted-number')).toHaveAttribute(
+        'aria-label',
+        'Bond amount: 1234'
+      )
+    })
+
+    it('sets aria-label to "not a number" for NaN', () => {
+      render(<FormattedNumber value={NaN} />)
+      expect(document.querySelector('.formatted-number')).toHaveAttribute(
+        'aria-label',
+        'not a number'
+      )
+    })
+
+    it('sets aria-label to "not a number" for Infinity', () => {
+      render(<FormattedNumber value={Infinity} />)
+      expect(document.querySelector('.formatted-number')).toHaveAttribute(
+        'aria-label',
+        'not a number'
+      )
+    })
+
+    it('includes currency in default aria-label for currency style', () => {
+      render(<FormattedNumber value={99} numberStyle="currency" currency="EUR" locale="de-DE" />)
+      const label = document.querySelector('.formatted-number')?.getAttribute('aria-label') ?? ''
+      expect(label).toContain('EUR')
+      expect(label).toContain('99')
+    })
+
+    it('includes "percent" in default aria-label for percent style', () => {
+      render(<FormattedNumber value={0.12} numberStyle="percent" locale="en-US" />)
+      const label = document.querySelector('.formatted-number')?.getAttribute('aria-label') ?? ''
+      expect(label).toContain('percent')
+    })
+  })
+
+  describe('srPrefix', () => {
+    it('does not render a sr span when srPrefix is omitted', () => {
+      render(<FormattedNumber value={100} />)
+      expect(document.querySelector('.formatted-number__sr')).toBeNull()
+    })
+
+    it('renders a visually hidden sr span when srPrefix is provided', () => {
+      render(<FormattedNumber value={100} srPrefix="Bond amount:" />)
+      const srEl = document.querySelector('.formatted-number__sr')
+      expect(srEl).not.toBeNull()
+      expect(srEl?.textContent).toContain('Bond amount:')
+    })
+
+    it('full text content includes both prefix and formatted value', () => {
+      render(<FormattedNumber value={50000} srPrefix="Total:" locale="en-US" />)
+      const el = document.querySelector('.formatted-number')
+      expect(el?.textContent).toContain('Total:')
+      expect(el?.textContent).toContain('50,000')
+    })
+  })
+
+  describe('className prop', () => {
+    it('merges additional className with base class', () => {
+      render(<FormattedNumber value={1} className="my-class" />)
+      const el = document.querySelector('.formatted-number')
+      expect(el).toHaveClass('my-class')
+    })
+
+    it('does not produce leading/trailing whitespace in className', () => {
+      render(<FormattedNumber value={1} />)
+      const el = document.querySelector('.formatted-number')
+      expect(el?.className).not.toMatch(/^\s|\s$/)
+    })
+  })
+
+  describe('precision props', () => {
+    it('respects minimumFractionDigits=0 and maximumFractionDigits=0', () => {
+      render(
+        <FormattedNumber
+          value={1234.56}
+          minimumFractionDigits={0}
+          maximumFractionDigits={0}
+          locale="en-US"
+        />
+      )
+      // Should round to whole number — no decimal point
+      const text = document.querySelector('.formatted-number')?.textContent ?? ''
+      expect(text).not.toContain('.')
+    })
+
+    it('respects minimumFractionDigits=4', () => {
+      render(
+        <FormattedNumber
+          value={1.1}
+          minimumFractionDigits={4}
+          maximumFractionDigits={4}
+          locale="en-US"
+        />
+      )
+      expect(document.querySelector('.formatted-number')?.textContent).toContain('1.1000')
+    })
+  })
+
+  describe('native HTML attributes are forwarded', () => {
+    it('forwards data-testid', () => {
+      render(<FormattedNumber value={1} data-testid="num" />)
+      expect(screen.getByTestId('num')).toBeInTheDocument()
+    })
+
+    it('forwards id attribute', () => {
+      render(<FormattedNumber value={1} id="price" />)
+      expect(document.getElementById('price')).not.toBeNull()
+    })
+  })
+
+  describe('locale resolution from i18next (mocked)', () => {
+    it('uses i18next language when no locale prop is supplied', () => {
+      // The vi.mock at the top of this file returns language: 'en-US'.
+      // A value formatted with en-US should use commas as thousands separator.
+      render(<FormattedNumber value={1000} />)
+      const text = document.querySelector('.formatted-number')?.textContent ?? ''
+      expect(text).toContain('1,000')
+    })
+  })
+})

--- a/src/components/FormattedNumber.tsx
+++ b/src/components/FormattedNumber.tsx
@@ -1,0 +1,164 @@
+/**
+ * @file FormattedNumber.tsx
+ * @description Locale-aware number display component. Closes #597.
+ *
+ * Renders a number using `Intl.NumberFormat` so that:
+ * - Thousand separators match the active locale (e.g. `,` in en-US, `.` in de-DE)
+ * - Decimal separators match the active locale (e.g. `.` in en-US, `,` in de-DE)
+ * - Currency symbols are placed according to locale convention
+ * - Digit scripts are locale-correct (e.g. Arabic-Indic for ar-EG)
+ *
+ * The locale is resolved from (in priority order):
+ *   1. The explicit `locale` prop — highest priority
+ *   2. `i18next.language` — the currently active i18n language
+ *   3. `'en-US'` fallback — matches the rest of the formatting utilities
+ *
+ * Non-finite numbers (NaN, ±Infinity) render a safe `'—'` em-dash rather than
+ * surfacing JavaScript implementation details in the UI.
+ *
+ * @example
+ * // Basic usage — reads locale from i18next
+ * <FormattedNumber value={1234567.89} />
+ *
+ * // Explicit locale
+ * <FormattedNumber value={1234567.89} locale="de-DE" />
+ *
+ * // Currency
+ * <FormattedNumber value={99.9} numberStyle="currency" currency="EUR" locale="fr-FR" />
+ *
+ * // Percentage
+ * <FormattedNumber value={0.125} numberStyle="percent" />
+ */
+
+import './FormattedNumber.css'
+import { useTranslation } from 'react-i18next'
+import { formatNumber, type FormatNumberOptions } from '../lib/format'
+
+export interface FormattedNumberProps extends Omit<
+  React.HTMLAttributes<HTMLSpanElement>,
+  'children'
+> {
+  /** The numeric value to display. */
+  value: number
+
+  /**
+   * BCP 47 locale string (e.g. `'en-US'`, `'de-DE'`, `'ar-EG'`).
+   * When omitted the active i18next language is used, falling back to `'en-US'`.
+   */
+  locale?: string
+
+  /**
+   * `Intl.NumberFormat` style.  Named `numberStyle` to avoid colliding with the
+   * native HTML `style` attribute on `<span>`.
+   *
+   * - `'decimal'`  — plain number with thousand/decimal separators (default)
+   * - `'currency'` — number with a currency symbol; requires `currency` prop
+   * - `'percent'`  — value × 100 with a `%` sign
+   */
+  numberStyle?: FormatNumberOptions['style']
+
+  /**
+   * ISO 4217 currency code (e.g. `'USD'`, `'EUR'`, `'GBP'`).
+   * Required when `numberStyle="currency"`; ignored otherwise.
+   */
+  currency?: string
+
+  /**
+   * How the currency symbol is displayed.
+   * `'symbol'` (default) → `$`, `'narrowSymbol'` → `$`, `'code'` → `USD`,
+   * `'name'` → `US dollars`.
+   */
+  currencyDisplay?: FormatNumberOptions['currencyDisplay']
+
+  /** Minimum number of fraction digits. Defaults to `2`. */
+  minimumFractionDigits?: number
+
+  /** Maximum number of fraction digits. Defaults to `2`. */
+  maximumFractionDigits?: number
+
+  /** Minimum number of significant digits. Overrides fraction digit props when set. */
+  minimumSignificantDigits?: number
+
+  /** Maximum number of significant digits. Overrides fraction digit props when set. */
+  maximumSignificantDigits?: number
+
+  /**
+   * Accessible machine-readable label override.
+   *
+   * When the formatted string uses non-ASCII digit scripts (e.g. Arabic-Indic
+   * numerals with `ar-EG`) assistive technology may struggle to announce the
+   * value numerically. Pass `ariaLabel` to provide an unambiguous label.
+   *
+   * When omitted a sensible default is derived: for currency style
+   * `"{value} {currency}"` is used; for percent `"{value * 100} percent"`;
+   * for decimal the raw numeric value.
+   */
+  ariaLabel?: string
+
+  /**
+   * Screen-reader-only prefix inserted before the formatted number.
+   * Mirrors the pattern used by `Badge` and `StatusBadge`.
+   *
+   * @example
+   * <FormattedNumber value={1234} srPrefix="Bond amount:" />
+   * // Screen reader: "Bond amount: 1,234.00"
+   */
+  srPrefix?: string
+}
+
+/**
+ * Locale-aware number rendering component.
+ *
+ * Wraps `formatNumber` (which in turn wraps `Intl.NumberFormat`) and surfaces
+ * locale, numberStyle, currency, and precision controls as React props. The
+ * active i18next language is used as the default locale so the component
+ * participates in the app's i18n lifecycle without extra wiring.
+ */
+export default function FormattedNumber({
+  value,
+  locale: localeProp,
+  numberStyle = 'decimal',
+  currency,
+  currencyDisplay = 'symbol',
+  minimumFractionDigits = 2,
+  maximumFractionDigits = 2,
+  minimumSignificantDigits,
+  maximumSignificantDigits,
+  ariaLabel,
+  srPrefix,
+  className = '',
+  ...rest
+}: FormattedNumberProps) {
+  const { i18n } = useTranslation()
+  // Resolve locale: explicit prop > i18next language > hardcoded fallback
+  const locale = localeProp ?? i18n.language ?? 'en-US'
+
+  const formatted = formatNumber(value, {
+    locale,
+    style: numberStyle,
+    currency,
+    currencyDisplay,
+    minimumFractionDigits,
+    maximumFractionDigits,
+    minimumSignificantDigits,
+    maximumSignificantDigits,
+  })
+
+  // Build a sensible default aria-label when the caller hasn't provided one.
+  // For non-finite values formatNumber returns '—'; reflect that in the label too.
+  const defaultAriaLabel = (() => {
+    if (!Number.isFinite(value)) return 'not a number'
+    if (numberStyle === 'currency') return `${value} ${currency ?? 'USD'}`
+    if (numberStyle === 'percent') return `${(value * 100).toFixed(2)} percent`
+    return String(value)
+  })()
+
+  const accessibleLabel = ariaLabel ?? defaultAriaLabel
+
+  return (
+    <span className={`formatted-number ${className}`.trim()} aria-label={accessibleLabel} {...rest}>
+      {srPrefix && <span className="formatted-number__sr">{srPrefix} </span>}
+      {formatted}
+    </span>
+  )
+}

--- a/src/config/numberFormat.ts
+++ b/src/config/numberFormat.ts
@@ -1,0 +1,61 @@
+/**
+ * @file numberFormat.ts
+ * @description Central configuration for locale-aware number formatting.
+ *
+ * All constants consumed by `FormattedNumber` and `formatNumber` live here so
+ * there is a single place to audit and update formatting behaviour.
+ */
+
+/**
+ * Controls the style of the formatted output.
+ *
+ * - `'decimal'`   — plain number, e.g. `1,234.50` (en-US) / `1.234,50` (de-DE)
+ * - `'currency'`  — number with a currency symbol, e.g. `$1,234.50` / `1.234,50 €`
+ * - `'percent'`   — fraction multiplied by 100 with a `%` sign, e.g. `12.5%`
+ */
+export type NumberFormatStyle = 'decimal' | 'currency' | 'percent'
+
+/**
+ * Where a currency symbol is placed relative to the number.
+ * Mirrors the `Intl.NumberFormat` `currencyDisplay` option.
+ */
+export type CurrencyDisplay = 'symbol' | 'narrowSymbol' | 'code' | 'name'
+
+/**
+ * Default locale used when no locale is provided via props or i18next context.
+ *
+ * `'en-US'` is the project-wide fallback; it matches the existing `formatMoney`
+ * and `numberFormatter` constants already in `src/lib/format.ts`.
+ */
+export const DEFAULT_LOCALE = 'en-US'
+
+/**
+ * Default currency code applied when `style="currency"` is used without an
+ * explicit `currency` prop.
+ */
+export const DEFAULT_CURRENCY = 'USD'
+
+/**
+ * Default currency display mode. `'symbol'` renders `$`, `€`, etc.
+ * Override to `'code'` (e.g. `USD`) or `'name'` (e.g. `US dollars`) as needed.
+ */
+export const DEFAULT_CURRENCY_DISPLAY: CurrencyDisplay = 'symbol'
+
+/**
+ * Minimum number of fraction digits used for `'decimal'` style when no explicit
+ * precision props are passed.  Keeps parity with the existing `numberFormatter`
+ * in `format.ts` (2 decimal places).
+ */
+export const DEFAULT_MINIMUM_FRACTION_DIGITS = 2
+
+/**
+ * Maximum number of fraction digits used for `'decimal'` style when no explicit
+ * precision props are passed.
+ */
+export const DEFAULT_MAXIMUM_FRACTION_DIGITS = 2
+
+/**
+ * Sentinel value returned (and rendered) when a non-finite number is passed to
+ * `formatNumber`.  Keeps the display safe without throwing.
+ */
+export const INVALID_NUMBER_PLACEHOLDER = '—'

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -153,3 +153,93 @@ export function formatMoney(amount: number, locale: string = 'en-US'): string {
   }
   return amount.toLocaleString(locale, { maximumFractionDigits: 2 })
 }
+
+/**
+ * Options accepted by {@link formatNumber}.
+ */
+export interface FormatNumberOptions {
+  /**
+   * BCP 47 locale string (e.g. `'en-US'`, `'de-DE'`, `'ar-EG'`).
+   * Defaults to `'en-US'` when omitted.
+   */
+  locale?: string
+  /**
+   * `Intl.NumberFormat` style.
+   * - `'decimal'`  — plain number (default)
+   * - `'currency'` — with currency symbol; requires `currency`
+   * - `'percent'`  — multiplied by 100 with % sign
+   */
+  style?: 'decimal' | 'currency' | 'percent'
+  /**
+   * ISO 4217 currency code (e.g. `'USD'`, `'EUR'`).
+   * Required when `style = 'currency'`; ignored otherwise.
+   */
+  currency?: string
+  /**
+   * How the currency symbol is displayed.
+   * `'symbol'` (default) | `'narrowSymbol'` | `'code'` | `'name'`
+   */
+  currencyDisplay?: 'symbol' | 'narrowSymbol' | 'code' | 'name'
+  /** Minimum number of fraction digits. */
+  minimumFractionDigits?: number
+  /** Maximum number of fraction digits. */
+  maximumFractionDigits?: number
+  /** Minimum number of significant digits. */
+  minimumSignificantDigits?: number
+  /** Maximum number of significant digits. */
+  maximumSignificantDigits?: number
+}
+
+/**
+ * Locale-aware number formatting utility.
+ *
+ * Wraps `Intl.NumberFormat` and handles non-finite inputs gracefully,
+ * returning `'—'` rather than throwing or showing `NaN`/`Infinity`.
+ *
+ * This is the single formatting primitive consumed by `<FormattedNumber>`.
+ * Use this function directly when you only need the formatted string (e.g.
+ * for `aria-label` attributes or non-React contexts).
+ *
+ * @example
+ * formatNumber(1234.5)                                   // → "1,234.50"
+ * formatNumber(1234.5, { locale: 'de-DE' })              // → "1.234,50"
+ * formatNumber(1234.5, { locale: 'fr-FR' })              // → "1 234,50"
+ * formatNumber(0.125,  { style: 'percent' })             // → "12.50%"
+ * formatNumber(1234.5, { style: 'currency', currency: 'EUR', locale: 'de-DE' })
+ *                                                        // → "1.234,50 €"
+ * formatNumber(NaN)                                      // → "—"
+ * formatNumber(Infinity)                                 // → "—"
+ */
+export function formatNumber(
+  amount: number,
+  {
+    locale = 'en-US',
+    style = 'decimal',
+    currency,
+    currencyDisplay = 'symbol',
+    minimumFractionDigits = 2,
+    maximumFractionDigits = 2,
+    minimumSignificantDigits,
+    maximumSignificantDigits,
+  }: FormatNumberOptions = {}
+): string {
+  if (!Number.isFinite(amount)) return '—'
+
+  const options: Intl.NumberFormatOptions = {
+    style,
+    currencyDisplay,
+    // Only apply fraction digit constraints when significant digit constraints
+    // are NOT set — the two groups are mutually exclusive in Intl.NumberFormat.
+    ...(minimumSignificantDigits === undefined && maximumSignificantDigits === undefined
+      ? { minimumFractionDigits, maximumFractionDigits }
+      : {}),
+    ...(minimumSignificantDigits !== undefined ? { minimumSignificantDigits } : {}),
+    ...(maximumSignificantDigits !== undefined ? { maximumSignificantDigits } : {}),
+  }
+
+  if (style === 'currency') {
+    options.currency = currency ?? 'USD'
+  }
+
+  return new Intl.NumberFormat(locale, options).format(amount)
+}


### PR DESCRIPTION
…lity

Pr Closes #597 

- Add `formatNumber(value, options)` to `src/lib/format.ts` Wraps `Intl.NumberFormat`; returns '—' for non-finite inputs.
- Add `<FormattedNumber>` React component Reads locale from `i18next.language` by default; exposes `numberStyle`, `currency`, `currencyDisplay`, fraction/significant digit props, `ariaLabel`, and `srPrefix`.
- Add `src/config/numberFormat.ts` as single source of truth for default locale, currency, fraction-digit counts and placeholder.
- Add 40 unit tests covering the utility and component.
- Add 13 Storybook stories including a locale-comparison table.
- Update `docs/COMPONENTS.md` with full prop table and examples.
- Update `README.md` with feature section and project layout entry.
- Add `.github/workflows/ci.yml` CI workflow (format:check, lint, build, test) on push/PR to main.