### PR TITLE
docs(hooks): document useForwardRef helper

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -23,6 +23,7 @@ behavior notes, and a minimal usage example linking to source.
 - [Hooks (`src/hooks/`)](#hooks-srchooks)
   - [`useFocusTrap`](#usefocustrap)
   - [`useDocumentTitle`](#usedocumenttitle)
+  - [`useForwardRef`](#useforwardref)
   - [`useMediaQuery`](#usemediaquery)
   - [`useQuery`](#usequery)
   - [`useReducedMotion`](#usereducedmotion)
@@ -158,6 +159,77 @@ function Bond() {
   useDocumentTitle('Bond') // document.title === 'Bond · Credence'
   return <main>…</main>
 }
+```
+
+---
+
+### `useForwardRef`
+
+Source: [`src/hooks/useForwardRef.ts`](../src/hooks/useForwardRef.ts)
+
+```ts
+function useForwardRef<T>(
+  ref?: NestedRef<T>,
+  initialValue: T | null = null
+): MutableRefObject<T | null>
+
+// Also exported:
+setRef<T>(ref: NestedRef<T>, value: T | null): void
+
+type ReactRef<T> = ForwardedRef<T> | MutableRefObject<T | null> | null | undefined
+type NestedRef<T> = ReactRef<T> | NestedRef<T>[]
+```
+
+A custom hook that merges a local ref with external forwarded refs, solving the common
+wrapper-component pattern where a component needs both internal access to a DOM node and
+the ability to forward that node to a parent via `ref`, `React.forwardRef`, or a callback
+ref. Supports deeply nested arrays of refs and cleans up on unmount.
+
+**Parameters**
+
+| Parameter    | Required | Description                                                                  |
+| ------------ | :------: | ---------------------------------------------------------------------------- |
+| `ref`        |          | A single ref, callback ref, or nested array of refs to synchronise. Optional. |
+| `initialValue` |        | Initial value for the internal ref. Defaults to `null`.                      |
+
+**Returns** a `MutableRefObject<T | null>` that the component attaches to its DOM node via JSX `ref`.
+
+**Behavior notes**
+
+- **Ref merging:** any time the internal ref changes (inside a `useIsomorphicLayoutEffect`),
+  the value is propagated to every ref in the `ref` argument — object refs via `.current`,
+  callback refs via invocation, and arrays recursively.
+- **Cleanup:** on unmount, `null` is propagated to all provided refs, ensuring parent
+  components do not hold stale node references.
+- **Failing callbacks:** if a callback ref throws, the error is silently caught so that
+  other refs in the same array are still updated.
+- **Frozen/read-only objects:** assignments to read-only or frozen ref objects are
+  silently skipped.
+- **SSR-safe / cleanup:** uses `useLayoutEffect` in the browser and falls back to
+  `useEffect` during SSR; the cleanup function propagates `null` on unmount.
+
+```tsx
+import { forwardRef, type ReactNode } from 'react'
+import { useForwardRef } from '../hooks/useForwardRef'
+
+interface FancyInputProps {
+  label: string
+  children?: ReactNode
+}
+
+const FancyInput = forwardRef<HTMLInputElement, FancyInputProps>(
+  function FancyInput({ label, children }, forwardedRef) {
+    const internalRef = useForwardRef<HTMLInputElement>(forwardedRef)
+
+    return (
+      <label>
+        {label}
+        <input ref={internalRef} />
+        {children}
+      </label>
+    )
+  }
+)
 ```
 
 ---


### PR DESCRIPTION
## Summary

Documents the `useForwardRef` helper (and its co-exports `setRef`, `ReactRef`, `NestedRef`) in `docs/HOOKS.md`, following the existing entry pattern. The hook itself was already implemented and tested in #737 — only the documentation was missing.

## What changed

- `docs/HOOKS.md` — added `useForwardRef` to the Contents table of contents and a full reference section with signature, parameter table, behavior notes (SSR safety, cleanup, edge cases), and a usage example

## Key design decisions

- Placed alphabetically between `useDocumentTitle` and `useMediaQuery` in both the TOC and section ordering
- Mirrored the exact formatting conventions from neighboring entries (source link, `| Required |` table, `---` separator, ````tsx code blocks)
- Covered `setRef` and the type exports in the signature block, matching the `useDocumentTitle` precedent

## Acceptance criteria checklist

- [x] The change matches the summary (docs for the existing helper)
- [x] No regression — `useForwardRef` 10/10 tests pass
- [x] Documented in `docs/HOOKS.md`
- [x] Tests, lint, and typecheck all clean (pre-existing failures elsewhere, none from this change)
- [x] Closes #662

## Test output

```
✓ src/hooks/useForwardRef.test.tsx (10 tests) 45ms
Test Files  1 passed (1)
```

## Follow-ups

None — pure docs addition.

## Security note

No code, props, or API surface changed. Markdown only.

Closes #662