### PR TITLE
Fetch client

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -24,6 +24,7 @@ behavior notes, and a minimal usage example linking to source.
   - [`useFocusTrap`](#usefocustrap)
   - [`useDocumentTitle`](#usedocumenttitle)
   - [`useMediaQuery`](#usemediaquery)
+  - [`useApiQuery`](#useapiquery)
   - [`useQuery`](#usequery)
   - [`useReducedMotion`](#usereducedmotion)
   - [`useReducedTransparency`](#usereducedtransparency)
@@ -200,6 +201,82 @@ const isWide = useMediaQuery('(min-width: 1024px)')
 function ActivityCard() {
   const isMobile = useIsMobile()
   return <h2>{isMobile ? 'Recent Activity' : 'Recent Activity Timeline'}</h2>
+}
+```
+
+---
+
+### `useApiQuery`
+
+Source: [`src/hooks/useApiQuery.ts`](../src/hooks/useApiQuery.ts) · Built on [`apiFetch`](../src/api/client.ts)
+
+```ts
+function useApiQuery<T>(
+  path: string,
+  options?: UseApiQueryOptions,
+): UseApiQueryResult<T>
+
+interface UseApiQueryOptions {
+  enabled?: boolean     // default: true
+  staleTimeMs?: number  // default: WIDGET_CACHE_DEFAULTS.STALE_TIME_MS (30 000)
+}
+
+interface UseApiQueryResult<T> {
+  data: T | undefined
+  isLoading: boolean
+  error: ApiError | null
+  isStale: boolean
+  refetch: () => Promise<void>
+}
+
+// Also exported: invalidateApiQuery(path), clearApiQueryCache()
+```
+
+Type-safe, cache-aware wrapper around `apiFetch` for GET requests. Caches responses keyed by API path and serves cached data within the configured `staleTime`. Abolishes the repetitive abort-controller / mounted-ref boilerplate that domain hooks (`useTrustScore`, `useTransactions`) currently manage by hand.
+
+**Parameters**
+
+| Option        | Required | Description                                                                  |
+| ------------- | :------: | ---------------------------------------------------------------------------- |
+| `path`        |    ✓     | API path passed to `apiFetch` (e.g. `'/trust-score/GABC…'`).               |
+| `enabled`     |          | Set `false` to skip the initial fetch. Default `true`.                      |
+| `staleTimeMs` |          | Time in ms before cached data is considered stale. Default `30 000`.        |
+
+**Behavior notes**
+
+- **Cache:** in-memory `Map` keyed by `path`. Cached data is served synchronously on mount (no loading flash). Cache entries are shared across all hook instances — mounting a second component with the same path reuses the cached result.
+- **Stale-while-revalidate:** when data is within `staleTimeMs`, the hook returns it directly and skips the network call. `refetch()` always bypasses stale-time checks and hits the network.
+- **`isStale`:** set to `true` when the current `data` is older than `staleTimeMs`. Useful for showing a subtle "refreshing" indicator without a full loading spinner.
+- **Abort safety:** in-flight requests are aborted when the component unmounts or when `refetch()` is called again (superseded). Stale responses and `AbortError`s are silently discarded.
+- **Offline-safe:** when `navigator.onLine` is `false`, the hook skips the fetch and sets `isLoading: false`.
+- **Race-condition protection:** run IDs guarantee only the latest triggered fetch updates component state.
+- **Manual invalidation:** call `invalidateApiQuery(path)` to evict a single entry (the next mount/refetch will re-fetch). Call `clearApiQueryCache()` to wipe everything (useful in tests).
+- **SSR-safe / cleanup:** all DOM/navigator checks are guarded; the active `AbortController` is aborted on unmount.
+
+```tsx
+import { useApiQuery } from '../hooks/useApiQuery'
+import type { TrustScore } from '../api/types'
+
+function TrustScoreCard({ address }: { address: string }) {
+  const { data, isLoading, error, isStale, refetch } = useApiQuery<TrustScore>(
+    `/trust-score/${address}`,
+  )
+
+  if (isLoading) return <p>Loading…</p>
+  if (error) {
+    return (
+      <p role="alert">
+        {error.message} <button onClick={refetch}>Retry</button>
+      </p>
+    )
+  }
+
+  return (
+    <div>
+      {isStale && <span className="stale-badge">Refreshing…</span>}
+      <p>Score: {data?.score}</p>
+    </div>
+  )
 }
 ```
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -23,6 +23,7 @@ Related focused docs: [button system](./button-system.md), [notifications](./not
 | TierLadder             | `src/components/TierLadder.css` + `Badge.css`                                       | None.                                                                                                                     |
 | ActivityTimeline       | `src/components/ActivityTimeline.css` + EmptyState inline styles for empty fallback | Empty fallback inherits `EmptyState` inline styles; migrate with states components.                                       |
 | FormField              | `src/components/forms/FormField.css`                                                | None.                                                                                                                     |
+| FilePicker             | `src/components/FilePicker.css` + `FormField.css`                                   | None.                                                                                                                     |
 | controls/Select        | `src/components/controls/controls.css`                                              | None.                                                                                                                     |
 | controls/Toggle        | `src/components/controls/controls.css`                                              | None.                                                                                                                     |
 | states/EmptyState      | Inline styles in `src/components/states/EmptyState.tsx`                             | Owns inline styles and should be migrated to CSS.                                                                         |
@@ -365,6 +366,47 @@ Tokens: `--credence-color-danger-text`, `--credence-font-size-sm`, `--credence-f
 ```
 
 Storybook: `Components/Forms/FormField` — **Default** · **WithHint** · **WithError** · **WithHintAndError**.
+
+## FilePicker
+
+Source: [`src/components/FilePicker.tsx`](../src/components/FilePicker.tsx).
+
+| Prop           | Type                          | Default                                  |
+| -------------- | ----------------------------- | ---------------------------------------- |
+| `id`           | `string`                      | Auto-generated                           |
+| `label`        | `string`                      | `'Upload files'`                         |
+| `hint`         | `string`                      | `undefined`                              |
+| `error`        | `string`                      | `undefined`                              |
+| `files`        | `File[]`                      | Required                                 |
+| `onChange`     | `(files: File[]) => void`     | Required                                 |
+| `accept`       | `string`                      | `undefined`                              |
+| `multiple`     | `boolean`                     | `false`                                  |
+| `disabled`     | `boolean`                     | `false`                                  |
+| `required`     | `boolean`                     | `false`                                  |
+| `maxSizeBytes` | `number`                      | `undefined`                              |
+| `className`    | `string`                      | `''`                                     |
+| `title`        | `string`                      | Context-sensitive drag-and-drop prompt   |
+| `dropHint`     | `string`                      | Accept format hint                       |
+| `ariaLabel`    | `string`                      | `undefined`                              |
+
+Accessibility: renders a dropzone with `role="button"`, `aria-roledescription="file drop zone"`, keyboard activation via Space/Enter, and `aria-controls` linking to live announcement regions. Drag state changes are announced via `aria-live="polite"` regions. File additions and rejections trigger screen-reader announcements. The dropzone is linked to `FormField` for label, hint, and error display. Hidden native `<input type="file">` is `aria-hidden` and focus is managed via the dropzone. File list items include remove buttons with descriptive `aria-label` attributes. Keyboard instructions are provided via sr-only text. Supports `prefers-reduced-motion` and dark mode.
+
+Tokens: border, danger, info, primary, slate, focus, font, line-height, motion, radius, spacing, surface, and text tokens.
+
+```tsx
+<FilePicker
+  id="evidence"
+  label="Upload evidence"
+  files={files}
+  onChange={setFiles}
+  accept=".pdf,image/*"
+  multiple
+  maxSizeBytes={10 * 1024 * 1024}
+  hint="PDF or images. Max 10 MB per file."
+/>
+```
+
+Storybook: `Components/Forms/FilePicker` — **Default** · **SingleFile** · **MultipleFiles** · **WithFiles** · **WithError** · **Disabled** · **DisabledWithFiles** · **WithSizeLimit** · **Required** · **DragActivePreview**.
 
 ## controls/Select
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -107,6 +107,7 @@
       "version": "7.29.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -434,6 +435,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -455,6 +457,432 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": ">=18"
       }
@@ -844,6 +1272,328 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.62.2",
@@ -1347,6 +2097,7 @@
       "version": "10.4.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -1591,6 +2342,7 @@
       "version": "26.1.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~8.3.0"
       }
@@ -1604,6 +2356,7 @@
       "version": "18.3.31",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -1613,6 +2366,7 @@
       "version": "18.3.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -1666,6 +2420,7 @@
       "version": "8.65.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -2051,6 +2806,7 @@
       "version": "8.17.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2649,6 +3405,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2718,6 +3475,7 @@
       "version": "10.8.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -3026,6 +3784,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "dev": true,
@@ -3283,6 +4056,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }
@@ -3608,6 +4382,7 @@
       "version": "26.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -4168,6 +4943,7 @@
       "version": "3.9.6",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4229,6 +5005,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -4267,6 +5044,7 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -4407,6 +5185,7 @@
       "version": "4.62.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -4603,6 +5382,7 @@
       "version": "8.6.18",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/core": "8.6.18"
       },
@@ -4951,6 +5731,7 @@
       "version": "5.2.2",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5074,6 +5855,7 @@
       "version": "5.4.21",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -5149,6 +5931,380 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/vite/node_modules/@esbuild/win32-x64": {
       "version": "0.21.5",
       "cpu": [
@@ -5201,10 +6357,26 @@
         "@esbuild/win32-x64": "0.21.5"
       }
     },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/vitest": {
       "version": "2.1.9",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",

--- a/src/components/FilePicker.css
+++ b/src/components/FilePicker.css
@@ -1,0 +1,192 @@
+.file-picker-wrapper {
+  display: grid;
+  gap: var(--credence-space-3);
+  width: 100%;
+}
+
+.file-picker-dropzone {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--credence-space-3);
+  padding: var(--credence-space-8) var(--credence-space-4);
+  border: 2px dashed var(--credence-border-default);
+  border-radius: var(--credence-radius-lg);
+  background-color: var(--credence-surface-card);
+  cursor: pointer;
+  text-align: center;
+  transition:
+    border-color var(--credence-motion-duration-fast) var(--credence-motion-easing-standard),
+    background-color var(--credence-motion-duration-fast) var(--credence-motion-easing-standard);
+}
+
+.file-picker-dropzone:hover:not([aria-disabled='true']) {
+  border-color: var(--credence-color-primary);
+  background-color: var(--credence-color-info-surface);
+}
+
+.file-picker-dropzone:focus-visible {
+  outline: var(--credence-focus-ring);
+  outline-offset: 2px;
+}
+
+.file-picker-dropzone[data-dragover='true'] {
+  border-color: var(--credence-color-primary);
+  background-color: var(--credence-color-info-surface);
+  border-style: solid;
+  transform: scale(1.01);
+}
+
+.file-picker-dropzone[aria-disabled='true'] {
+  opacity: 0.6;
+  cursor: not-allowed;
+  background-color: var(--credence-color-slate-50);
+}
+
+[data-theme='dark'] .file-picker-dropzone[aria-disabled='true'] {
+  background-color: var(--credence-color-slate-700);
+}
+
+.file-picker-dropzone[data-invalid='true'] {
+  border-color: var(--credence-color-danger-border);
+}
+
+.file-picker-icon {
+  width: 48px;
+  height: 48px;
+  color: var(--credence-text-secondary);
+  flex-shrink: 0;
+}
+
+.file-picker-dropzone[data-dragover='true'] .file-picker-icon {
+  color: var(--credence-color-primary);
+}
+
+.file-picker-text {
+  display: grid;
+  gap: var(--credence-space-1);
+}
+
+.file-picker-title {
+  font-size: var(--credence-font-size-base);
+  font-weight: var(--credence-font-weight-semibold);
+  color: var(--credence-text-primary);
+}
+
+.file-picker-hint {
+  font-size: var(--credence-font-size-sm);
+  color: var(--credence-text-secondary);
+}
+
+.file-picker-kbd {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px var(--credence-space-2);
+  font-size: var(--credence-font-size-xs);
+  font-family: inherit;
+  border: 1px solid var(--credence-border-default);
+  border-radius: var(--credence-radius-sm);
+  background-color: var(--credence-surface-page);
+  color: var(--credence-text-secondary);
+}
+
+.file-picker-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.file-picker-file-list {
+  display: grid;
+  gap: var(--credence-space-2);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.file-picker-file-item {
+  display: flex;
+  align-items: center;
+  gap: var(--credence-space-3);
+  padding: var(--credence-space-3) var(--credence-space-4);
+  background-color: var(--credence-surface-card);
+  border: 1px solid var(--credence-border-default);
+  border-radius: var(--credence-radius-md);
+}
+
+.file-picker-file-icon {
+  width: 20px;
+  height: 20px;
+  color: var(--credence-text-secondary);
+  flex-shrink: 0;
+}
+
+.file-picker-file-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.file-picker-file-name {
+  font-size: var(--credence-font-size-sm);
+  font-weight: var(--credence-font-weight-semibold);
+  color: var(--credence-text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.file-picker-file-meta {
+  font-size: var(--credence-font-size-xs);
+  color: var(--credence-text-secondary);
+}
+
+.file-picker-file-remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid var(--credence-border-default);
+  border-radius: var(--credence-radius-sm);
+  background-color: var(--credence-surface-page);
+  color: var(--credence-text-secondary);
+  cursor: pointer;
+  flex-shrink: 0;
+  transition:
+    border-color var(--credence-motion-duration-instant) var(--credence-motion-easing-standard),
+    background-color var(--credence-motion-duration-instant) var(--credence-motion-easing-standard),
+    color var(--credence-motion-duration-instant) var(--credence-motion-easing-standard);
+}
+
+.file-picker-file-remove:hover:not(:disabled) {
+  border-color: var(--credence-color-danger-border);
+  background-color: var(--credence-color-danger-surface);
+  color: var(--credence-color-danger-text);
+}
+
+.file-picker-file-remove:focus-visible {
+  outline: var(--credence-focus-ring);
+  outline-offset: 2px;
+}
+
+.file-picker-file-remove:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.file-picker-file-remove-icon {
+  width: 16px;
+  height: 16px;
+}

--- a/src/components/FilePicker.stories.tsx
+++ b/src/components/FilePicker.stories.tsx
@@ -1,0 +1,139 @@
+import React, { useState } from 'react'
+import type { Meta, StoryObj } from '@storybook/react'
+import FilePicker from './FilePicker'
+
+function FilePickerWithState(args: React.ComponentProps<typeof FilePicker>) {
+  const [files, setFiles] = useState<File[]>(args.files || [])
+  return <FilePicker {...args} files={files} onChange={setFiles} />
+}
+
+const meta: Meta<typeof FilePicker> = {
+  title: 'Components/Forms/FilePicker',
+  component: FilePicker,
+  tags: ['autodocs'],
+  argTypes: {
+    onChange: { action: 'changed' },
+  },
+  args: {
+    id: 'file-picker',
+    label: 'Upload evidence',
+    files: [],
+  },
+  render: (args) => <FilePickerWithState {...args} />,
+}
+
+export default meta
+type Story = StoryObj<typeof FilePicker>
+
+export const Default: Story = {
+  args: {
+    files: [],
+    hint: 'Upload supporting documents for your attestation.',
+  },
+}
+
+export const SingleFile: Story = {
+  args: {
+    label: 'Upload document',
+    multiple: false,
+    accept: '.pdf,.doc,.docx',
+    hint: 'PDF, DOC, or DOCX format. Max 10 MB.',
+  },
+}
+
+export const MultipleFiles: Story = {
+  args: {
+    label: 'Upload attachments',
+    multiple: true,
+    accept: 'image/*,.pdf',
+    hint: 'Images or PDFs. Up to 5 files, 10 MB each.',
+  },
+}
+
+export const WithFiles: Story = {
+  args: {
+    label: 'Upload attachments',
+    multiple: true,
+    accept: 'image/*,.pdf',
+    files: [
+      new File(['pdf-content'], 'evidence-report.pdf', { type: 'application/pdf', lastModified: 1700000000000 }),
+      new File(['img-content'], 'screenshot.png', { type: 'image/png', lastModified: 1700000001000 }),
+    ],
+    hint: 'Images or PDFs. Up to 5 files, 10 MB each.',
+  },
+}
+
+export const WithError: Story = {
+  args: {
+    label: 'Upload evidence',
+    error: 'Please select a PDF file before continuing.',
+    hint: 'PDF format required. Max 10 MB.',
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    label: 'Upload evidence',
+    disabled: true,
+    hint: 'Uploads are disabled while processing.',
+  },
+}
+
+export const DisabledWithFiles: Story = {
+  args: {
+    label: 'Upload attachments',
+    multiple: true,
+    disabled: true,
+    files: [
+      new File(['pdf-content'], 'evidence-report.pdf', { type: 'application/pdf', lastModified: 1700000000000 }),
+    ],
+    hint: 'Uploads are locked after submission.',
+  },
+}
+
+export const WithSizeLimit: Story = {
+  args: {
+    label: 'Upload profile image',
+    multiple: false,
+    accept: 'image/*',
+    maxSizeBytes: 2 * 1024 * 1024,
+    hint: 'Image files only. Max 2 MB.',
+  },
+}
+
+export const Required: Story = {
+  args: {
+    label: 'Proof of identity',
+    required: true,
+    accept: '.pdf,image/*',
+    hint: 'A valid photo ID or passport scan is required.',
+  },
+}
+
+function FilePickerDragActiveDemo() {
+  const [files, setFiles] = useState<File[]>([])
+  return (
+    <FilePicker
+      id="drag-active-demo"
+      label="Upload evidence"
+      files={files}
+      onChange={setFiles}
+      accept=".pdf,image/*"
+      multiple
+      hint="Drag a file over the drop zone to see the active state. Press Space or Enter to browse."
+    />
+  )
+}
+
+export const DragActivePreview: Story = {
+  name: 'Drag Active (Visual Preview)',
+  render: () => <FilePickerDragActiveDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'This story shows the file picker with accept restrictions. The drag-active visual state (border solid, subtle scale) is triggered by the HTML5 Drag and Drop API and announced to screen readers via a live region.',
+      },
+    },
+  },
+}

--- a/src/components/FilePicker.test.tsx
+++ b/src/components/FilePicker.test.tsx
@@ -1,0 +1,646 @@
+import React, { useState } from 'react'
+import { render, screen, act, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import FilePicker from './FilePicker'
+
+function makeFile(name: string, size: number, type: string): File {
+  const file = new File([new ArrayBuffer(size)], name, { type })
+  Object.defineProperty(file, 'size', { value: size })
+  return file
+}
+
+function FilePickerWithState(props: Partial<React.ComponentProps<typeof FilePicker>>) {
+  const [files, setFiles] = useState<File[]>([])
+  return <FilePicker id="test-picker" label="Test picker" files={files} onChange={setFiles} {...props} />
+}
+
+function makeDragEvent(files: File[]): Partial<React.DragEvent> {
+  const dataTransfer = {
+    items: files.map(() => ({ kind: 'file' })),
+    files,
+    clearData: vi.fn(),
+    types: ['Files'],
+  }
+  return {
+    dataTransfer: dataTransfer as unknown as DataTransfer,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  }
+}
+
+describe('FilePicker', () => {
+  describe('rendering', () => {
+    it('renders the dropzone with the correct label', () => {
+      render(<FilePickerWithState label="Upload evidence" />)
+      expect(screen.getByText('Upload evidence')).toBeInTheDocument()
+    })
+
+    it('renders the default title when no title prop is given for single file', () => {
+      render(<FilePickerWithState multiple={false} />)
+      expect(
+        screen.getByText('Drag and drop a file here, or click to browse'),
+      ).toBeInTheDocument()
+    })
+
+    it('renders the default title when no title prop is given for multiple files', () => {
+      render(<FilePickerWithState multiple={true} />)
+      expect(
+        screen.getByText('Drag and drop files here, or click to browse'),
+      ).toBeInTheDocument()
+    })
+
+    it('renders a custom title when provided', () => {
+      render(<FilePickerWithState title="Drop your receipts" />)
+      expect(screen.getByText('Drop your receipts')).toBeInTheDocument()
+    })
+
+    it('renders hint text', () => {
+      render(<FilePickerWithState hint="PDF or images only" />)
+      expect(screen.getByText('PDF or images only')).toBeInTheDocument()
+    })
+
+    it('renders error text with alert role', () => {
+      render(<FilePickerWithState error="Please select a file" />)
+      const errorEl = screen.getByRole('alert')
+      expect(errorEl).toHaveTextContent('Please select a file')
+    })
+
+    it('marks dropzone as aria-disabled when disabled is true', () => {
+      render(<FilePickerWithState disabled={true} />)
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      expect(dropzone).toHaveAttribute('aria-disabled', 'true')
+    })
+
+    it('sets aria-required on the dropzone when required is true', () => {
+      render(<FilePickerWithState required={true} />)
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      expect(dropzone).toHaveAttribute('aria-required', 'true')
+    })
+
+    it('sets aria-invalid on the dropzone when there is an error', () => {
+      render(<FilePickerWithState error="Something went wrong" />)
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      expect(dropzone).toHaveAttribute('aria-invalid', 'true')
+    })
+
+    it('includes polite live regions for announcements', () => {
+      render(<FilePickerWithState />)
+      const liveRegions = screen.getAllByRole('status')
+      expect(liveRegions.length).toBeGreaterThanOrEqual(1)
+      liveRegions.forEach((live) => {
+        expect(live).toHaveAttribute('aria-live', 'polite')
+      })
+    })
+
+    it('renders the file list with count aria-label when files exist', () => {
+      const files = [makeFile('report.pdf', 1024, 'application/pdf')]
+      render(<FilePickerWithState files={files} />)
+      const list = screen.getByTestId('file-picker-file-list')
+      expect(list).toHaveAttribute('aria-label', 'Selected files, 1 item')
+    })
+  })
+
+  describe('keyboard interaction', () => {
+    it('is reachable via Tab key (dropzone has tabIndex=0)', () => {
+      render(<FilePickerWithState />)
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      expect(dropzone).toHaveAttribute('tabindex', '0')
+    })
+
+    it('has tabindex=-1 when disabled', () => {
+      render(<FilePickerWithState disabled={true} />)
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      expect(dropzone).toHaveAttribute('tabindex', '-1')
+    })
+
+    it('opens the file dialog when Enter is pressed', async () => {
+      const user = userEvent.setup()
+      render(<FilePickerWithState />)
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      const input = screen.getByTestId('file-picker-input') as HTMLInputElement
+      const clickSpy = vi.spyOn(input, 'click')
+      await act(async () => {
+        await user.type(dropzone, '{Enter}')
+      })
+      expect(clickSpy).toHaveBeenCalled()
+    })
+
+    it('opens the file dialog when Space is pressed', async () => {
+      const user = userEvent.setup()
+      render(<FilePickerWithState />)
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      const input = screen.getByTestId('file-picker-input') as HTMLInputElement
+      const clickSpy = vi.spyOn(input, 'click')
+      await act(async () => {
+        fireEvent.focus(dropzone)
+        fireEvent.keyDown(dropzone, { key: ' ' })
+      })
+      expect(clickSpy).toHaveBeenCalled()
+    })
+
+    it('does not open the file dialog on Enter when disabled', async () => {
+      const user = userEvent.setup()
+      render(<FilePickerWithState disabled={true} />)
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      const input = screen.getByTestId('file-picker-input') as HTMLInputElement
+      const clickSpy = vi.spyOn(input, 'click')
+      await act(async () => {
+        fireEvent.keyDown(dropzone, { key: 'Enter' })
+      })
+      expect(clickSpy).not.toHaveBeenCalled()
+    })
+
+    it('remove button is reachable and operable by keyboard', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+      const files = [makeFile('report.pdf', 1024, 'application/pdf')]
+      render(
+        <FilePicker
+          id="rp"
+          label="R"
+          files={files}
+          onChange={onChange}
+        />,
+      )
+      const removeBtn = screen.getByTestId('file-picker-remove-button-0')
+      expect(removeBtn).toHaveAttribute('type', 'button')
+      await act(async () => {
+        await user.click(removeBtn)
+      })
+      expect(onChange).toHaveBeenCalledWith([])
+    })
+  })
+
+  describe('file selection via input', () => {
+    it('calls onChange with a single file when multiple=false', () => {
+      const onChange = vi.fn()
+      const files: File[] = []
+      render(
+        <FilePicker
+          id="sp"
+          label="Single"
+          multiple={false}
+          files={files}
+          onChange={onChange}
+        />,
+      )
+      const fileA = makeFile('a.pdf', 500, 'application/pdf')
+      const fileB = makeFile('b.pdf', 600, 'application/pdf')
+      const input = screen.getByTestId('file-picker-input') as HTMLInputElement
+      const dataTransfer = new DataTransfer()
+      dataTransfer.items.add(fileA)
+      dataTransfer.items.add(fileB)
+      input.files = dataTransfer.files
+      fireEvent.change(input)
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange.mock.calls[0][0]).toHaveLength(1)
+      expect(onChange.mock.calls[0][0][0].name).toBe('a.pdf')
+    })
+
+    it('appends files when multiple=true', () => {
+      const onChange = vi.fn()
+      const existing = [makeFile('prev.pdf', 100, 'application/pdf')]
+      render(
+        <FilePicker
+          id="mp"
+          label="Multi"
+          multiple={true}
+          files={existing}
+          onChange={onChange}
+        />,
+      )
+      const newFile = makeFile('next.pdf', 200, 'application/pdf')
+      const input = screen.getByTestId('file-picker-input') as HTMLInputElement
+      const dataTransfer = new DataTransfer()
+      dataTransfer.items.add(newFile)
+      input.files = dataTransfer.files
+      fireEvent.change(input)
+      expect(onChange).toHaveBeenCalledTimes(1)
+      const result = onChange.mock.calls[0][0] as File[]
+      expect(result).toHaveLength(2)
+      expect(result[0].name).toBe('prev.pdf')
+      expect(result[1].name).toBe('next.pdf')
+    })
+
+    it('deduplicates by file name in multiple mode', () => {
+      const onChange = vi.fn()
+      const existing = [makeFile('dup.pdf', 100, 'application/pdf')]
+      render(
+        <FilePicker
+          id="dp"
+          label="Dup"
+          multiple={true}
+          files={existing}
+          onChange={onChange}
+        />,
+      )
+      const dupFile = makeFile('dup.pdf', 999, 'application/pdf')
+      const input = screen.getByTestId('file-picker-input') as HTMLInputElement
+      const dataTransfer = new DataTransfer()
+      dataTransfer.items.add(dupFile)
+      input.files = dataTransfer.files
+      fireEvent.change(input)
+      expect(onChange).toHaveBeenCalledWith(existing)
+    })
+
+    it('filters files by accept type (extension)', () => {
+      const onChange = vi.fn()
+      render(
+        <FilePicker
+          id="ap"
+          label="Accept"
+          multiple={true}
+          accept=".pdf"
+          files={[]}
+          onChange={onChange}
+        />,
+      )
+      const pdf = makeFile('ok.pdf', 100, 'application/pdf')
+      const txt = makeFile('bad.txt', 100, 'text/plain')
+      const input = screen.getByTestId('file-picker-input') as HTMLInputElement
+      const dataTransfer = new DataTransfer()
+      dataTransfer.items.add(pdf)
+      dataTransfer.items.add(txt)
+      input.files = dataTransfer.files
+      fireEvent.change(input)
+      const result = onChange.mock.calls[0][0] as File[]
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('ok.pdf')
+    })
+
+    it('filters files by accept type (mime wildcard image/*)', () => {
+      const onChange = vi.fn()
+      render(
+        <FilePicker
+          id="ap2"
+          label="Accept2"
+          multiple={true}
+          accept="image/*"
+          files={[]}
+          onChange={onChange}
+        />,
+      )
+      const png = makeFile('ok.png', 100, 'image/png')
+      const pdf = makeFile('bad.pdf', 100, 'application/pdf')
+      const input = screen.getByTestId('file-picker-input') as HTMLInputElement
+      const dataTransfer = new DataTransfer()
+      dataTransfer.items.add(png)
+      dataTransfer.items.add(pdf)
+      input.files = dataTransfer.files
+      fireEvent.change(input)
+      const result = onChange.mock.calls[0][0] as File[]
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('ok.png')
+    })
+
+    it('filters files by maxSizeBytes', () => {
+      const onChange = vi.fn()
+      render(
+        <FilePicker
+          id="sz"
+          label="Size"
+          maxSizeBytes={500}
+          files={[]}
+          onChange={onChange}
+        />,
+      )
+      const small = makeFile('small.pdf', 100, 'application/pdf')
+      const big = makeFile('big.pdf', 9999, 'application/pdf')
+      const input = screen.getByTestId('file-picker-input') as HTMLInputElement
+      const dataTransfer = new DataTransfer()
+      dataTransfer.items.add(small)
+      dataTransfer.items.add(big)
+      input.files = dataTransfer.files
+      fireEvent.change(input)
+      const result = onChange.mock.calls[0][0] as File[]
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('small.pdf')
+    })
+
+    it('does not call onChange when all files are filtered out', () => {
+      const onChange = vi.fn()
+      render(
+        <FilePicker
+          id="nf"
+          label="No"
+          accept=".pdf"
+          files={[]}
+          onChange={onChange}
+        />,
+      )
+      const txt = makeFile('bad.txt', 100, 'text/plain')
+      const input = screen.getByTestId('file-picker-input') as HTMLInputElement
+      const dataTransfer = new DataTransfer()
+      dataTransfer.items.add(txt)
+      input.files = dataTransfer.files
+      fireEvent.change(input)
+      expect(onChange).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('drag and drop', () => {
+    it('sets data-dragover=true on dragenter with files', () => {
+      render(<FilePickerWithState />)
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      expect(dropzone).toHaveAttribute('data-dragover', 'false')
+      act(() => {
+        fireEvent.dragEnter(dropzone, makeDragEvent([makeFile('a.pdf', 1, 'application/pdf')]))
+      })
+      expect(dropzone).toHaveAttribute('data-dragover', 'true')
+    })
+
+    it('clears data-dragover after dragleave balancing nested events', () => {
+      render(<FilePickerWithState />)
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      act(() => {
+        fireEvent.dragEnter(dropzone, makeDragEvent([makeFile('a.pdf', 1, 'application/pdf')]))
+        fireEvent.dragEnter(dropzone, makeDragEvent([makeFile('a.pdf', 1, 'application/pdf')]))
+        fireEvent.dragLeave(dropzone)
+      })
+      expect(dropzone).toHaveAttribute('data-dragover', 'true')
+      act(() => {
+        fireEvent.dragLeave(dropzone)
+      })
+      expect(dropzone).toHaveAttribute('data-dragover', 'false')
+    })
+
+    it('calls onChange with files on drop', () => {
+      const onChange = vi.fn()
+      render(
+        <FilePicker
+          id="dr"
+          label="Drop"
+          multiple={true}
+          files={[]}
+          onChange={onChange}
+        />,
+      )
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      const file = makeFile('dropped.pdf', 500, 'application/pdf')
+      act(() => {
+        fireEvent.drop(dropzone, makeDragEvent([file]))
+      })
+      expect(onChange).toHaveBeenCalledTimes(1)
+      const result = onChange.mock.calls[0][0] as File[]
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('dropped.pdf')
+    })
+
+    it('does not call onChange on drop when disabled', () => {
+      const onChange = vi.fn()
+      render(
+        <FilePicker
+          id="dd"
+          label="DD"
+          disabled={true}
+          files={[]}
+          onChange={onChange}
+        />,
+      )
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      const file = makeFile('blocked.pdf', 500, 'application/pdf')
+      act(() => {
+        fireEvent.drop(dropzone, makeDragEvent([file]))
+      })
+      expect(onChange).not.toHaveBeenCalled()
+    })
+
+    it('applies accept filter on drop', () => {
+      const onChange = vi.fn()
+      render(
+        <FilePicker
+          id="da"
+          label="DA"
+          accept="image/*"
+          multiple={true}
+          files={[]}
+          onChange={onChange}
+        />,
+      )
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      const png = makeFile('ok.png', 100, 'image/png')
+      const pdf = makeFile('bad.pdf', 100, 'application/pdf')
+      act(() => {
+        fireEvent.drop(dropzone, makeDragEvent([png, pdf]))
+      })
+      const result = onChange.mock.calls[0][0] as File[]
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('ok.png')
+    })
+  })
+
+  describe('file list management', () => {
+    it('renders each file with name and formatted size', () => {
+      const files = [
+        makeFile('report.pdf', 2.5 * 1024 * 1024, 'application/pdf'),
+        makeFile('tiny.txt', 512, 'text/plain'),
+      ]
+      render(
+        <FilePicker id="list" label="List" files={files} onChange={vi.fn()} />,
+      )
+      expect(screen.getByText('report.pdf')).toBeInTheDocument()
+      expect(screen.getByText('2.5 MB')).toBeInTheDocument()
+      expect(screen.getByText('tiny.txt')).toBeInTheDocument()
+      expect(screen.getByText('512 B')).toBeInTheDocument()
+    })
+
+    it('renders KB and GB boundaries correctly', () => {
+      const files = [
+        makeFile('a', 2048, 'x'),
+        makeFile('b', 1.5 * 1024 * 1024 * 1024, 'x'),
+      ]
+      render(<FilePicker id="fmt" label="Fmt" files={files} onChange={vi.fn()} />)
+      expect(screen.getByText('2.0 KB')).toBeInTheDocument()
+      expect(screen.getByText('1.5 GB')).toBeInTheDocument()
+    })
+
+    it('removes the correct file by index', () => {
+      const onChange = vi.fn()
+      const files = [
+        makeFile('first.pdf', 1, 'application/pdf'),
+        makeFile('second.pdf', 2, 'application/pdf'),
+      ]
+      render(<FilePicker id="rm" label="Rm" files={files} onChange={onChange} />)
+      const removeFirst = screen.getByTestId('file-picker-remove-button-0')
+      fireEvent.click(removeFirst)
+      expect(onChange).toHaveBeenCalledTimes(1)
+      const result = onChange.mock.calls[0][0] as File[]
+      expect(result).toHaveLength(1)
+      expect(result[0].name).toBe('second.pdf')
+    })
+
+    it('remove buttons respect disabled state', () => {
+      const onChange = vi.fn()
+      const files = [makeFile('stuck.pdf', 100, 'application/pdf')]
+      render(
+        <FilePicker id="rd" label="Rd" disabled={true} files={files} onChange={onChange} />,
+      )
+      const btn = screen.getByTestId('file-picker-remove-button-0')
+      expect(btn).toBeDisabled()
+      fireEvent.click(btn)
+      expect(onChange).not.toHaveBeenCalled()
+    })
+
+    it('remove button has an aria-label describing which file it removes', () => {
+      const files = [makeFile('contract.pdf', 1, 'application/pdf')]
+      render(<FilePicker id="ra" label="Ra" files={files} onChange={vi.fn()} />)
+      const btn = screen.getByTestId('file-picker-remove-button-0')
+      expect(btn).toHaveAttribute('aria-label', 'Remove contract.pdf')
+    })
+  })
+
+  describe('accessibility attributes', () => {
+    it('wires FormField ids through to dropzone aria-describedby', () => {
+      render(<FilePickerWithState id="fp" hint="Some hint" error="Some error" />)
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      const described = dropzone.getAttribute('aria-describedby')
+      expect(described).toContain('fp-hint')
+      expect(described).toContain('fp-error')
+    })
+
+    it('dropzone has role=button', () => {
+      render(<FilePickerWithState />)
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      expect(dropzone.tagName.toLowerCase()).toBe('div')
+      expect(dropzone).toHaveAttribute('role', 'button')
+    })
+
+    it('decorative icons are aria-hidden', () => {
+      render(<FilePickerWithState />)
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      const svgs = dropzone.querySelectorAll('svg')
+      svgs.forEach((svg) => {
+        expect(svg).toHaveAttribute('aria-hidden', 'true')
+      })
+    })
+
+    it('the hidden native file input is aria-hidden and tabbable via dropzone only', () => {
+      render(<FilePickerWithState />)
+      const input = screen.getByTestId('file-picker-input')
+      expect(input).toHaveAttribute('aria-hidden', 'true')
+      expect(input).toHaveAttribute('tabindex', '-1')
+      expect(input).toHaveAttribute('type', 'file')
+    })
+
+    it('dropzone has aria-roledescription describing its purpose', () => {
+      render(<FilePickerWithState />)
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      expect(dropzone).toHaveAttribute('aria-roledescription', 'file drop zone')
+    })
+
+    it('includes a second live region for drag announcements', () => {
+      render(<FilePickerWithState />)
+      const liveRegions = screen.getAllByRole('status')
+      expect(liveRegions).toHaveLength(2)
+      const dragRegion = liveRegions.find((el) => el.id.includes('drag-announce'))
+      expect(dragRegion).toBeDefined()
+      expect(dragRegion).toHaveAttribute('aria-live', 'polite')
+    })
+
+    it('dropzone includes keyboard instruction in sr-only text', () => {
+      render(<FilePickerWithState />)
+      expect(screen.getByText('Press Space or Enter to browse files.')).toBeInTheDocument()
+    })
+  })
+
+  describe('drag announcements', () => {
+    it('announces files detected on dragenter', () => {
+      render(<FilePickerWithState />)
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      act(() => {
+        fireEvent.dragEnter(dropzone, makeDragEvent([makeFile('a.pdf', 1, 'application/pdf')]))
+      })
+      const liveRegions = screen.getAllByRole('status')
+      const dragRegion = liveRegions.find((el) => el.id.includes('drag-announce'))
+      expect(dragRegion).toHaveTextContent('Files detected. Drop to add files.')
+    })
+
+    it('clears drag announcement on dragleave', () => {
+      render(<FilePickerWithState />)
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      act(() => {
+        fireEvent.dragEnter(dropzone, makeDragEvent([makeFile('a.pdf', 1, 'application/pdf')]))
+        fireEvent.dragLeave(dropzone)
+      })
+      const liveRegions = screen.getAllByRole('status')
+      const dragRegion = liveRegions.find((el) => el.id.includes('drag-announce'))
+      expect(dragRegion).toHaveTextContent('')
+    })
+
+    it('clears drag announcement on drop', () => {
+      render(<FilePickerWithState />)
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      act(() => {
+        fireEvent.dragEnter(dropzone, makeDragEvent([makeFile('a.pdf', 1, 'application/pdf')]))
+        fireEvent.drop(dropzone, makeDragEvent([makeFile('a.pdf', 100, 'application/pdf')]))
+      })
+      const liveRegions = screen.getAllByRole('status')
+      const dragRegion = liveRegions.find((el) => el.id.includes('drag-announce'))
+      expect(dragRegion).toHaveTextContent('')
+    })
+  })
+
+  describe('file rejection announcements', () => {
+    it('announces rejected files when all files fail accept filter on drop', () => {
+      render(
+        <FilePicker
+          id="rej"
+          label="Reject"
+          accept=".pdf"
+          files={[]}
+          onChange={vi.fn()}
+        />,
+      )
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      const txt = makeFile('bad.txt', 100, 'text/plain')
+      act(() => {
+        fireEvent.drop(dropzone, makeDragEvent([txt]))
+      })
+      const liveRegions = screen.getAllByRole('status')
+      const announceRegion = liveRegions.find((el) => el.id === 'rej-announce')
+      expect(announceRegion).toHaveTextContent('1 file rejected. Check file type and size.')
+    })
+
+    it('announces rejected files when all files exceed maxSizeBytes', () => {
+      render(
+        <FilePicker
+          id="rej2"
+          label="Reject2"
+          maxSizeBytes={100}
+          files={[]}
+          onChange={vi.fn()}
+        />,
+      )
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      const big = makeFile('big.pdf', 9999, 'application/pdf')
+      act(() => {
+        fireEvent.drop(dropzone, makeDragEvent([big]))
+      })
+      const liveRegions = screen.getAllByRole('status')
+      const announceRegion = liveRegions.find((el) => el.id === 'rej2-announce')
+      expect(announceRegion).toHaveTextContent('1 file rejected. Check file type and size.')
+    })
+
+    it('announces plural rejection when multiple files fail', () => {
+      render(
+        <FilePicker
+          id="rej3"
+          label="Reject3"
+          accept=".pdf"
+          files={[]}
+          onChange={vi.fn()}
+        />,
+      )
+      const dropzone = screen.getByTestId('file-picker-dropzone')
+      const txt1 = makeFile('bad1.txt', 100, 'text/plain')
+      const txt2 = makeFile('bad2.txt', 100, 'text/plain')
+      act(() => {
+        fireEvent.drop(dropzone, makeDragEvent([txt1, txt2]))
+      })
+      const liveRegions = screen.getAllByRole('status')
+      const announceRegion = liveRegions.find((el) => el.id === 'rej3-announce')
+      expect(announceRegion).toHaveTextContent('2 files rejected. Check file types and size.')
+    })
+  })
+})

--- a/src/components/FilePicker.tsx
+++ b/src/components/FilePicker.tsx
@@ -1,0 +1,488 @@
+import React, { useCallback, useId, useRef, useState } from 'react'
+import { FormField } from './forms/FormField'
+import './FilePicker.css'
+import { TEST_IDS } from '@/config/testIds'
+
+export interface FilePickerProps {
+  id?: string
+  label?: string
+  hint?: string
+  error?: string
+  files: File[]
+  onChange: (files: File[]) => void
+  accept?: string
+  multiple?: boolean
+  disabled?: boolean
+  required?: boolean
+  maxSizeBytes?: number
+  className?: string
+  title?: string
+  dropHint?: string
+  ariaLabel?: string
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`
+  }
+  if (bytes < 1024 * 1024 * 1024) {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  }
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
+}
+
+function UploadIcon() {
+  return (
+    <svg
+      className="file-picker-icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M12 16V4M12 4L6 10M12 4L18 10"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M4 20H20"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+function FileIcon() {
+  return (
+    <svg
+      className="file-picker-file-icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M14 2H6C5.46957 2 4.96086 2.21071 4.58579 2.58579C4.21071 2.96086 4 3.46957 4 4V20C4 20.5304 4.21071 21.0391 4.58579 21.4142C4.96086 21.7893 5.46957 22 6 22H18C18.5304 22 19.0391 21.7893 19.4142 21.4142C19.7893 21.0391 20 20.5304 20 20V8L14 2Z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M14 2V8H20"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+function RemoveIcon() {
+  return (
+    <svg
+      className="file-picker-file-remove-icon"
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M18 6L6 18M6 6L18 18"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+interface FilePickerInnerProps {
+  id?: string
+  'aria-describedby'?: string
+  'aria-invalid'?: 'true' | 'false'
+  inputId: string
+  dropzoneRef: React.RefObject<HTMLDivElement>
+  inputRef: React.RefObject<HTMLInputElement>
+  announceId: string
+  dragAnnounceId: string
+  isDragging: boolean
+  files: File[]
+  accept?: string
+  multiple?: boolean
+  disabled?: boolean
+  required?: boolean
+  title: string
+  dropHint: string
+  onDragEnter: (e: React.DragEvent<HTMLDivElement>) => void
+  onDragOver: (e: React.DragEvent<HTMLDivElement>) => void
+  onDragLeave: (e: React.DragEvent<HTMLDivElement>) => void
+  onDrop: (e: React.DragEvent<HTMLDivElement>) => void
+  onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void
+  onClick: () => void
+  onFileChange: (e: React.ChangeEvent<HTMLInputElement>) => void
+  onRemove: (index: number) => void
+}
+
+function FilePickerInner({
+  id,
+  'aria-describedby': ariaDescribedBy,
+  'aria-invalid': ariaInvalid,
+  inputId,
+  dropzoneRef,
+  inputRef,
+  announceId,
+  dragAnnounceId,
+  isDragging,
+  files,
+  accept,
+  multiple,
+  disabled,
+  required,
+  title,
+  dropHint,
+  onDragEnter,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  onKeyDown,
+  onClick,
+  onFileChange,
+  onRemove,
+}: FilePickerInnerProps) {
+  return (
+    <>
+      <div
+        ref={dropzoneRef}
+        id={id}
+        role="button"
+        tabIndex={disabled ? -1 : 0}
+        aria-disabled={disabled || undefined}
+        aria-describedby={ariaDescribedBy}
+        aria-invalid={ariaInvalid}
+        aria-required={required || undefined}
+        aria-labelledby={`${inputId}-label`}
+        aria-controls={`${announceId} ${dragAnnounceId}`}
+        aria-roledescription="file drop zone"
+        data-dragover={isDragging}
+        data-invalid={ariaInvalid === 'true'}
+        className="file-picker-dropzone"
+        onDragEnter={onDragEnter}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
+        onKeyDown={onKeyDown}
+        onClick={onClick}
+        data-testid={TEST_IDS.FILE_PICKER_DROPZONE}
+      >
+        <input
+          ref={inputRef}
+          id={inputId}
+          type="file"
+          className="file-picker-input"
+          tabIndex={-1}
+          accept={accept}
+          multiple={multiple}
+          disabled={disabled}
+          required={required}
+          aria-hidden="true"
+          onChange={onFileChange}
+          data-testid={TEST_IDS.FILE_PICKER_INPUT}
+        />
+        <UploadIcon />
+        <div className="file-picker-text">
+          <div className="file-picker-title">{title}</div>
+          <div className="file-picker-hint">{dropHint}</div>
+          <span className="sr-only">Press Space or Enter to browse files.</span>
+        </div>
+        <span aria-hidden="true" className="file-picker-kbd">
+          Space
+        </span>
+      </div>
+
+      {files.length > 0 && (
+        <ul
+          className="file-picker-file-list"
+          aria-label={`Selected files, ${files.length} item${files.length !== 1 ? 's' : ''}`}
+          data-testid={TEST_IDS.FILE_PICKER_FILE_LIST}
+        >
+          {files.map((file, index) => (
+            <li
+              key={`${file.name}-${file.size}-${file.lastModified}-${index}`}
+              className="file-picker-file-item"
+            >
+              <FileIcon />
+              <div className="file-picker-file-info">
+                <span className="file-picker-file-name" title={file.name}>
+                  {file.name}
+                </span>
+                <span className="file-picker-file-meta">{formatFileSize(file.size)}</span>
+              </div>
+              <button
+                type="button"
+                className="file-picker-file-remove"
+                onClick={() => onRemove(index)}
+                disabled={disabled}
+                aria-label={`Remove ${file.name}`}
+                data-testid={`${TEST_IDS.FILE_PICKER_REMOVE_BUTTON}-${index}`}
+              >
+                <RemoveIcon />
+                <span className="sr-only">Remove {file.name}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  )
+}
+
+export default function FilePicker({
+  id: externalId,
+  label = 'Upload files',
+  hint,
+  error,
+  files,
+  onChange,
+  accept,
+  multiple = false,
+  disabled = false,
+  required = false,
+  maxSizeBytes,
+  className = '',
+  title,
+  dropHint,
+  ariaLabel,
+}: FilePickerProps) {
+  const autoId = useId()
+  const inputId = externalId ? `${externalId}-input` : `file-picker-${autoId}-input`
+  const announceId = externalId ? `${externalId}-announce` : `file-picker-${autoId}-announce`
+  const dragAnnounceId = externalId ? `${externalId}-drag-announce` : `file-picker-${autoId}-drag-announce`
+  const wrapperId = externalId || `file-picker-${autoId}`
+
+  const dropzoneRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const dragCounter = useRef(0)
+
+  const [isDragging, setIsDragging] = useState(false)
+  const [announcement, setAnnouncement] = useState('')
+  const [dragAnnouncement, setDragAnnouncement] = useState('')
+
+  const defaultTitle = multiple ? 'Drag and drop files here, or click to browse' : 'Drag and drop a file here, or click to browse'
+  const effectiveTitle = title || defaultTitle
+
+  const defaultDropHint = multiple
+    ? `${accept ? `Accepted formats: ${accept}. ` : ''}`
+    : `${accept ? `Accepted formats: ${accept}. ` : ''}`
+  const effectiveDropHint = dropHint || defaultDropHint
+
+  const validateAndFilterFiles = useCallback(
+    (fileList: FileList | File[]): File[] => {
+      const filesArray = Array.from(fileList)
+      return filesArray.filter((file) => {
+        if (maxSizeBytes && file.size > maxSizeBytes) {
+          return false
+        }
+        if (accept) {
+          const acceptTypes = accept.split(',').map((t) => t.trim().toLowerCase())
+          const fileType = file.type.toLowerCase()
+          const fileName = file.name.toLowerCase()
+          return acceptTypes.some((type) => {
+            if (type.startsWith('.')) {
+              return fileName.endsWith(type)
+            }
+            if (type.endsWith('/*')) {
+              return fileType.startsWith(type.slice(0, -1))
+            }
+            return fileType === type
+          })
+        }
+        return true
+      })
+    },
+    [accept, maxSizeBytes],
+  )
+
+  const handleFiles = useCallback(
+    (fileList: FileList | File[]) => {
+      const validFiles = validateAndFilterFiles(fileList)
+      const totalCount = Array.from(fileList).length
+      const rejectedCount = totalCount - validFiles.length
+      if (validFiles.length === 0) {
+        if (rejectedCount > 0) {
+          setAnnouncement(
+            `${rejectedCount} file${rejectedCount !== 1 ? 's' : ''} rejected. Check file type${rejectedCount !== 1 ? 's' : ''} and size.`,
+          )
+        }
+        return
+      }
+
+      let nextFiles: File[]
+      if (multiple) {
+        const existingNames = new Set(files.map((f) => f.name))
+        const newFiles = validFiles.filter((f) => !existingNames.has(f.name))
+        nextFiles = [...files, ...newFiles]
+      } else {
+        nextFiles = validFiles.slice(0, 1)
+      }
+
+      onChange(nextFiles)
+
+      const addedCount = multiple ? nextFiles.length - files.length : nextFiles.length
+      if (addedCount > 0) {
+        setAnnouncement(
+          `${addedCount} file${addedCount !== 1 ? 's' : ''} added. ${nextFiles.length} total file${nextFiles.length !== 1 ? 's' : ''} selected.`,
+        )
+      }
+    },
+    [files, multiple, onChange, validateAndFilterFiles],
+  )
+
+  const handleDragEnter = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+    dragCounter.current += 1
+    if (e.dataTransfer.items && e.dataTransfer.items.length > 0) {
+      setIsDragging(true)
+      setDragAnnouncement('Files detected. Drop to add files.')
+    }
+  }, [])
+
+  const handleDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+  }, [])
+
+  const handleDragLeave = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+    dragCounter.current -= 1
+    if (dragCounter.current <= 0) {
+      dragCounter.current = 0
+      setIsDragging(false)
+      setDragAnnouncement('')
+    }
+  }, [])
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault()
+      e.stopPropagation()
+      dragCounter.current = 0
+      setIsDragging(false)
+      setDragAnnouncement('')
+
+      if (disabled) {
+        return
+      }
+
+      if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+        handleFiles(e.dataTransfer.files)
+        e.dataTransfer.clearData()
+      }
+    },
+    [disabled, handleFiles],
+  )
+
+  const handleClick = useCallback(() => {
+    if (disabled) {
+      return
+    }
+    inputRef.current?.click()
+  }, [disabled])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (disabled) {
+        return
+      }
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
+        handleClick()
+      }
+    },
+    [disabled, handleClick],
+  )
+
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (e.target.files && e.target.files.length > 0) {
+        handleFiles(e.target.files)
+      }
+      e.target.value = ''
+    },
+    [handleFiles],
+  )
+
+  const handleRemove = useCallback(
+    (index: number) => {
+      const removedFile = files[index]
+      const nextFiles = files.filter((_, i) => i !== index)
+      onChange(nextFiles)
+      setAnnouncement(`Removed ${removedFile?.name || 'file'}. ${nextFiles.length} file${nextFiles.length !== 1 ? 's' : ''} remaining.`)
+    },
+    [files, onChange],
+  )
+
+  const composedHint = [
+    hint,
+    maxSizeBytes ? `Maximum file size: ${formatFileSize(maxSizeBytes)}.` : undefined,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return (
+    <div className={`file-picker-wrapper ${className}`}>
+      <FormField
+        id={wrapperId}
+        label={ariaLabel || label}
+        hint={composedHint || undefined}
+        error={error}
+        srOnlyLabel={Boolean(ariaLabel)}
+      >
+        <FilePickerInner
+          inputId={inputId}
+          dropzoneRef={dropzoneRef}
+          inputRef={inputRef}
+          announceId={announceId}
+          dragAnnounceId={dragAnnounceId}
+          isDragging={isDragging}
+          files={files}
+          accept={accept}
+          multiple={multiple}
+          disabled={disabled}
+          required={required}
+          title={effectiveTitle}
+          dropHint={effectiveDropHint}
+          onDragEnter={handleDragEnter}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+          onKeyDown={handleKeyDown}
+          onClick={handleClick}
+          onFileChange={handleFileChange}
+          onRemove={handleRemove}
+        />
+      </FormField>
+
+      <div id={announceId} className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        {announcement}
+      </div>
+
+      <div id={dragAnnounceId} className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        {dragAnnouncement}
+      </div>
+    </div>
+  )
+}

--- a/src/config/testIds.ts
+++ b/src/config/testIds.ts
@@ -9,4 +9,8 @@ export const TEST_IDS = {
   TX_BULK_DELETE_BUTTON: 'transactions-bulk-delete-button',
   TX_BULK_EXPORT_BUTTON: 'transactions-bulk-export-button',
   TX_BULK_CLEAR_BUTTON: 'transactions-bulk-clear-button',
+  FILE_PICKER_DROPZONE: 'file-picker-dropzone',
+  FILE_PICKER_INPUT: 'file-picker-input',
+  FILE_PICKER_FILE_LIST: 'file-picker-file-list',
+  FILE_PICKER_REMOVE_BUTTON: 'file-picker-remove-button',
 } as const

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,5 @@
 export { useInfiniteQuery } from './useInfiniteQuery'
 export { useSmartBack } from './useSmartBack'
 export { useForwardRef, setRef, type ReactRef, type NestedRef } from './useForwardRef'
+export { useApiQuery, invalidateApiQuery, clearApiQueryCache } from './useApiQuery'
+export type { UseApiQueryOptions, UseApiQueryResult } from './useApiQuery'

--- a/src/hooks/useApiQuery.test.ts
+++ b/src/hooks/useApiQuery.test.ts
@@ -1,0 +1,342 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ApiError } from '../api/client'
+import {
+  useApiQuery,
+  invalidateApiQuery,
+  clearApiQueryCache,
+} from './useApiQuery'
+
+const apiFetchMock = vi.fn<typeof import('../api/client').apiFetch>()
+
+vi.mock('../api/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../api/client')>()
+  return {
+    ...actual,
+    apiFetch: (...args: Parameters<typeof actual.apiFetch>) => apiFetchMock(...args),
+  }
+})
+
+interface MockData {
+  score: number
+  tier: string
+}
+
+const mockData: MockData = { score: 720, tier: 'gold' }
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+beforeEach(() => {
+  apiFetchMock.mockReset()
+  clearApiQueryCache()
+  vi.unstubAllGlobals()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('useApiQuery', () => {
+  it('fetches on mount and transitions loading → success', async () => {
+    apiFetchMock.mockResolvedValueOnce(mockData)
+
+    const { result } = renderHook(() =>
+      useApiQuery<MockData>('/trust-score/GABC')
+    )
+
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.data).toBeUndefined()
+    expect(result.current.error).toBeNull()
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.data).toEqual(mockData)
+    expect(result.current.error).toBeNull()
+    expect(result.current.isStale).toBe(false)
+  })
+
+  it('skips fetch when enabled=false', async () => {
+    const { result } = renderHook(() =>
+      useApiQuery<MockData>('/trust-score/GABC', { enabled: false })
+    )
+
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.data).toBeUndefined()
+    expect(apiFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('transitions loading → error when the API rejects', async () => {
+    apiFetchMock.mockRejectedValueOnce(new ApiError(503, 'Service unavailable'))
+
+    const { result } = renderHook(() =>
+      useApiQuery<MockData>('/trust-score/GABC')
+    )
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.data).toBeUndefined()
+    expect(result.current.error).toMatchObject({
+      status: 503,
+      message: 'Service unavailable',
+    })
+  })
+
+  it('serves from cache within stale time', async () => {
+    apiFetchMock.mockResolvedValue(mockData)
+
+    const { result, unmount } = renderHook(() =>
+      useApiQuery<MockData>('/trust-score/GABC')
+    )
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(1)
+    unmount()
+
+    const { result: result2 } = renderHook(() =>
+      useApiQuery<MockData>('/trust-score/GABC')
+    )
+
+    expect(result2.current.data).toEqual(mockData)
+    expect(apiFetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-fetches when stale time has expired', async () => {
+    apiFetchMock.mockResolvedValue(mockData)
+
+    const { result, unmount } = renderHook(() =>
+      useApiQuery<MockData>('/trust-score/GABC', { staleTimeMs: 1 })
+    )
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    unmount()
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10))
+    })
+
+    const { result: result2 } = renderHook(() =>
+      useApiQuery<MockData>('/trust-score/GABC', { staleTimeMs: 1 })
+    )
+
+    await waitFor(() => {
+      expect(result2.current.isLoading).toBe(false)
+    })
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('refetch() always bypasses cache', async () => {
+    const freshData = { score: 900, tier: 'platinum' }
+    apiFetchMock.mockResolvedValueOnce(mockData).mockResolvedValueOnce(freshData)
+
+    const { result } = renderHook(() =>
+      useApiQuery<MockData>('/trust-score/GABC')
+    )
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.data).toEqual(mockData)
+    expect(apiFetchMock).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await result.current.refetch()
+    })
+
+    expect(result.current.data).toEqual(freshData)
+    expect(apiFetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('aborts in-flight request on unmount', async () => {
+    const pending = deferred<MockData>()
+    apiFetchMock.mockReturnValueOnce(pending.promise)
+
+    const { result, unmount } = renderHook(() =>
+      useApiQuery<MockData>('/trust-score/GABC')
+    )
+
+    expect(result.current.isLoading).toBe(true)
+
+    const signal = apiFetchMock.mock.calls[0]?.[1]?.signal as AbortSignal
+    expect(signal.aborted).toBe(false)
+
+    unmount()
+
+    expect(signal.aborted).toBe(true)
+  })
+
+  it('aborts superseded request when refetch is called', async () => {
+    const first = deferred<MockData>()
+    const second = deferred<MockData>()
+    apiFetchMock.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+
+    const { result } = renderHook(() =>
+      useApiQuery<MockData>('/trust-score/GABC')
+    )
+
+    await waitFor(() => {
+      expect(apiFetchMock).toHaveBeenCalledTimes(1)
+    })
+
+    const firstSignal = apiFetchMock.mock.calls[0]?.[1]?.signal as AbortSignal
+    expect(firstSignal.aborted).toBe(false)
+
+    // Fire refetch without awaiting — avoids deadlock with deferred
+    act(() => {
+      void result.current.refetch()
+    })
+
+    expect(firstSignal.aborted).toBe(true)
+
+    await act(async () => {
+      second.resolve({ score: 810, tier: 'platinum' })
+      await second.promise
+    })
+
+    await waitFor(() => {
+      expect(result.current.data?.score).toBe(810)
+    })
+  })
+
+  it('wraps unexpected errors in ApiError', async () => {
+    apiFetchMock.mockRejectedValueOnce('unexpected string error')
+
+    const { result } = renderHook(() =>
+      useApiQuery<MockData>('/trust-score/GABC')
+    )
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.error).toBeInstanceOf(ApiError)
+    expect(result.current.error?.status).toBe(0)
+  })
+
+  it('isStale is true when cached data is older than staleTimeMs', async () => {
+    apiFetchMock.mockResolvedValue(mockData)
+
+    const { result, unmount } = renderHook(() =>
+      useApiQuery<MockData>('/trust-score/GABC', { staleTimeMs: 1 })
+    )
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.isStale).toBe(false)
+    unmount()
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10))
+    })
+
+    const { result: result2 } = renderHook(() =>
+      useApiQuery<MockData>('/trust-score/GABC', { staleTimeMs: 1 })
+    )
+
+    expect(result2.current.data).toEqual(mockData)
+    expect(result2.current.isStale).toBe(true)
+  })
+
+  it('invalidateApiQuery clears a specific cached entry', async () => {
+    apiFetchMock.mockResolvedValue(mockData)
+
+    const { result, unmount } = renderHook(() =>
+      useApiQuery<MockData>('/trust-score/GABC')
+    )
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    unmount()
+    invalidateApiQuery('/trust-score/GABC')
+
+    const { result: result2 } = renderHook(() =>
+      useApiQuery<MockData>('/trust-score/GABC')
+    )
+
+    await waitFor(() => {
+      expect(result2.current.isLoading).toBe(false)
+    })
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('clearApiQueryCache removes all entries', async () => {
+    apiFetchMock.mockResolvedValue(mockData)
+
+    const { result, unmount } = renderHook(() =>
+      useApiQuery<MockData>('/trust-score/GABC')
+    )
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    unmount()
+    clearApiQueryCache()
+
+    const { result: result2 } = renderHook(() =>
+      useApiQuery<MockData>('/trust-score/GABC')
+    )
+
+    await waitFor(() => {
+      expect(result2.current.isLoading).toBe(false)
+    })
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not fetch when offline', async () => {
+    vi.stubGlobal('navigator', { onLine: false })
+
+    const { result } = renderHook(() =>
+      useApiQuery<MockData>('/trust-score/GABC')
+    )
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(result.current.data).toBeUndefined()
+    expect(apiFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('passes AbortSignal to apiFetch', async () => {
+    apiFetchMock.mockResolvedValueOnce(mockData)
+
+    const { result } = renderHook(() =>
+      useApiQuery<MockData>('/trust-score/GABC')
+    )
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/trust-score/GABC',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    )
+  })
+})

--- a/src/hooks/useApiQuery.ts
+++ b/src/hooks/useApiQuery.ts
@@ -1,0 +1,185 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { apiFetch, ApiError } from '../api/client'
+import { WIDGET_CACHE_DEFAULTS } from '../config/widgetCache'
+
+// ── Cache ───────────────────────────────────────────────────────────────────
+
+interface CacheEntry<T> {
+  data: T
+  lastUpdated: number
+}
+
+const cache = new Map<string, CacheEntry<unknown>>()
+
+function getCacheEntry<T>(key: string): CacheEntry<T> | undefined {
+  return cache.get(key) as CacheEntry<T> | undefined
+}
+
+function setCacheEntry<T>(key: string, data: T): void {
+  cache.set(key, { data, lastUpdated: Date.now() })
+}
+
+function isCacheFresh(key: string, staleTimeMs: number): boolean {
+  const entry = getCacheEntry(key)
+  if (!entry) return false
+  return Date.now() - entry.lastUpdated < staleTimeMs
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+export interface UseApiQueryOptions {
+  /** Set `false` to skip the initial fetch. Default `true`. */
+  enabled?: boolean
+  /** Time in ms before cached data is considered stale. Default 30 000. */
+  staleTimeMs?: number
+}
+
+export interface UseApiQueryResult<T> {
+  data: T | undefined
+  isLoading: boolean
+  error: ApiError | null
+  /** Whether the current data came from cache (within staleTime). */
+  isStale: boolean
+  /** Force a re-fetch, bypassing stale-time checks. */
+  refetch: () => Promise<void>
+}
+
+/**
+ * Type-safe, cache-aware wrapper around `apiFetch` for GET requests.
+ *
+ * Automatically manages loading/error states, caches responses keyed by the
+ * API path, and serves cached data within the configured `staleTime`. An
+ * in-flight request is aborted when the component unmounts or when a new
+ * fetch supersedes it.
+ *
+ * @param path    API path passed to `apiFetch` (e.g. `'/trust-score/GABC…'`).
+ * @param options `{ enabled, staleTimeMs }`.
+ *
+ * @example
+ * ```tsx
+ * const { data, isLoading, error } = useApiQuery<TrustScore>(
+ *   `/trust-score/${address}`,
+ * )
+ * ```
+ */
+export function useApiQuery<T>(
+  path: string,
+  options: UseApiQueryOptions = {},
+): UseApiQueryResult<T> {
+  const { enabled = true, staleTimeMs = WIDGET_CACHE_DEFAULTS.STALE_TIME_MS } =
+    options
+
+  const [data, setData] = useState<T | undefined>(() => {
+    const cached = getCacheEntry<T>(path)
+    return cached?.data
+  })
+  const [error, setError] = useState<ApiError | null>(null)
+  const [isLoading, setIsLoading] = useState<boolean>(enabled)
+  const [isStale, setIsStale] = useState<boolean>(() => {
+    const cached = getCacheEntry<T>(path)
+    return cached !== undefined && !isCacheFresh(path, staleTimeMs)
+  })
+
+  const mountedRef = useRef(true)
+  const runIdRef = useRef(0)
+  const abortRef = useRef<AbortController | null>(null)
+  const pathRef = useRef(path)
+  pathRef.current = path
+
+  // Cleanup: mark unmounted, abort any in-flight request
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      abortRef.current?.abort('unmounted')
+      abortRef.current = null
+    }
+  }, [])
+
+  const fetch = useCallback(
+    async (bypassCache = false): Promise<void> => {
+      const currentPath = pathRef.current
+
+      // Serve from cache unless bypassed
+      if (!bypassCache && isCacheFresh(currentPath, staleTimeMs)) {
+        const cached = getCacheEntry<T>(currentPath)
+        if (cached) {
+          setData(cached.data)
+          setIsStale(false)
+          setError(null)
+          setIsLoading(false)
+          return
+        }
+      }
+
+      // Offline guard
+      if (typeof window !== 'undefined' && !window.navigator.onLine) {
+        setIsLoading(false)
+        return
+      }
+
+      // Abort any previous in-flight request for this hook
+      abortRef.current?.abort('superseded')
+      const controller = new AbortController()
+      abortRef.current = controller
+
+      const currentRunId = ++runIdRef.current
+      setIsLoading(true)
+      setError(null)
+
+      try {
+        const result = await apiFetch<T>(currentPath, {
+          signal: controller.signal,
+        })
+
+        if (mountedRef.current && currentRunId === runIdRef.current) {
+          setData(result)
+          setCacheEntry(currentPath, result)
+          setIsStale(false)
+          setError(null)
+        }
+      } catch (err) {
+        if (controller.signal.aborted) return
+
+        if (mountedRef.current && currentRunId === runIdRef.current) {
+          setError(err instanceof ApiError ? err : new ApiError(0, String(err)))
+        }
+      } finally {
+        if (mountedRef.current && currentRunId === runIdRef.current) {
+          setIsLoading(false)
+        }
+      }
+    },
+    [staleTimeMs],
+  )
+
+  // Initial fetch
+  useEffect(() => {
+    if (enabled) {
+      void fetch(false)
+    } else {
+      setIsLoading(false)
+    }
+  }, [enabled, fetch])
+
+  return { data, isLoading, error, isStale, refetch: () => fetch(true) }
+}
+
+/**
+ * Invalidate a single cached entry so the next mount or refetch re-fetches.
+ *
+ * @example
+ * ```ts
+ * invalidateApiQuery('/trust-score/GABC…')
+ * ```
+ */
+export function invalidateApiQuery(path: string): void {
+  cache.delete(path)
+}
+
+/**
+ * Clear the entire API query cache. Useful in tests.
+ */
+export function clearApiQueryCache(): void {
+  cache.clear()
+}


### PR DESCRIPTION
Close: #670
 Here's what was implemented:
src/hooks/useApiQuery.ts — Type-safe, cache-aware wrapper around apiFetch for GET calls. Key features:
In-memory cache keyed by API path — serves cached data synchronously on mount (no loading flash)
Configurable staleTimeMs (default 30s) — skips network when cache is fresh
isStale flag — signals when cached data exceeds staleTimeMs
Abort safety — cancels in-flight on unmount or superseded refetch()
Offline guard — skips fetch when navigator.onLine is false
invalidateApiQuery(path) / clearApiQueryCache() — manual eviction utilities
src/hooks/useApiQuery.test.ts — 14 tests covering: mount→success, mount→error, enabled=false, cache hit/miss, stale expiration, refetch bypass, unmount abort, superseded abort, unexpected error wrapping, isStale correctness, invalidation, cache clearing, offline guard, signal passthrough.
src/hooks/index.ts — Added exports for useApiQuery, invalidateApiQuery, clearApiQueryCache, and types.
docs/HOOKS.md — Full documentation entry with signature, params, behavior notes, and usage example.