### PR TITLE
config: expose i18n default via env (#743)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,8 @@ VITE_API_BASE_URL=http://localhost:3000
 VITE_DOCS=
 VITE_TERMS=
 VITE_PRIVACY=
+
+# i18n default locale override. Must be one of the supported locales
+# defined in src/config/i18n.ts (currently: en). Invalid values fall
+# back to "en" and log a console error at startup.
+VITE_DEFAULT_LOCALE=en

--- a/src/config/i18n.test.ts
+++ b/src/config/i18n.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+describe('getDefaultLocale resolution', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllEnvs()
+  })
+
+  const setEnv = (key: string, value: string | undefined) => {
+    if (value === undefined) {
+      vi.stubEnv(key, undefined as unknown as string)
+    } else {
+      vi.stubEnv(key, value)
+    }
+  }
+
+  const getDefaultLocale = async () => {
+    return ((await vi.importActual('./i18n')) as typeof import('./i18n')).getDefaultLocale()
+  }
+
+  it('uses VITE_DEFAULT_LOCALE when it is a supported locale', async () => {
+    setEnv('VITE_DEFAULT_LOCALE', 'en')
+    expect(await getDefaultLocale()).toBe('en')
+  })
+
+  it('falls back to "en" when VITE_DEFAULT_LOCALE is unset', async () => {
+    setEnv('VITE_DEFAULT_LOCALE', undefined)
+    expect(await getDefaultLocale()).toBe('en')
+  })
+
+  it('falls back to "en" when VITE_DEFAULT_LOCALE is whitespace', async () => {
+    setEnv('VITE_DEFAULT_LOCALE', '   ')
+    expect(await getDefaultLocale()).toBe('en')
+  })
+
+  it('falls back to "en" and logs an error for an unsupported locale (failure mode)', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    setEnv('VITE_DEFAULT_LOCALE', 'fr')
+
+    expect(await getDefaultLocale()).toBe('en')
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid VITE_DEFAULT_LOCALE "fr"'))
+
+    errorSpy.mockRestore()
+  })
+})

--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -1,0 +1,33 @@
+// i18n runtime configuration
+// Default locale can be overridden via Vite env var:
+// - VITE_DEFAULT_LOCALE
+
+export const SUPPORTED_LOCALES = ['en'] as const
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number]
+
+const DEFAULT_LOCALE: SupportedLocale = 'en'
+
+const isSupportedLocale = (value: string): value is SupportedLocale =>
+  (SUPPORTED_LOCALES as readonly string[]).includes(value)
+
+export const getDefaultLocale = (): SupportedLocale => {
+  const raw = import.meta.env.VITE_DEFAULT_LOCALE?.trim()
+
+  if (!raw) {
+    return DEFAULT_LOCALE
+  }
+
+  if (isSupportedLocale(raw)) {
+    return raw
+  }
+
+  console.error(
+    `[i18n] Invalid VITE_DEFAULT_LOCALE "${raw}". Supported locales: ${SUPPORTED_LOCALES.join(', ')}. Falling back to "${DEFAULT_LOCALE}".`
+  )
+  return DEFAULT_LOCALE
+}
+
+export const DEFAULT_LOCALE_CONFIG = {
+  defaultLocale: getDefaultLocale(),
+  supportedLocales: SUPPORTED_LOCALES,
+} as const

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -2,6 +2,9 @@ import i18n from 'i18next'
 import { initReactI18next } from 'react-i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
 import en from './locales/en.json'
+import { getDefaultLocale } from '@/config/i18n'
+
+const defaultLocale = getDefaultLocale()
 
 i18n
   .use(LanguageDetector)
@@ -10,8 +13,8 @@ i18n
     resources: {
       en: { translation: en },
     },
-    fallbackLng: 'en',
-    lng: 'en',
+    fallbackLng: defaultLocale,
+    lng: defaultLocale,
     interpolation: {
       escapeValue: false,
     },
@@ -20,11 +23,8 @@ i18n
       caches: ['localStorage'],
     },
   })
-
 i18n.on('languageChanged', (lng) => {
   document.documentElement.lang = lng
 })
-
-document.documentElement.lang = i18n.language || 'en'
-
+document.documentElement.lang = i18n.language || defaultLocale
 export default i18n


### PR DESCRIPTION
Closes #743

## What
Adds a `VITE_DEFAULT_LOCALE` environment variable to override the i18n default locale, with a sane built-in fallback.

## Why
Keeps env-driven config centralized and testable. Following the existing precedent in `src/config/links.ts` (default-first, override-second), a new `src/config/i18n.ts` module is the single source of truth for locale resolution — `src/i18n/config.ts` now consumes it instead of reading env vars inline inside i18next initialization.

## Changes
- **`src/config/i18n.ts`** (new): `getDefaultLocale()` resolves `VITE_DEFAULT_LOCALE` against a whitelist of supported locales (currently `en`).
- **`src/i18n/config.ts`**: uses `getDefaultLocale()` for both `fallbackLng` and `lng`, and for the initial `document.documentElement.lang`.
- **`.env.example`**: documents `VITE_DEFAULT_LOCALE`.
- **`src/config/i18n.test.ts`** (new): covers happy path (valid override, unset → default) and the explicit failure mode below.

## Failure mode covered
An invalid/unsupported `VITE_DEFAULT_LOCALE` (e.g. a locale with no matching translation file) does **not** silently break i18next or render raw translation keys to the user. It falls back to `en` and logs a `console.error` at startup, so a misconfigured deploy is visible in build/console logs rather than hidden in the UI.

## Testing

npx vitest run src/config/i18n.test.ts src/config/links.test.ts

20/20 passing.

## Note for reviewers
`main` currently fails `npm run lint` (31 pre-existing errors) and `npm run build` (97 pre-existing TS errors) — confirmed via `grep` that none reference `i18n` or this PR's files. Unrelated, pre-existing on base branch. Also hit the known npm/rollup optional-dependency bug ([npm/cli#4828](https://github.com/npm/cli/issues/4828)) on a fresh install — fixed locally via `rm -rf node_modules package-lock.json && npm install`, flagging in case other contributors hit the same wall.

## Out of scope (per issue)
No changes to unrelated files, no additional locales added beyond `en` (none exist in `src/i18n/locales/` yet), no stylistic-only edits.