### PR TITLE
docs: add guide on how i18n messages are extracted

### DIFF
--- a/docs/COPY_TONE.md
+++ b/docs/COPY_TONE.md
@@ -315,6 +315,9 @@ const { t } = useTranslation()
 ;<EmptyState title="No active bonds" description="You do not have any active bonds yet." />
 ```
 
+> [!NOTE]
+> For a step-by-step guide on how to extract hardcoded strings into the i18n files, see the [i18n Extraction Guide](./i18n-extraction.md).
+
 Exception: toast messages currently use hard-coded English strings in the codebase
 (e.g., `addToast('success', 'Bond created successfully.')`). When adding new toast
 strings, follow the existing pattern, and prefer action-oriented past-tense sentences.

--- a/docs/README.md
+++ b/docs/README.md
@@ -128,6 +128,11 @@ This directory contains comprehensive design specifications and implementation g
     - Privacy-first approach (no telemetry collected)
     - No PII handling or third-party analytics
 
+19. **[i18n Extraction Guide](./i18n-extraction.md)** ⭐ NEW
+    - Step-by-step instructions for contributors to extract hardcoded strings
+    - Explanation of the manual extraction process
+    - Examples of adding strings to locales and using the `useTranslation` hook
+
 ### Quick Start
 
 To implement UI states in your components:

--- a/docs/i18n-extraction.md
+++ b/docs/i18n-extraction.md
@@ -1,0 +1,65 @@
+# Extracting i18n Messages
+
+This guide is for **contributors** who need to extract hardcoded user-facing strings from React components into our localization files. 
+
+By extracting these strings into `src/i18n/locales/en.json`, we keep the application auditable, safe to change, and ready for future translations.
+
+## Extraction Process
+
+We do not use automated extraction scripts. All string extraction is done manually. When you write a new component or refactor an existing one, you must move any English strings to the JSON locale file and replace them with the `useTranslation` hook.
+
+### 1. Add the string to the locale file
+
+Open `src/i18n/locales/en.json` and add your string. Group keys logically by feature or component.
+
+**Example:**
+If you are adding an empty state to the Dashboard:
+
+```json
+{
+  "dashboard": {
+    "emptyStateTitle": "No recent activity",
+    "emptyStateDescription": "New trust score events will appear here once bonds, attestations, or score updates occur."
+  }
+}
+```
+
+### 2. Replace the hardcoded string in the component
+
+In your component, import the `useTranslation` hook from `react-i18next` and reference the newly created key.
+
+**Before (Hardcoded):**
+```tsx
+import { EmptyState } from '@/components/states'
+
+export function DashboardActivity() {
+  return (
+    <EmptyState 
+      title="No recent activity" 
+      description="New trust score events will appear here once bonds, attestations, or score updates occur." 
+    />
+  )
+}
+```
+
+**After (Extracted):**
+```tsx
+import { useTranslation } from 'react-i18next'
+import { EmptyState } from '@/components/states'
+
+export function DashboardActivity() {
+  const { t } = useTranslation()
+  
+  return (
+    <EmptyState 
+      title={t('dashboard.emptyStateTitle')} 
+      description={t('dashboard.emptyStateDescription')} 
+    />
+  )
+}
+```
+
+## Related Documentation
+
+- For guidelines on how to phrase user-facing copy, see the [Copy Tone Guide](./COPY_TONE.md).
+- To understand when and how to show empty states or error states, see the [UI States Guide](./UI_STATES_GUIDE.md).


### PR DESCRIPTION
Closes #741 

**Title:** docs: add guide on how i18n messages are extracted

**Description:**

This PR introduces documentation for contributors on how to manually extract hardcoded user-facing strings into our localization files. 

**Changes included:**
*   Added `docs/i18n-extraction.md` detailing the step-by-step extraction process (adding to `src/i18n/locales/en.json` and replacing strings with `useTranslation`).
*   Included concrete examples (e.g., `EmptyState` component extraction).
*   Cross-linked the new guide in `docs/README.md` and `docs/COPY_TONE.md` to ensure discoverability and prevent document rot.

**Checklist:**
*   [x] The change matches the summary in the issue.
*   [x] Targeted primarily at contributors with concrete code entry point examples.
*   [x] Cross-linked from the README and relevant documents.
*   [x] PR description references the issue with "Closes #".

