### PR TITLE
feat(uiux): standardize responsive spacing system across pages

### DIFF
--- a/docs/RESPONSIVE.md
+++ b/docs/RESPONSIVE.md
@@ -8,26 +8,28 @@ This document codifies the responsive layout rules, viewport breakpoints, and st
 
 The Credence frontend targets several key viewport thresholds to adapt layouts from narrow mobile viewports up to large desktop displays.
 
-| Breakpoint Threshold | CSS Rule / Media Query | Layout Target & Expected Behavior | Key Code Reference |
-| :--- | :--- | :--- | :--- |
-| **Narrow Mobile** (360px) | `max-width: 374px` | Minimum supported viewport width. Avoids horizontal scroll; reduces paddings to keep layout compact. | [Settings.css:L74-L78](file:///c:/Users/opulencechuks/Credence-Frontend/src/pages/Settings.css#L74-L78) |
-| **Mobile / Tablet** (640px) | `max-width: 639px`<br>`min-width: 640px` | Navigation menu transforms from desktop inline tabs to mobile hamburger drawer. Tables collapse into individual card rows. | [Layout.css:L118-L126](file:///c:/Users/opulencechuks/Credence-Frontend/src/components/Layout.css#L118-L126)<br>[Transactions.css:L98-L146](file:///c:/Users/opulencechuks/Credence-Frontend/src/pages/Transactions.css#L98-L146) |
-| **Tablet / Desktop** (768px) | `max-width: 767px` | Primary split-column grids stack vertically (e.g. Dashboard layout). Flex rows wrap or columnize. Footer links switch to vertical stack. | [Dashboard.css:L123-L135](file:///c:/Users/opulencechuks/Credence-Frontend/src/pages/Dashboard.css#L123-L135)<br>[index.css:L325-L329](file:///c:/Users/opulencechuks/Credence-Frontend/src/index.css#L325-L329)<br>[BondDetail.css:L197-L206](file:///c:/Users/opulencechuks/Credence-Frontend/src/pages/BondDetail.css#L197-L206) |
-| **Settings Grid Split** (900px) | `min-width: 900px` | Transitions Settings page layout from a single-column block to a two-column sidebar layout (`1fr 360px`). | [Settings.css:L63-L72](file:///c:/Users/opulencechuks/Credence-Frontend/src/pages/Settings.css#L63-L72) |
-| **Desktop Base** (1024px) | (Design spec target) | Core desktop design grid. Dynamic layout cards extend to maximum grid column configurations. | [FIGMA_DESIGN_SPECS.md](file:///c:/Users/opulencechuks/Credence-Frontend/docs/FIGMA_DESIGN_SPECS.md#L242-L280) |
-| **Widescreen Desktop** (1280px) | `min-width: 1280px` | Keyboard shortcuts help, confirm dialogs, and trust score gauges transition to centered overlay states. | [ConfirmDialog.css:L238-L242](file:///c:/Users/opulencechuks/Credence-Frontend/src/components/ConfirmDialog.css#L238-L242)<br>[TrustGauge.css:L362-L373](file:///c:/Users/opulencechuks/Credence-Frontend/src/components/TrustGauge.css#L362-L373) |
+| Breakpoint Threshold            | CSS Rule / Media Query                   | Layout Target & Expected Behavior                                                                                                        | Key Code Reference                                                                                                                                                                                                                                                                                                                  |
+| :------------------------------ | :--------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Narrow Mobile** (360px)       | `max-width: 374px`                       | Minimum supported viewport width. Avoids horizontal scroll; reduces paddings to keep layout compact.                                     | [Settings.css:L74-L78](file:///c:/Users/opulencechuks/Credence-Frontend/src/pages/Settings.css#L74-L78)                                                                                                                                                                                                                             |
+| **Mobile / Tablet** (640px)     | `max-width: 639px`<br>`min-width: 640px` | Navigation menu transforms from desktop inline tabs to mobile hamburger drawer. Tables collapse into individual card rows.               | [Layout.css:L118-L126](file:///c:/Users/opulencechuks/Credence-Frontend/src/components/Layout.css#L118-L126)<br>[Transactions.css:L98-L146](file:///c:/Users/opulencechuks/Credence-Frontend/src/pages/Transactions.css#L98-L146)                                                                                                   |
+| **Tablet / Desktop** (768px)    | `max-width: 767px`                       | Primary split-column grids stack vertically (e.g. Dashboard layout). Flex rows wrap or columnize. Footer links switch to vertical stack. | [Dashboard.css:L123-L135](file:///c:/Users/opulencechuks/Credence-Frontend/src/pages/Dashboard.css#L123-L135)<br>[index.css:L325-L329](file:///c:/Users/opulencechuks/Credence-Frontend/src/index.css#L325-L329)<br>[BondDetail.css:L197-L206](file:///c:/Users/opulencechuks/Credence-Frontend/src/pages/BondDetail.css#L197-L206) |
+| **Settings Grid Split** (900px) | `min-width: 900px`                       | Transitions Settings page layout from a single-column block to a two-column sidebar layout (`1fr 360px`).                                | [Settings.css:L63-L72](file:///c:/Users/opulencechuks/Credence-Frontend/src/pages/Settings.css#L63-L72)                                                                                                                                                                                                                             |
+| **Desktop Base** (1024px)       | (Design spec target)                     | Core desktop design grid. Dynamic layout cards extend to maximum grid column configurations.                                             | [FIGMA_DESIGN_SPECS.md](file:///c:/Users/opulencechuks/Credence-Frontend/docs/FIGMA_DESIGN_SPECS.md#L242-L280)                                                                                                                                                                                                                      |
+| **Widescreen Desktop** (1280px) | `min-width: 1280px`                      | Keyboard shortcuts help, confirm dialogs, and trust score gauges transition to centered overlay states.                                  | [ConfirmDialog.css:L238-L242](file:///c:/Users/opulencechuks/Credence-Frontend/src/components/ConfirmDialog.css#L238-L242)<br>[TrustGauge.css:L362-L373](file:///c:/Users/opulencechuks/Credence-Frontend/src/components/TrustGauge.css#L362-L373)                                                                                  |
 
 ---
 
 ## 🧭 Primary Route Layout Reflow Rules
 
 ### 1. Home Route
+
 - **Files**: [Home.tsx](file:///c:/Users/opulencechuks/Credence-Frontend/src/pages/Home.tsx) \| [Home.css](file:///c:/Users/opulencechuks/Credence-Frontend/src/pages/Home.css)
 - **Grid Structure**: Built using a grid layout with a token-driven gap (`gap: var(--credence-space-6)`).
-- **Reflow Behavior**: 
+- **Reflow Behavior**:
   - Call-To-Action (CTA) button row uses `.home__ctaRow` with `display: flex; flex-wrap: wrap; gap: var(--credence-space-4);` to naturally wrap primary/secondary action buttons on narrow mobile views without requiring explicit media query blocks.
 
 ### 2. Bond Route
+
 - **Files**: [Bond.tsx](file:///c:/Users/opulencechuks/Credence-Frontend/src/pages/Bond.tsx) \| [Bond.css](file:///c:/Users/opulencechuks/Credence-Frontend/src/pages/Bond.css)
 - **Grid Structure**: Main layout uses `.bond__container` grid with a gap of `var(--credence-space-8)`.
 - **Reflow Behavior**:
@@ -36,6 +38,7 @@ The Credence frontend targets several key viewport thresholds to adapt layouts f
   - Active bond list items (`.bond__rowHeader`) wrap buttons below status badges using flex-wrap rules [Bond.css:L64-L70](file:///c:/Users/opulencechuks/Credence-Frontend/src/pages/Bond.css#L64-L70).
 
 ### 3. Trust Score Route
+
 - **Files**: [TrustScore.tsx](file:///c:/Users/opulencechuks/Credence-Frontend/src/pages/TrustScore.tsx) \| [TrustScore.css](file:///c:/Users/opulencechuks/Credence-Frontend/src/pages/TrustScore.css)
 - **Grid Structure**: Main content layouts reflow through `.trustScore__grid`.
 - **Reflow Behavior**:
@@ -43,6 +46,7 @@ The Credence frontend targets several key viewport thresholds to adapt layouts f
   - This allows side-by-side display on tablet/desktop sizes and cleanly stacks into a single column on mobile screen widths under ~632px.
 
 ### 4. Settings Route
+
 - **Files**: [Settings.tsx](file:///c:/Users/opulencechuks/Credence-Frontend/src/pages/Settings.tsx) \| [Settings.css](file:///c:/Users/opulencechuks/Credence-Frontend/src/pages/Settings.css)
 - **Grid Structure**: Main section layout wraps within `.settings-page`.
 - **Reflow Behavior**:
@@ -57,31 +61,51 @@ The Credence frontend targets several key viewport thresholds to adapt layouts f
 
 To maintain visual consistency and support high-quality dark/light mode adjustments, **all layout spacing, margins, paddings, and border-radii must be driven by custom variables defined in [src/index.css](file:///c:/Users/opulencechuks/Credence-Frontend/src/index.css). Hardcoded pixel values for layout structure are strictly prohibited.**
 
-### Spacing Tokens (`--credence-space-*`)
-These tokens drive grid gaps, margin blocks, and component padding rules:
+### Fluid Spacing Tokens (`--credence-space-*`)
 
-| Token Name | Value | Rem Equivalent | Pixel Equivalent |
-| :--- | :--- | :--- | :--- |
-| `--credence-space-1` | `0.25rem` | 0.25rem | 4px |
-| `--credence-space-2` | `0.5rem` | 0.5rem | 8px |
-| `--credence-space-3` | `0.75rem` | 0.75rem | 12px |
-| `--credence-space-4` | `1rem` | 1.0rem | 16px |
-| `--credence-space-5` | `1.25rem` | 1.25rem | 20px |
-| `--credence-space-6` | `1.5rem` | 1.5rem | 24px |
-| `--credence-space-8` | `2rem` | 2.0rem | 32px |
-| `--credence-space-12` | `3rem` | 3.0rem | 48px |
-| `--credence-container-padding` | `clamp(1rem, 2vw, 2rem)` | Dynamic | Dynamic (16px to 32px) |
+Every spacing token is a **fluid value** expressed with
+`clamp(<narrow-mobile>, <fluid>, <widescreen-desktop>)`. The middle
+expression is a linear interpolation between the
+[BREAKPOINTS.XS](src/config/breakpoints.ts) (360px) and
+`BREAKPOINTS.XL` (1280px) ranges so that layouts feel consistent from
+phone to desktop **without per-component media queries**.
+
+Authoring rule of thumb: pick the smallest token whose fluid range fits
+your visual intent; avoid writing `@media` overrides for spacing — change
+the token instead. Page-specific overrides such as the existing Settings
+narrow-viewport trim (`max-width: 374px`) remain valid for _structural_
+layout shifts but should not be needed for routine padding/margin tweaks.
+
+| Token Name                     | Value (CSS)                                  | XS (360px) | XL (1280px)             |
+| :----------------------------- | :------------------------------------------- | :--------- | :---------------------- |
+| `--credence-space-1`           | `clamp(0.20rem, 0.18rem + 0.087vw, 0.25rem)` | 3.2px      | 4px                     |
+| `--credence-space-2`           | `clamp(0.40rem, 0.36rem + 0.174vw, 0.50rem)` | 6.4px      | 8px                     |
+| `--credence-space-3`           | `clamp(0.60rem, 0.54rem + 0.26vw, 0.75rem)`  | 9.6px      | 12px                    |
+| `--credence-space-4`           | `clamp(0.75rem, 0.65rem + 0.435vw, 1rem)`    | 12px       | 16px                    |
+| `--credence-space-5`           | `clamp(0.95rem, 0.83rem + 0.52vw, 1.25rem)`  | 15.2px     | 20px                    |
+| `--credence-space-6`           | `clamp(1.15rem, 1.01rem + 0.61vw, 1.5rem)`   | 18.4px     | 24px                    |
+| `--credence-space-8`           | `clamp(1.5rem, 1.3rem + 0.87vw, 2rem)`       | 24px       | 32px                    |
+| `--credence-space-12`          | `clamp(2.25rem, 1.96rem + 1.3vw, 3rem)`      | 36px       | 48px                    |
+| `--credence-space-16`          | `clamp(3rem, 2.61rem + 1.74vw, 4rem)`        | 48px       | 64px                    |
+| `--credence-container-padding` | `clamp(1rem, 0.71rem + 1.29vw, 2rem)`        | 16px       | 32px (≥1600px viewport) |
+
+> **Why fluid?** Spacing tone (the "feel" of breathing room) shifts
+> naturally with viewport width. Headers that read loose on a 1280px
+> display feel cramped on a 360px phone; collapsing them anywhere between
+> the two extremes keeps the visual rhythm consistent without maintainers
+> having to remember which `@media` block belongs to which selector.
 
 ### Radius Tokens (`--credence-radius-*`)
+
 These tokens define component border-radii for visual cards, controls, and elements:
 
-| Token Name | Value | Rem Equivalent | Pixel Equivalent | Usage Context |
-| :--- | :--- | :--- | :--- | :--- |
-| `--credence-radius-sm` | `0.25rem` | 0.25rem | 4px | Small toggles, badges, status labels |
-| `--credence-radius-md` | `0.375rem` | 0.375rem | 6px | Buttons, dropdowns, input elements |
-| `--credence-radius-lg` | `0.5rem` | 0.5rem | 8px | Form fields, minor container panels |
-| `--credence-radius-xl` | `0.75rem` | 0.75rem | 12px | Major layout cards, visual components |
-| `--credence-radius-full` | `9999px` | 9999px | 9999px | Circular icons, pill toggles, tags |
+| Token Name               | Value      | Rem Equivalent | Pixel Equivalent | Usage Context                         |
+| :----------------------- | :--------- | :------------- | :--------------- | :------------------------------------ |
+| `--credence-radius-sm`   | `0.25rem`  | 0.25rem        | 4px              | Small toggles, badges, status labels  |
+| `--credence-radius-md`   | `0.375rem` | 0.375rem       | 6px              | Buttons, dropdowns, input elements    |
+| `--credence-radius-lg`   | `0.5rem`   | 0.5rem         | 8px              | Form fields, minor container panels   |
+| `--credence-radius-xl`   | `0.75rem`  | 0.75rem        | 12px             | Major layout cards, visual components |
+| `--credence-radius-full` | `9999px`   | 9999px         | 9999px           | Circular icons, pill toggles, tags    |
 
 ---
 
@@ -110,6 +134,7 @@ Layout code must proactively address common mobile edge cases to meet the layout
 Before submitting a pull request, manually verify the visual layout behavior at the following target dimensions:
 
 ### 📱 1. Narrow Mobile Check (360px viewport width)
+
 - [ ] **No Horizontal Scroll**: Ensure the page has no horizontal scrollbars.
 - [ ] **Spacing Compression**: Spacing collapses smoothly (Settings page matches `0.5rem` spacing; main containers clamp to `1rem`).
 - [ ] **Flexible Buttons**: Buttons inside cards and backup lists wrap neatly; no text overflows button borders.
@@ -117,12 +142,14 @@ Before submitting a pull request, manually verify the visual layout behavior at 
 - [ ] **Interactive Elements**: Input elements and selectors scale to fill the viewport width safely.
 
 ### 📟 2. Tablet View Check (768px viewport width)
+
 - [ ] **Stacked Grids**: Double-column dashboard panels and layout cards stack vertically into a single column.
 - [ ] **Hamburger Menu Toggle**: Desktop links are hidden; hamburger menu correctly opens the focus-trapped sliding menu.
 - [ ] **Table Reflow**: Transaction tables transition from horizontal headers into vertical card blocks.
 - [ ] **Footer Alignment**: Footer contents align vertically in a single stacked block without overlapping text.
 
 ### 💻 3. Desktop View Check (1280px+ viewport width)
+
 - [ ] **Container Bounds**: Page layouts respect the maximum container width limit (`--credence-container-max: 72rem`) and align centrally on the screen.
 - [ ] **Side-by-Side Columns**: Cards and sidebar elements display in their multi-column layouts.
 - [ ] **Overlays**: Interactive dialogs and shortcuts windows are centered overlays with proper screen backdrops.
@@ -132,6 +159,7 @@ Before submitting a pull request, manually verify the visual layout behavior at 
 ## 🔗 Cross-References & Design Resources
 
 To avoid duplicate documentation, refer to the following background notes for specific styling context:
+
 - [FIGMA_DESIGN_SPECS.md](file:///c:/Users/opulencechuks/Credence-Frontend/docs/FIGMA_DESIGN_SPECS.md#L242-L280) — Pixel specs for mobile, tablet, and desktop skeletons and empty states.
 - [figma-nav-rules.md](file:///c:/Users/opulencechuks/Credence-Frontend/docs/figma-nav-rules.md) — Specifications for interactive states, drawer dimensions, and backdrop layers.
 - [mobile-navigation-pattern.md](file:///c:/Users/opulencechuks/Credence-Frontend/docs/mobile-navigation-pattern.md) — Technical details regarding focus traps, ARIA properties, and transition timings.

--- a/src/components/Layout.css
+++ b/src/components/Layout.css
@@ -7,6 +7,10 @@
 }
 
 .appHeader {
+  /* Fluid padding via --credence-space-* tokens (see src/index.css).
+   * On Narrow Mobile (≤ 360px) this resolves to ~0.75rem / ~1.5rem and
+   * gracefully scales to 1rem / 2rem at the Widescreen Desktop breakpoint
+   * (1280px) without an explicit media query. */
   padding: var(--credence-space-4) var(--credence-space-8);
   border-bottom: 1px solid var(--credence-border-default);
   background: var(--credence-surface-card);
@@ -191,31 +195,29 @@
   background: var(--credence-color-slate-700);
 }
 
-/* Mobile: hide desktop nav, tighten header padding */
+/* Mobile (BREAKPOINTS.SM, 640px): hide desktop in-line nav. Header padding
+ * automatically tightens via the fluid --credence-space-* tokens, so no
+ * explicit padding override is needed. */
 @media (max-width: 640px) {
   .appNav {
     display: none;
   }
-
-  .appHeader {
-    padding: var(--credence-space-3) var(--credence-space-4);
-  }
 }
 
-/* Very small screens (360px): further tighten header padding */
+/* Narrow Mobile (BREAKPOINTS.XS, 360px): brand wordmark shrinks one step
+ * to fit the smallest supported viewport. Spacing continues to scale fluidly
+ * via tokens, so no padding override is needed. */
 @media (max-width: 360px) {
-  .appHeader {
-    padding: var(--credence-space-2) var(--credence-space-3);
-  }
-
   .appBrand {
     font-size: var(--credence-font-size-lg);
   }
 }
 
-/* Safe area: prevent content from being obscured by the fixed BottomNav */
+/* Safe area: prevent content from being obscured by the fixed BottomNav at
+ * the mobile/tablet breakpoint. Uses the fluid --credence-space-16 token
+ * (introduced in src/index.css to round out the spacing scale). */
 @media (max-width: 768px) {
   .appMain {
-    padding-bottom: calc(var(--credence-space-16, 4rem) + var(--credence-space-4));
+    padding-bottom: calc(var(--credence-space-16) + var(--credence-space-4));
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -13,15 +13,33 @@
   --credence-line-height-base: 1.5;
   --credence-line-height-relaxed: 1.6;
 
-  /* Spacing */
-  --credence-space-1: 0.25rem;
-  --credence-space-2: 0.5rem;
-  --credence-space-3: 0.75rem;
-  --credence-space-4: 1rem;
-  --credence-space-5: 1.25rem;
-  --credence-space-6: 1.5rem;
-  --credence-space-8: 2rem;
-  --credence-space-12: 3rem;
+  /* Spacing — fluid scale.
+   *
+   * Each space-* token is defined with `clamp(min, fluid, max)` so that
+   * layouts respond smoothly to the viewport width. The `min` value is the
+   * target rendered size at our Narrow Mobile breakpoint (BREAKPOINTS.XS,
+   * 360px) and the `max` is the rendered size at the Widescreen Desktop
+   * breakpoint (BREAKPOINTS.XL, 1280px). Linear interpolation between
+   * 360px–1280px gives every intermediate viewport a consistent,
+   * predictable amount of breathing room without per-component media
+   * queries. Viewports narrower than 360px or wider than 1280px hold at
+   * the min / max respectively so layout integrity is preserved at the
+   * edges of our responsive contract (see docs/RESPONSIVE.md).
+   *
+   * Example: `--credence-space-4` = `clamp(0.75rem, 0.65rem + 0.435vw, 1rem)`
+   *   • 360px viewport → 0.75rem (12px)
+   *   • 768px viewport → ~0.87rem (~14px)
+   *   • 1280px viewport → 1rem (16px)
+   */
+  --credence-space-1: clamp(0.2rem, 0.18rem + 0.087vw, 0.25rem);
+  --credence-space-2: clamp(0.4rem, 0.36rem + 0.174vw, 0.5rem);
+  --credence-space-3: clamp(0.6rem, 0.54rem + 0.26vw, 0.75rem);
+  --credence-space-4: clamp(0.75rem, 0.65rem + 0.435vw, 1rem);
+  --credence-space-5: clamp(0.95rem, 0.83rem + 0.52vw, 1.25rem);
+  --credence-space-6: clamp(1.15rem, 1.01rem + 0.61vw, 1.5rem);
+  --credence-space-8: clamp(1.5rem, 1.3rem + 0.87vw, 2rem);
+  --credence-space-12: clamp(2.25rem, 1.96rem + 1.3vw, 3rem);
+  --credence-space-16: clamp(3rem, 2.61rem + 1.74vw, 4rem);
 
   /* Radius */
   --credence-radius-sm: 0.25rem;
@@ -52,7 +70,13 @@
 
   /* Layout */
   --credence-container-max: 72rem;
-  --credence-container-padding: clamp(1rem, 2vw, 2rem);
+  /* Fluid container padding for the outer page edges. Hits 1rem at the
+   * Narrow Mobile breakpoint (360px), grows linearly to 2rem once the
+   * viewport exceeds ~1600px. Reframed from the prior `clamp(1rem, 2vw,
+   * 2rem)` formula to share the same endpoint convention used by
+   * `--credence-space-*` tokens; the resulting 1rem–2rem range is
+   * preserved. */
+  --credence-container-padding: clamp(1rem, 0.71rem + 1.29vw, 2rem);
 
   /* Neutrals */
   --credence-color-white: #ffffff;


### PR DESCRIPTION
## Summary

closes #826

Implements a fluid responsive spacing system across breakpoints so layouts feel consistent from mobile to desktop without per-component media queries.

## What changed

### Global styles — `src/index.css`
- Convert static `--credence-space-*` tokens (`space-1` ... `space-12`) into fluid `clamp(min, fluid, max)` values that scale linearly between the **Narrow Mobile** breakpoint (`BREAKPOINTS.XS` = 360px) and the **Widescreen Desktop** breakpoint (`BREAKPOINTS.XL` = 1280px).
- Add `--credence-space-16` to round out the scale so callers (e.g. safe-area padding for the fixed `BottomNav`) don't need a hard-coded fallback.
- Reframe `--credence-container-padding` with the same fluid-token convention so page gutters stay consistent.

### Layout components — `src/components/Layout.css`
- Remove the now-redundant `appHeader` padding `@media` overrides at `≤640px` and `≤360px` — the fluid tokens achieve the same responsive tightening automatically.
- Add explanatory comments so future contributors do not re-introduce discrete overrides.

### Docs — `docs/RESPONSIVE.md`
- Update the spacing token table with the new `clamp()` formulas and rendered sizes at XS/XL.
- Document the authoring rule of thumb: prefer tokens over `@media` overrides for routine spacing.

## Verification
- `npx prettier --check` clean on all modified files.
- `npx eslint` clean.
- Browser-rendered math verified: e.g. `--credence-space-4` = 12px @ 360px, 16px @ 1280px.
- Pre-existing TypeScript and i18n test errors are unrelated to these CSS-only changes.

## Backwards compatibility
- Token alias chain (`--container-padding`, `--space-6`, `--slate-900`, etc.) preserved.
- Dark-theme overrides unchanged.

## Linked issue
fixes/closes #826