### PR TITLE
feat(uiux): standardize Bond page layout and action card grid

### DIFF
--- a/src/components/ActionCard.css
+++ b/src/components/ActionCard.css
@@ -8,7 +8,9 @@
   color: var(--credence-text-primary);
   /* Default padding */
   padding: var(--credence-space-6);
-  transition: transform var(--credence-motion-duration-fast, 0.2s) ease, box-shadow var(--credence-motion-duration-fast, 0.2s) ease;
+  transition:
+    transform var(--credence-motion-duration-fast, 0.2s) ease,
+    box-shadow var(--credence-motion-duration-fast, 0.2s) ease;
   position: relative;
   overflow: hidden;
 }
@@ -44,21 +46,29 @@
 }
 
 .actionCard--elevated {
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+    0 2px 4px -1px rgba(0, 0, 0, 0.06);
 }
 
 .actionCard--elevated:hover {
   transform: translateY(-2px);
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  box-shadow:
+    0 10px 15px -3px rgba(0, 0, 0, 0.1),
+    0 4px 6px -2px rgba(0, 0, 0, 0.05);
 }
 
 /* Dark mode flips tokens */
-[data-theme="dark"] .actionCard--elevated {
-  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.5), 0 2px 4px -1px rgba(0, 0, 0, 0.3);
+[data-theme='dark'] .actionCard--elevated {
+  box-shadow:
+    0 4px 6px -1px rgba(0, 0, 0, 0.5),
+    0 2px 4px -1px rgba(0, 0, 0, 0.3);
 }
 
-[data-theme="dark"] .actionCard--elevated:hover {
-  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.5), 0 4px 6px -2px rgba(0, 0, 0, 0.3);
+[data-theme='dark'] .actionCard--elevated:hover {
+  box-shadow:
+    0 10px 15px -3px rgba(0, 0, 0, 0.5),
+    0 4px 6px -2px rgba(0, 0, 0, 0.3);
 }
 
 .actionCard__header {
@@ -91,7 +101,8 @@
   color: var(--credence-text-secondary);
   cursor: pointer;
   flex-shrink: 0;
-  transition: color var(--credence-motion-duration-fast, 0.2s) ease,
+  transition:
+    color var(--credence-motion-duration-fast, 0.2s) ease,
     background-color var(--credence-motion-duration-fast, 0.2s) ease,
     border-color var(--credence-motion-duration-fast, 0.2s) ease;
 }
@@ -124,16 +135,18 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background-color var(--credence-motion-duration-fast, 0.2s) ease, color var(--credence-motion-duration-fast, 0.2s) ease;
+  transition:
+    background-color var(--credence-motion-duration-fast, 0.2s) ease,
+    color var(--credence-motion-duration-fast, 0.2s) ease;
 }
 
 .actionCard__close:hover {
-  background-color: var(--credence-surface-hover, rgba(0,0,0,0.05));
+  background-color: var(--credence-surface-hover, rgba(0, 0, 0, 0.05));
   color: var(--credence-text-primary, #0f172a);
 }
 
-[data-theme="dark"] .actionCard__close:hover {
-  background-color: var(--credence-surface-hover, rgba(255,255,255,0.1));
+[data-theme='dark'] .actionCard__close:hover {
+  background-color: var(--credence-surface-hover, rgba(255, 255, 255, 0.1));
   color: var(--credence-text-primary, #f8fafc);
 }
 

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useCallback, useState } from 'react'
+import type { ToastSeverity, ToastData } from '../events'
 import './Toast.css'
 
 export type { ToastSeverity, ToastData }
@@ -67,7 +68,6 @@ const ICONS: Record<ToastSeverity, React.ReactNode> = {
     </svg>
   ),
 }
-
 
 interface ToastProps {
   toast: ToastData

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -3,6 +3,9 @@ import { initReactI18next } from 'react-i18next'
 import LanguageDetector from 'i18next-browser-languagedetector'
 import en from './locales/en.json'
 import { handleLanguageChanged, setPreviousLng } from './localeBreadcrumb'
+import { getDefaultLocale } from '@/config/i18n'
+
+const defaultLocale = getDefaultLocale()
 
 i18n
   .use(LanguageDetector)

--- a/src/index.css
+++ b/src/index.css
@@ -21,6 +21,7 @@
   --credence-space-5: 1.25rem;
   --credence-space-6: 1.5rem;
   --credence-space-8: 2rem;
+  --credence-space-10: 2.5rem;
   --credence-space-12: 3rem;
 
   /* Radius */

--- a/src/pages/Bond.css
+++ b/src/pages/Bond.css
@@ -40,6 +40,11 @@
   align-items: start;
 }
 
+.bond__cardDescription {
+  margin: 0;
+  color: var(--credence-text-secondary);
+}
+
 /* Bond list container */
 .bond__listContainer {
   list-style: none;
@@ -149,4 +154,3 @@
   color: var(--credence-color-danger-action);
   font-weight: var(--credence-font-weight-semibold);
 }
-

--- a/src/pages/Bond.tsx
+++ b/src/pages/Bond.tsx
@@ -199,13 +199,7 @@ export default function Bond() {
   return (
     <div className="bond__container">
       {/* aria-live region announces async transaction progress to assistive tech */}
-      <div
-        id={txStatusId}
-        role="status"
-        aria-live="polite"
-        aria-atomic="true"
-        className="sr-only"
-      >
+      <div id={txStatusId} role="status" aria-live="polite" aria-atomic="true" className="sr-only">
         {txStatus}
       </div>
 
@@ -216,9 +210,7 @@ export default function Bond() {
         </p>
       </div>
 
-      <Banner severity="info">
-        {t('bond.infoBanner')}
-      </Banner>
+      <Banner severity="info">{t('bond.infoBanner')}</Banner>
 
       {!isConnected && (
         <Banner
@@ -242,7 +234,7 @@ export default function Bond() {
           <span id={mismatchBannerId}>
             {t('bond.networkMismatchDescription', {
               expected: networkMismatch.expected,
-              actual: networkMismatch.actual
+              actual: networkMismatch.actual,
             })}
           </span>
         </Banner>
@@ -255,16 +247,14 @@ export default function Bond() {
             status: slashExposureBond.status === 'locked' ? 'locked' : 'in grace period',
             penaltyAmount: slashBannerBreakdown.penaltyAmount,
             percent: slashBannerBreakdown.penaltyPercent,
-            result: slashBannerBreakdown.resultingBalance
+            result: slashBannerBreakdown.resultingBalance,
           })}
         </Banner>
       )}
 
       <div className="bond__cardGrid">
         <ActionCard title={t('bond.createNewBond')}>
-          <p style={{ color: 'var(--credence-text-secondary)', margin: 0 }}>
-            {t('bond.createBondDescription')}
-          </p>
+          <p className="bond__cardDescription">{t('bond.createBondDescription')}</p>
 
           <FormField
             id="bond-amount-quick"
@@ -319,7 +309,7 @@ export default function Bond() {
                   bond={bond}
                   isConnected={isConnected}
                   onWithdraw={requestWithdraw}
-                    onConnect={() => setConnectModalOpen(true)}
+                  onConnect={() => setConnectModalOpen(true)}
                 />
               ))}
             </ul>
@@ -334,7 +324,7 @@ export default function Bond() {
             title={t('bond.confirmWithdrawal')}
             subtitle={t('bond.withdrawalSubtitle', {
               id: withdrawTarget.id,
-              amount: formatUsdc(withdrawTarget.amountUsdc)
+              amount: formatUsdc(withdrawTarget.amountUsdc),
             })}
             breakdown={withdrawBreakdown}
             onConfirm={confirmWithdraw}
@@ -351,9 +341,7 @@ export default function Bond() {
         returnFocusRef={connectTriggerRef}
       />
 
-      <Disclaimer
-        context="Bonding USDC locks funds in a non-custodial smart contract. Slashing conditions apply."
-      />
+      <Disclaimer context="Bonding USDC locks funds in a non-custodial smart contract. Slashing conditions apply." />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Replaces the last inline `style={{}}` on the Bond page (the create-bond card description) with a token-driven CSS class, `bond__cardDescription`, matching how `Bond.css` already handles every other element on the page.
- Adds the missing `--credence-space-10` spacing token. `ActionCard.css`'s beta-ribbon padding already referenced this token, but it was never defined in `src/index.css`'s spacing scale (which jumped 6 → 8 → 12), so it silently resolved to an invalid/zero value.
- The rest of the Bond page grid and `ActionCard` (used for both action cards) were already fully token-driven (`--credence-space-*`), so no other structural changes were needed.

## Pre-existing repo issues found (unrelated, included minimally to get a working build)
While verifying this change I found the app's build/dev-server/test suite is currently broken on `main` due to prior merges (`-X theirs`) that dropped variable/type definitions while keeping their usages:
- `src/i18n/config.ts` referenced an undefined `defaultLocale` (broke the entire Vitest suite).
- `src/components/Toast.tsx` re-exported `ToastSeverity`/`ToastData` types it never imported (broke the app in the browser, not just tests).

Both are restored to their original wiring in an isolated commit, since they were blocking me from running tests/build locally at all. I did **not** attempt to fix several other pre-existing broken files I found in the same pass (e.g. `src/components/AddressInput.tsx`, `src/pages/Dashboard.tsx`, `src/components/ActivityTimeline.tsx` all have duplicate-declaration errors from similar bad merges) — that's a much larger, separate cleanup unrelated to this Bond UI/UX ticket and worth tracking as its own issue.

Closes #804

## Test plan
- [x] `npx vitest run src/pages/Bond.test.tsx` — 21/21 passing
- [x] `npx prettier --check` and `npx eslint` clean on all 6 touched files
- [x] Visual QA of the Bond page via an isolated preview harness (full app dev server is blocked by the pre-existing unrelated breakage noted above)
- [ ] Full `npm run build` / `npm run lint` / `npm run test` are red on this branch, but identically red on `main` before this change (verified via `git stash`), for reasons unrelated to this PR