### PR TITLE
feat(uiux): standardize button variants and interactive states

### DIFF
--- a/src/components/Button.css
+++ b/src/components/Button.css
@@ -1,7 +1,11 @@
 /*
- * Button System: primary/secondary/ghost variants + disabled/loading states
- * Follows Credence design tokens and accessibility requirements
+ * Button System: primary / secondary / ghost / danger / link variants
+ * Size variants: sm / md (default) / lg
+ * Interactive states: hover, active, focus-visible, disabled, loading
+ * Follows Credence design tokens and WCAG 2.1 focus-ring requirements.
  */
+
+/* ─── Base ────────────────────────────────────────────────────────────────── */
 
 .credence-button {
   position: relative;
@@ -9,36 +13,89 @@
   align-items: center;
   justify-content: center;
   gap: var(--credence-space-2);
-  padding: var(--credence-space-3) var(--credence-space-6);
   font-family: var(--credence-font-family-base);
-  font-size: var(--credence-font-size-base);
   font-weight: var(--credence-font-weight-semibold);
   line-height: var(--credence-line-height-tight);
   border-radius: var(--credence-radius-lg);
   border: 2px solid transparent;
   cursor: pointer;
+  text-decoration: none;
   transition:
-    background-color 0.2s ease,
-    border-color 0.2s ease,
-    color 0.2s ease,
-    transform 0.1s ease;
+    background-color var(--credence-motion-duration-fast) var(--credence-motion-easing-standard),
+    border-color var(--credence-motion-duration-fast) var(--credence-motion-easing-standard),
+    color var(--credence-motion-duration-fast) var(--credence-motion-easing-standard),
+    box-shadow var(--credence-motion-duration-fast) var(--credence-motion-easing-standard),
+    transform var(--credence-motion-duration-fast) var(--credence-motion-easing-standard);
   white-space: nowrap;
+  /* Ensure the focus ring is never clipped by overflow:hidden parents */
+  isolation: isolate;
 }
 
 .credence-button:active:not(:disabled) {
   transform: translateY(1px);
 }
 
+/* ─── Focus styles ────────────────────────────────────────────────────────── */
+/*
+ * Two-layer ring technique: a thin offset outline + a contrasting shadow ring.
+ * This is visible against both light and dark backgrounds without needing
+ * separate media queries. The outer ring uses the page background colour so it
+ * always creates a visible gap regardless of the button's own colour.
+ *
+ * WCAG 2.1 SC 2.4.7 (Level AA) — focus indicator visible.
+ * WCAG 2.2 SC 2.4.11 (Level AA) — enhanced focus appearance.
+ */
 .credence-button:focus-visible {
-  outline: var(--credence-focus-ring);
-  outline-offset: 2px;
+  outline: 3px solid var(--credence-color-focus-ring);
+  outline-offset: 3px;
+  box-shadow: 0 0 0 5px var(--credence-surface-page);
 }
+
+/* Dark mode: invert the halo so the white gap still separates ring from button */
+[data-theme='dark'] .credence-button:focus-visible {
+  outline-color: var(--credence-color-primary);
+  box-shadow:
+    0 0 0 5px var(--credence-surface-page),
+    0 0 0 7px var(--credence-color-primary);
+}
+
+/* High-contrast media query: draw an extra opaque border so the ring is
+   visible even when forced-colour overrides remove box-shadow. */
+@media (forced-colors: active) {
+  .credence-button:focus-visible {
+    outline: 3px solid ButtonText;
+    outline-offset: 3px;
+    box-shadow: none;
+  }
+}
+
+/* ─── Sizes ───────────────────────────────────────────────────────────────── */
+
+.credence-button--sm {
+  padding: var(--credence-space-1) var(--credence-space-3);
+  font-size: var(--credence-font-size-sm);
+  border-radius: var(--credence-radius-md);
+}
+
+.credence-button--md {
+  padding: var(--credence-space-3) var(--credence-space-6);
+  font-size: var(--credence-font-size-base);
+}
+
+.credence-button--lg {
+  padding: var(--credence-space-4) var(--credence-space-8);
+  font-size: var(--credence-font-size-lg);
+  border-radius: var(--credence-radius-xl);
+}
+
+/* ─── Full width ──────────────────────────────────────────────────────────── */
 
 .credence-button--full-width {
   width: 100%;
 }
 
-/* Primary variant - main CTAs */
+/* ─── Primary variant — main CTAs ────────────────────────────────────────── */
+
 .credence-button--primary {
   background: var(--credence-color-primary);
   color: var(--credence-color-white);
@@ -54,7 +111,8 @@
   background: var(--credence-color-primary-strong);
 }
 
-/* Secondary variant - alternative actions */
+/* ─── Secondary variant — alternative actions ────────────────────────────── */
+
 .credence-button--secondary {
   background: var(--credence-surface-card);
   color: var(--credence-text-primary);
@@ -80,7 +138,8 @@
   border-color: var(--credence-color-slate-500);
 }
 
-/* Ghost variant - subtle actions */
+/* ─── Ghost variant — subtle actions ─────────────────────────────────────── */
+
 .credence-button--ghost {
   background: transparent;
   color: var(--credence-color-primary);
@@ -104,7 +163,8 @@
   background: rgba(56, 189, 248, 0.15);
 }
 
-/* Danger variant - destructive confirmations */
+/* ─── Danger variant — destructive confirmations ─────────────────────────── */
+
 .credence-button--danger {
   background: var(--credence-color-danger-action);
   color: var(--credence-color-white);
@@ -128,7 +188,67 @@
   opacity: 1;
 }
 
-/* Disabled state - all variants */
+/* Danger focus ring uses a red tint for extra context */
+.credence-button--danger:focus-visible {
+  outline-color: var(--credence-color-danger-border);
+}
+
+/* ─── Link variant — inline text actions ─────────────────────────────────── */
+/*
+ * Looks like a hyperlink but fires a button action. Useful for "Cancel",
+ * "Dismiss", or secondary text-level actions inside forms.
+ */
+
+.credence-button--link {
+  background: transparent;
+  color: var(--credence-color-primary);
+  border-color: transparent;
+  border-radius: var(--credence-radius-sm);
+  padding-inline: var(--credence-space-1);
+  padding-block: 0;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  font-weight: var(--credence-font-weight-regular);
+}
+
+.credence-button--link:hover:not(:disabled) {
+  color: var(--credence-color-primary-strong);
+  text-decoration-thickness: 2px;
+}
+
+.credence-button--link:active:not(:disabled) {
+  color: var(--credence-color-primary-strong);
+  transform: none; /* link buttons don't press-down */
+}
+
+.credence-button--link:disabled {
+  color: var(--credence-color-slate-400);
+  text-decoration: none;
+  opacity: 1; /* override base :disabled opacity to avoid double-fading */
+}
+
+/* Link buttons use underline-based focus so it's clear it is inline text */
+.credence-button--link:focus-visible {
+  outline: 2px solid var(--credence-color-focus-ring);
+  outline-offset: 2px;
+  box-shadow: none;
+  border-radius: var(--credence-radius-sm);
+}
+
+[data-theme='dark'] .credence-button--link {
+  color: var(--credence-color-primary);
+}
+
+[data-theme='dark'] .credence-button--link:hover:not(:disabled) {
+  color: var(--credence-color-primary-strong);
+}
+
+[data-theme='dark'] .credence-button--link:disabled {
+  color: var(--credence-color-slate-500);
+}
+
+/* ─── Disabled state — all variants ──────────────────────────────────────── */
+
 .credence-button:disabled {
   cursor: not-allowed;
   opacity: 0.5;
@@ -155,7 +275,8 @@
   color: var(--credence-color-slate-400);
 }
 
-/* Loading state */
+/* ─── Loading state ───────────────────────────────────────────────────────── */
+
 .credence-button__spinner {
   position: absolute;
   left: 50%;
@@ -192,6 +313,7 @@
   from {
     transform: rotate(0deg);
   }
+
   to {
     transform: rotate(360deg);
   }
@@ -203,17 +325,24 @@
   }
 }
 
-/* Responsive adjustments */
+/* ─── Responsive adjustments ─────────────────────────────────────────────── */
+
 @media (max-width: 768px) {
-  .credence-button {
+  .credence-button--md {
     padding: var(--credence-space-3) var(--credence-space-4);
     font-size: var(--credence-font-size-sm);
+  }
+
+  .credence-button--lg {
+    padding: var(--credence-space-3) var(--credence-space-6);
+    font-size: var(--credence-font-size-base);
   }
 }
 
 /* Very small screens (360px): further reduce button padding */
 @media (max-width: 360px) {
-  .credence-button {
+  .credence-button--md,
+  .credence-button--lg {
     padding: var(--credence-space-2) var(--credence-space-3);
     font-size: var(--credence-font-size-xs);
   }

--- a/src/components/Button.stories.test.tsx
+++ b/src/components/Button.stories.test.tsx
@@ -1,11 +1,10 @@
 import { render, screen } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 import Button, { ButtonProps } from './Button'
-import { Primary, Disabled } from './Button.stories'
+import { Primary, Disabled, Link, Small, Large } from './Button.stories'
 
 describe('Button Stories', () => {
   it('happy-path: renders the Primary story correctly', () => {
-    // We test that the story args can be used to render the component correctly
     render(<Button {...(Primary.args as ButtonProps)} />)
     const button = screen.getByRole('button', { name: /Primary Button/i })
     expect(button).toBeInTheDocument()
@@ -13,10 +12,29 @@ describe('Button Stories', () => {
   })
 
   it('failure-mode: Disabled story renders a disabled button', () => {
-    // Tests an explicit "failure" or disabled mode of the component
     render(<Button {...(Disabled.args as ButtonProps)} />)
     const button = screen.getByRole('button', { name: /Disabled Button/i })
     expect(button).toBeInTheDocument()
     expect(button).toBeDisabled()
+  })
+
+  it('Link story renders a link-variant button', () => {
+    render(<Button {...(Link.args as ButtonProps)} />)
+    const button = screen.getByRole('button', { name: /Link Button/i })
+    expect(button).toBeInTheDocument()
+    expect(button).toHaveClass('credence-button--link')
+    expect(button).not.toBeDisabled()
+  })
+
+  it('Small story renders with sm size class', () => {
+    render(<Button {...(Small.args as ButtonProps)} />)
+    const button = screen.getByRole('button', { name: /Small/i })
+    expect(button).toHaveClass('credence-button--sm')
+  })
+
+  it('Large story renders with lg size class', () => {
+    render(<Button {...(Large.args as ButtonProps)} />)
+    const button = screen.getByRole('button', { name: /Large/i })
+    expect(button).toHaveClass('credence-button--lg')
   })
 })

--- a/src/components/Button.stories.tsx
+++ b/src/components/Button.stories.tsx
@@ -8,8 +8,13 @@ const meta: Meta<typeof Button> = {
   argTypes: {
     variant: {
       control: 'select',
-      options: ['primary', 'secondary', 'ghost', 'danger'],
+      options: ['primary', 'secondary', 'ghost', 'danger', 'link'],
       description: 'Visual style variant',
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Size variant',
     },
     isLoading: {
       control: 'boolean',
@@ -30,6 +35,7 @@ const meta: Meta<typeof Button> = {
   },
   args: {
     variant: 'primary',
+    size: 'md',
     children: 'Click me',
     isLoading: false,
     fullWidth: false,
@@ -39,6 +45,8 @@ const meta: Meta<typeof Button> = {
 
 export default meta
 type Story = StoryObj<typeof Button>
+
+/* ─── All Variants ───────────────────────────────────────────────────────── */
 
 export const Primary: Story = {
   args: {
@@ -68,10 +76,59 @@ export const Danger: Story = {
   },
 }
 
+export const Link: Story = {
+  args: {
+    variant: 'link',
+    children: 'Link Button',
+  },
+}
+
+/* ─── Sizes ──────────────────────────────────────────────────────────────── */
+
+export const Small: Story = {
+  args: {
+    size: 'sm',
+    children: 'Small',
+  },
+}
+
+export const Medium: Story = {
+  args: {
+    size: 'md',
+    children: 'Medium (default)',
+  },
+}
+
+export const Large: Story = {
+  args: {
+    size: 'lg',
+    children: 'Large',
+  },
+}
+
+export const SizeComparison: Story = {
+  render: () => (
+    <div style={{ display: 'flex', gap: '1rem', alignItems: 'center', flexWrap: 'wrap' }}>
+      <Button size="sm">Small</Button>
+      <Button size="md">Medium</Button>
+      <Button size="lg">Large</Button>
+    </div>
+  ),
+}
+
+/* ─── States ─────────────────────────────────────────────────────────────── */
+
 export const Loading: Story = {
   args: {
     isLoading: true,
     children: 'Loading...',
+  },
+}
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    children: 'Disabled Button',
   },
 }
 
@@ -82,9 +139,152 @@ export const FullWidth: Story = {
   },
 }
 
-export const Disabled: Story = {
-  args: {
-    disabled: true,
-    children: 'Disabled Button',
-  },
+/* ─── Keyboard Focus Review ──────────────────────────────────────────────── */
+
+/**
+ * Focus review: Tab through all variants to verify the focus ring is visible
+ * against both the button background and the page background in both light
+ * and dark modes. The ring should create a clear separation and meet WCAG
+ * 2.1 SC 2.4.7 (Focus Visible) and 2.2 SC 2.4.11 (Focus Appearance).
+ *
+ * Test in:
+ * - Light mode
+ * - Dark mode
+ * - Windows High Contrast mode (forced-colors: active)
+ * - Reduced motion (prefers-reduced-motion: reduce)
+ */
+export const KeyboardFocusReview: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '1.5rem',
+        maxWidth: '600px',
+        padding: '2rem',
+      }}
+    >
+      <p style={{ marginBottom: '1rem', color: 'var(--credence-text-secondary)' }}>
+        <strong>Instructions:</strong> Press Tab to cycle through each button. Verify that the
+        focus ring is clearly visible on every variant in both light and dark modes.
+      </p>
+
+      <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+        <Button variant="primary">Primary</Button>
+        <Button variant="secondary">Secondary</Button>
+        <Button variant="ghost">Ghost</Button>
+        <Button variant="danger">Danger</Button>
+        <Button variant="link">Link</Button>
+      </div>
+
+      <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+        <Button size="sm">Small</Button>
+        <Button size="md">Medium</Button>
+        <Button size="lg">Large</Button>
+      </div>
+
+      <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+        <Button variant="primary" disabled>
+          Disabled Primary
+        </Button>
+        <Button variant="secondary" disabled>
+          Disabled Secondary
+        </Button>
+        <Button variant="link" disabled>
+          Disabled Link
+        </Button>
+      </div>
+
+      <div
+        style={{
+          background: 'var(--credence-color-slate-900)',
+          padding: '1rem',
+          borderRadius: '0.5rem',
+        }}
+      >
+        <p style={{ color: 'white', marginBottom: '0.5rem', fontSize: '0.875rem' }}>
+          Dark background test
+        </p>
+        <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+          <Button variant="primary">Primary</Button>
+          <Button variant="ghost">Ghost</Button>
+          <Button variant="link">Link</Button>
+        </div>
+      </div>
+    </div>
+  ),
+}
+
+/**
+ * Hover and active state review: Hover over each variant to verify that
+ * the hover state is visually distinct from the default state. Click and
+ * hold to verify the active (pressed) state.
+ */
+export const InteractiveStates: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '1.5rem',
+        maxWidth: '600px',
+        padding: '2rem',
+      }}
+    >
+      <p style={{ marginBottom: '1rem', color: 'var(--credence-text-secondary)' }}>
+        <strong>Instructions:</strong> Hover over each button to verify the hover state, then
+        click and hold to verify the active (pressed) state.
+      </p>
+
+      <div>
+        <h3 style={{ marginBottom: '0.5rem', fontSize: '1rem' }}>Primary</h3>
+        <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+          <Button variant="primary">Default</Button>
+          <Button variant="primary" disabled>
+            Disabled
+          </Button>
+        </div>
+      </div>
+
+      <div>
+        <h3 style={{ marginBottom: '0.5rem', fontSize: '1rem' }}>Secondary</h3>
+        <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+          <Button variant="secondary">Default</Button>
+          <Button variant="secondary" disabled>
+            Disabled
+          </Button>
+        </div>
+      </div>
+
+      <div>
+        <h3 style={{ marginBottom: '0.5rem', fontSize: '1rem' }}>Ghost</h3>
+        <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+          <Button variant="ghost">Default</Button>
+          <Button variant="ghost" disabled>
+            Disabled
+          </Button>
+        </div>
+      </div>
+
+      <div>
+        <h3 style={{ marginBottom: '0.5rem', fontSize: '1rem' }}>Danger</h3>
+        <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+          <Button variant="danger">Default</Button>
+          <Button variant="danger" disabled>
+            Disabled
+          </Button>
+        </div>
+      </div>
+
+      <div>
+        <h3 style={{ marginBottom: '0.5rem', fontSize: '1rem' }}>Link</h3>
+        <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+          <Button variant="link">Default</Button>
+          <Button variant="link" disabled>
+            Disabled
+          </Button>
+        </div>
+      </div>
+    </div>
+  ),
 }

--- a/src/components/Button.test.tsx
+++ b/src/components/Button.test.tsx
@@ -562,3 +562,137 @@ describe('Button – class string shape (no stray spaces regression)', () => {
     }
   })
 })
+
+// ---------------------------------------------------------------------------
+// 13. Link variant
+// ---------------------------------------------------------------------------
+
+describe('Button – link variant', () => {
+  it('applies credence-button--link class for variant="link"', () => {
+    render(<Button variant="link">Go back</Button>)
+    expect(getBtn()).toHaveClass('credence-button--link')
+    expect(getBtn()).not.toHaveClass('credence-button--primary')
+  })
+
+  it('fires onClick when link variant is clicked and enabled', async () => {
+    const handler = vi.fn()
+    render(
+      <Button variant="link" onClick={handler}>
+        Cancel
+      </Button>
+    )
+    await userEvent.click(getBtn())
+    expect(handler).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not fire onClick when link variant is disabled', async () => {
+    const handler = vi.fn()
+    render(
+      <Button variant="link" disabled onClick={handler}>
+        Disabled link
+      </Button>
+    )
+    await userEvent.click(getBtn())
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('is still a <button> element (not an <a>)', () => {
+    render(<Button variant="link">Link-style</Button>)
+    expect(getBtn().tagName).toBe('BUTTON')
+  })
+
+  it('forwards ref correctly for link variant', () => {
+    const ref = createRef<HTMLButtonElement>()
+    render(
+      <Button ref={ref} variant="link">
+        Ref link
+      </Button>
+    )
+    expect(ref.current).toBeInstanceOf(HTMLButtonElement)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 14. Size prop
+// ---------------------------------------------------------------------------
+
+describe('Button – size prop', () => {
+  it('applies credence-button--md class by default when size is omitted', () => {
+    render(<Button>No size</Button>)
+    expect(getBtn()).toHaveClass('credence-button--md')
+  })
+
+  it('applies credence-button--sm class for size="sm"', () => {
+    render(<Button size="sm">Small</Button>)
+    expect(getBtn()).toHaveClass('credence-button--sm')
+    expect(getBtn()).not.toHaveClass('credence-button--md')
+    expect(getBtn()).not.toHaveClass('credence-button--lg')
+  })
+
+  it('applies credence-button--md class for size="md"', () => {
+    render(<Button size="md">Medium</Button>)
+    expect(getBtn()).toHaveClass('credence-button--md')
+    expect(getBtn()).not.toHaveClass('credence-button--sm')
+    expect(getBtn()).not.toHaveClass('credence-button--lg')
+  })
+
+  it('applies credence-button--lg class for size="lg"', () => {
+    render(<Button size="lg">Large</Button>)
+    expect(getBtn()).toHaveClass('credence-button--lg')
+    expect(getBtn()).not.toHaveClass('credence-button--sm')
+    expect(getBtn()).not.toHaveClass('credence-button--md')
+  })
+
+  it('each size produces exactly one size class', () => {
+    const sizes = ['sm', 'md', 'lg'] as const
+    for (const size of sizes) {
+      const { unmount } = render(<Button size={size}>S</Button>)
+      const btn = getBtn()
+      const sizeClasses = ['sm', 'md', 'lg'].filter((s) =>
+        btn.classList.contains(`credence-button--${s}`)
+      )
+      expect(sizeClasses).toHaveLength(1)
+      expect(sizeClasses[0]).toBe(size)
+      unmount()
+    }
+  })
+
+  it('size and variant classes coexist correctly', () => {
+    render(
+      <Button variant="secondary" size="lg">
+        Big secondary
+      </Button>
+    )
+    const btn = getBtn()
+    expect(btn).toHaveClass('credence-button--secondary')
+    expect(btn).toHaveClass('credence-button--lg')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 15. Class string shape — includes size classes (regression)
+// ---------------------------------------------------------------------------
+
+describe('Button – class string shape with size prop (no stray spaces regression)', () => {
+  it('class string has no leading/double spaces for all variant+size combos', () => {
+    const cases = [
+      { variant: 'primary' as const, size: 'sm' as const },
+      { variant: 'primary' as const, size: 'md' as const },
+      { variant: 'primary' as const, size: 'lg' as const },
+      { variant: 'secondary' as const, size: 'md' as const },
+      { variant: 'ghost' as const, size: 'sm' as const },
+      { variant: 'danger' as const, size: 'lg' as const },
+      { variant: 'link' as const, size: 'md' as const },
+    ]
+    for (const { variant, size } of cases) {
+      const { unmount } = render(
+        <Button variant={variant} size={size}>
+          Test
+        </Button>
+      )
+      const cls = getBtn().className
+      expect(cls).not.toMatch(/\s{2,}/)
+      unmount()
+    }
+  })
+})

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -5,7 +5,9 @@ import './Button.css'
 
 export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   /** Visual style variant */
-  variant?: 'primary' | 'secondary' | 'ghost' | 'danger'
+  variant?: 'primary' | 'secondary' | 'ghost' | 'danger' | 'link'
+  /** Size variant */
+  size?: 'sm' | 'md' | 'lg'
   /** Loading state - shows spinner and disables interaction */
   isLoading?: boolean
   /** Full width button */
@@ -22,6 +24,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
   {
     variant = 'primary',
+    size = 'md',
     isLoading = false,
     fullWidth = false,
     disabled,
@@ -45,6 +48,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
       className={[
         'credence-button',
         `credence-button--${variant}`,
+        `credence-button--${size}`,
         fullWidth ? 'credence-button--full-width' : '',
         className,
       ]


### PR DESCRIPTION
- Add 'link' variant: underline-style inline text action button
- Add 'size' prop: sm / md (default) / lg
- Enhance focus styles: dual-ring technique (outline + box-shadow halo) visible on both light and dark backgrounds
- Dark mode focus: reinforced ring with layered box-shadow
- Windows High Contrast / forced-colors: fallback to ButtonText outline
- Danger variant focus ring uses red tint for extra context
- Responsive size overrides for 768px and 360px breakpoints
- Add KeyboardFocusReview and InteractiveStates Storybook stories
- Extend tests: link variant (§13), size prop (§14-15), stories smoke tests

closes #811 