### PR TITLE
fix(uiux): preserve active-page indication on hover/focus of header nav links

### DIFF
--- a/src/components/Layout.css
+++ b/src/components/Layout.css
@@ -56,6 +56,14 @@
   text-underline-offset: 3px;
 }
 
+/* Keep the active indication visible when the active link is also hovered
+   or focused — .appNav-link:hover otherwise wins on specificity and hides it. */
+.appNav-link--active:hover,
+.appNav-link--active:focus-visible {
+  background: var(--credence-color-slate-100);
+  color: var(--credence-color-primary);
+}
+
 .appNav-link:focus-visible {
   outline: 2px solid var(--credence-color-primary);
   outline-offset: 2px;

--- a/src/components/navigation/MobileNav.css
+++ b/src/components/navigation/MobileNav.css
@@ -118,7 +118,19 @@
   color: var(--credence-color-white);
 }
 
+/* Keep the active indication visible when the active link is also hovered
+   or focused — .mobileNav-link:hover otherwise wins on specificity and hides it. */
+.mobileNav-link--active:hover {
+  background: var(--credence-color-primary);
+  color: var(--credence-color-white);
+}
+
 .mobileNav-link:focus-visible {
+  outline: 2px solid var(--credence-color-primary);
+  outline-offset: 2px;
+}
+
+.mobileNav-link--active:focus-visible {
   outline: 2px solid var(--credence-color-primary);
   outline-offset: 2px;
 }


### PR DESCRIPTION
## Problem
Issue #849 asked for default/hover/focus-visible/active state definitions for the header nav links, including hover/focus interplay with the active state.

The desktop nav (`PrefetchNavLink` wrapping React Router's `NavLink` in `Layout.tsx`) and the mobile drawer nav (`MobileNav.tsx`) already use `NavLink`, already set an `--active` class, and `aria-current="page"` is already applied (automatically by `NavLink`, and explicitly in `MobileNav.tsx`).

However, the active indication broke specifically on **hover and keyboard focus**: `.appNav-link:hover` / `.mobileNav-link:hover` have higher CSS specificity (two class-level selectors) than `.appNav-link--active` / `.mobileNav-link--active` (one class selector), so hovering or focusing the *currently active* link silently reverted it to the inactive style — losing the "you are here" cue exactly when a user interacts with it.

## Fix
Add `.appNav-link--active:hover` / `:focus-visible` and `.mobileNav-link--active:hover` / `:focus-visible` rules (in `Layout.css` and `MobileNav.css`) that preserve the active color/background while still layering in a hover/focus affordance. No component/TSX changes needed — `NavLink` + `aria-current` were already correctly wired up.

## Note for reviewers
While investigating, I found that `src/components/Layout.tsx` on `main` currently references several undefined identifiers (`DOM_EVENTS`, `Banner`, `ThemeToggle`, `NetworkIndicator`, `PRELOADS_BY_PATH`, `openShortcuts`, `launcherOpen`, `closeLauncher`) with no corresponding imports or state — this looks like a pre-existing, unrelated build break (missing imports/handlers, not styling) and is out of scope for this issue. Flagging it here since it means `npm run build` currently fails on `main` independent of this PR.

## Test plan
- [x] Manually verified via CSS specificity that `.appNav-link--active:hover`/`:focus-visible` (and the mobile equivalents) now win over the plain `:hover`/`:focus-visible` rules.
- [ ] Visual QA at 375px and 1280px across routes (recommend maintainer/CI verification given the unrelated build break noted above).
- [x] `aria-current="page"` already applied to the active link (via `NavLink` default behavior and explicit prop in `MobileNav.tsx`).

Closes #849