### PR TITLE
docs(uiux): add accessibility rationale and motion checklist to guidelines

### DIFF
--- a/docs/motion-guidelines.md
+++ b/docs/motion-guidelines.md
@@ -44,6 +44,17 @@ The application includes a global reduced-motion fallback:
 - `scroll-behavior` falls back to `auto`
 - decorative, looping motion like shimmer is stopped
 
+## Accessibility rationale
+
+Honoring `prefers-reduced-motion` is an accessibility requirement, not a nicety. Vestibular disorders, migraine, and motion sensitivity mean that transform-based or looping motion can trigger nausea, dizziness, or disorientation.
+
+Two WCAG success criteria apply directly:
+
+- **2.3.3 Animation from Interactions (Level AAA)** motion triggered by interaction (hover, focus, state changes, entrance and exit transitions) must be able to be disabled unless it is essential. The global reset satisfies this by neutralizing every transition and animation when reduce is requested.
+- **2.2.2 Pause, Stop, Hide (Level A)** auto-starting motion that loops (the shimmer skeleton is `infinite`) must be stoppable. Reduced motion caps `animation-iteration-count` to `1`, so looping decoration stops on its own.
+
+The reset in `src/index.css` is global and uses `!important`, so CSS-driven motion is covered automatically. The only motion the browser cannot neutralize is animation driven by inline JS styles, which is why those components consume `useReducedMotion` (see below).
+
 ## Implementation examples
 
 ### Toast notifications
@@ -151,3 +162,14 @@ const baseStyle = {
 ```
 
 Components covered by the JS-level hook today: `TrustGauge`, `LoadingSkeleton`, `CreateBondFlow`. Components still relying solely on the CSS layer: `MobileNav`, `ThemeToggle`, and the link/footer transitions in `src/index.css` (acceptable because they only swap colors, not transform in space).
+
+## Checklist for new motion
+
+Before merging a component that adds or changes motion:
+
+- [ ] Timing and easing come from `--credence-motion-*` tokens, not hardcoded `ms` or `cubic-bezier` values.
+- [ ] Motion is expressed in CSS (`transition` / `animation`) where possible, so the global reduced-motion reset applies for free.
+- [ ] Any animation driven by inline JS styles reads `useReducedMotion` and drops the `transition` / `animation` when it returns `true`.
+- [ ] Looping or auto-starting motion (spinners, shimmer) does not rely on `infinite` running under reduced motion.
+- [ ] Entrance / exit motion stays within `--credence-motion-duration-slow` (400ms) and does not shift primary content layout.
+- [ ] Verified with the OS "reduce motion" setting on, or via DevTools rendering emulation of `prefers-reduced-motion: reduce`.


### PR DESCRIPTION
## What
Strengthens the motion guidelines for #815. The core deliverables already exist on `main` (`docs/motion-guidelines.md` and a comprehensive `@media (prefers-reduced-motion: reduce)` reset in `src/index.css`), so this fills the two genuine gaps in the doc rather than rewriting what works:

1. **Accessibility rationale** - cites the two WCAG criteria that actually apply here: **2.3.3 Animation from Interactions (AAA)** for the interaction-triggered transitions, and **2.2.2 Pause, Stop, Hide (A)** for the `infinite` skeleton shimmer (which the reduced-motion block caps to `animation-iteration-count: 1`). Grounded in the real CSS mechanism.
2. **Checklist for new motion** - a short, actionable PR checklist grounded in the real tokens/hooks (`--credence-motion-*`, `useReducedMotion`), with no invented tokens.

I verified the existing reduced-motion block already neutralizes every keyframe globally (`*, *::before, *::after` zeroing animation/transition durations and iteration count, `scroll-behavior: auto`), and that no component overrides it with an `!important` duration, so I deliberately did not touch it.

## Testing
Docs-only change (+22 lines to `docs/motion-guidelines.md`). `npx prettier --check` passes on the file. The repo's `npm run lint` and `npm run build` have pre-existing failures on `main` (37 lint / 149 tsc errors in unrelated files); this change adds none (ESLint/tsc do not process markdown), verified against the baseline.

Closes #815
