### PR TITLE
security: guard against reintroducing a font-CDN dependency

### DIFF
--- a/src/config/security.test.ts
+++ b/src/config/security.test.ts
@@ -44,11 +44,24 @@ describe('CSP string', () => {
   it('contains default-src', () => {
     expect(CSP).toContain('default-src')
   })
+
+  it("contains font-src 'self' with no third-party font-CDN host", () => {
+    // Fonts must stay self-hosted (see src/lib/fontCdnCheck.ts): if this ever
+    // grows a host like fonts.googleapis.com, every visitor's IP and
+    // User-Agent would leak to that host on every page load.
+    const fontSrcMatch = CSP.match(/font-src([^;]*)/)
+    expect(fontSrcMatch).not.toBeNull()
+    expect(fontSrcMatch![1].trim()).toBe("'self'")
+  })
 })
 
 describe('CSP_DIRECTIVES object', () => {
   it("scriptSrc contains only 'self'", () => {
     expect(CSP_DIRECTIVES.scriptSrc).toEqual(["'self'"])
+  })
+
+  it("fontSrc contains only 'self' (fonts must be self-hosted, not CDN-served)", () => {
+    expect(CSP_DIRECTIVES.fontSrc).toEqual(["'self'"])
   })
 
   it("frameAncestors is 'none'", () => {

--- a/src/lib/fontCdnCheck.test.ts
+++ b/src/lib/fontCdnCheck.test.ts
@@ -1,0 +1,158 @@
+import { readFileSync, readdirSync } from 'fs'
+import { resolve, join } from 'path'
+import { describe, it, expect } from 'vitest'
+import { checkNoFontCdn, KNOWN_FONT_CDN_HOSTS } from './fontCdnCheck'
+
+// ---------------------------------------------------------------------------
+// checkNoFontCdn — negative tests (demonstrate the check catches a CDN font)
+// ---------------------------------------------------------------------------
+
+describe('checkNoFontCdn — NEGATIVE: font served from a CDN', () => {
+  /**
+   * These are the negative tests required by the acceptance criteria: they
+   * fail against the check's own logic if the CDN-host list or the URL
+   * matcher regresses, and they demonstrate the exact violation CI is meant
+   * to block.
+   *
+   * Threat: without this check, a future PR could add a Google Fonts <link>
+   * (or an @font-face pointing at one) and nothing would flag that every
+   * visitor's IP and User-Agent are now sent to a third party on every load.
+   */
+  it('fails on a <link> that loads a Google Fonts stylesheet', () => {
+    const html = `
+      <html>
+        <head>
+          <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter">
+        </head>
+      </html>
+    `
+    const result = checkNoFontCdn(html)
+    expect(result.ok).toBe(false)
+    expect(result.violations).toHaveLength(1)
+    expect(result.violations[0].host).toBe('fonts.googleapis.com')
+  })
+
+  it('fails on an @font-face referencing fonts.gstatic.com', () => {
+    const css = `
+      @font-face {
+        font-family: 'Inter';
+        src: url(https://fonts.gstatic.com/s/inter/v12/xxx.woff2) format('woff2');
+      }
+    `
+    const result = checkNoFontCdn(css)
+    expect(result.ok).toBe(false)
+    expect(result.violations[0].host).toBe('fonts.gstatic.com')
+  })
+
+  it('fails on a CSS @import of a font CDN stylesheet', () => {
+    const css = `@import url('https://fonts.bunny.net/css?family=inter');`
+    const result = checkNoFontCdn(css)
+    expect(result.ok).toBe(false)
+    expect(result.violations[0].host).toBe('fonts.bunny.net')
+  })
+
+  it('fails on Adobe Fonts / Typekit', () => {
+    const html = `<link rel="stylesheet" href="https://use.typekit.net/abc1234.css">`
+    const result = checkNoFontCdn(html)
+    expect(result.ok).toBe(false)
+    expect(result.violations[0].host).toBe('use.typekit.net')
+  })
+
+  it('reports every violating reference, not just the first', () => {
+    const html = `
+      <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter">
+      <link rel="stylesheet" href="https://use.typekit.net/abc1234.css">
+    `
+    const result = checkNoFontCdn(html)
+    expect(result.ok).toBe(false)
+    expect(result.violations).toHaveLength(2)
+  })
+
+  it('includes an actionable, human-readable message', () => {
+    const html = `<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter">`
+    const result = checkNoFontCdn(html)
+    expect(result.violations[0].message).toMatch(/self-host/i)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// checkNoFontCdn — positive tests (self-hosted fonts pass)
+// ---------------------------------------------------------------------------
+
+describe('checkNoFontCdn — POSITIVE: self-hosted / system fonts pass', () => {
+  it('passes for a system-font stack with no url() at all', () => {
+    const css = `
+      :root {
+        --font-family-base: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      }
+    `
+    const result = checkNoFontCdn(css)
+    expect(result.ok).toBe(true)
+    expect(result.violations).toHaveLength(0)
+  })
+
+  it('passes for an @font-face served from the same origin', () => {
+    const css = `
+      @font-face {
+        font-family: 'Inter';
+        src: url(/fonts/inter.woff2) format('woff2');
+      }
+    `
+    const result = checkNoFontCdn(css)
+    expect(result.ok).toBe(true)
+  })
+
+  it('passes for an unrelated third-party asset (not a font host)', () => {
+    const html = `<script src="https://cdn.jsdelivr.net/npm/some-lib@1.0/dist/lib.min.js"></script>`
+    const result = checkNoFontCdn(html)
+    expect(result.ok).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Regression: the actual project source contains no font-CDN references
+// ---------------------------------------------------------------------------
+
+describe('checkNoFontCdn — regression: project source', () => {
+  /**
+   * Scans the real entry HTML and every stylesheet under src/ so that a
+   * future PR reintroducing a font-CDN reference fails CI immediately,
+   * rather than relying on manual review to catch it.
+   */
+  function readAllCssFiles(dir: string): string[] {
+    const entries = readdirSync(dir, { withFileTypes: true, recursive: true })
+    return entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.css'))
+      .map((entry) => readFileSync(join(entry.parentPath, entry.name), 'utf-8'))
+  }
+
+  it('index.html contains no font-CDN references', () => {
+    const html = readFileSync(resolve(__dirname, '../../index.html'), 'utf-8')
+    const result = checkNoFontCdn(html)
+
+    if (!result.ok) {
+      const msgs = result.violations.map((v) => `  • ${v.message}`).join('\n')
+      throw new Error(`index.html loads fonts from a CDN:\n${msgs}`)
+    }
+    expect(result.ok).toBe(true)
+  })
+
+  it('no stylesheet under src/ contains a font-CDN reference', () => {
+    const cssSources = readAllCssFiles(resolve(__dirname, '..'))
+    expect(cssSources.length).toBeGreaterThan(0)
+
+    const violations = cssSources.flatMap((css) => checkNoFontCdn(css).violations)
+
+    if (violations.length > 0) {
+      const msgs = violations.map((v) => `  • ${v.message}`).join('\n')
+      throw new Error(`Found font-CDN reference(s) in src/**/*.css:\n${msgs}`)
+    }
+    expect(violations).toHaveLength(0)
+  })
+
+  it('documents the full list of hosts CI treats as font CDNs', () => {
+    // Guard against an accidental empty list silently turning this whole
+    // check into a no-op.
+    expect(KNOWN_FONT_CDN_HOSTS.length).toBeGreaterThan(0)
+  })
+})

--- a/src/lib/fontCdnCheck.ts
+++ b/src/lib/fontCdnCheck.ts
@@ -1,0 +1,84 @@
+/**
+ * Font-CDN dependency guard.
+ *
+ * Threat model
+ * ------------
+ * Serving fonts from a third-party host (Google Fonts, Adobe Fonts/Typekit,
+ * Bunny Fonts, cdnfonts.com, …) means every page load sends the visitor's IP
+ * address, User-Agent, and Referer header to that third party before a single
+ * glyph renders — a passive tracking channel that exists independent of any
+ * script on the page and that a wallet-adjacent app should not open. This is
+ * true even if the tag also carries a valid SRI hash: `integrity` only makes
+ * the browser reject *tampered* bytes after the request has already leaked to
+ * the CDN, it does not stop the request itself (see sriCheck.ts, which
+ * defends against a different threat — a compromised CDN serving malicious
+ * bytes — and is complementary to this check, not a substitute for it).
+ *
+ * A font CDN is also an availability dependency: corporate proxies,
+ * ad-blockers, and region-blocks routinely block font-CDN hosts, degrading to
+ * invisible (FOIT) or unstyled text, and it silently grows the set of origins
+ * `font-src` must trust in the CSP (src/config/security.ts).
+ *
+ * This module scans HTML/CSS source for `<link>`, `@import`, and `@font-face`
+ * references to known font-CDN hosts so that CI catches a future PR that
+ * reintroduces one, rather than relying on someone remembering that fonts
+ * must stay self-hosted.
+ */
+
+/** Hostnames of well-known third-party font delivery services. */
+export const KNOWN_FONT_CDN_HOSTS = [
+  'fonts.googleapis.com',
+  'fonts.gstatic.com',
+  'use.typekit.net',
+  'p.typekit.net',
+  'fonts.bunny.net',
+  'cdnfonts.com',
+  'fast.fonts.net',
+] as const
+
+export interface FontCdnViolation {
+  /** The font-CDN host that was matched. */
+  host: string
+  /** The full URL the reference was found in. */
+  url: string
+  /** Human-readable description for display in test output / CI logs. */
+  message: string
+}
+
+export interface FontCdnResult {
+  ok: boolean
+  violations: FontCdnViolation[]
+}
+
+// Matches CSS `url(...)` (bare, single- or double-quoted) and HTML
+// `href="…"` / `src="…"` attribute values.
+const URL_RE = /url\(\s*(['"]?)([^'")]+)\1\s*\)|(?:href|src)\s*=\s*(['"])([^'"]+)\3/gi
+
+/**
+ * Scan `source` (HTML or CSS text) for references to a known font-CDN host.
+ *
+ * @param source  Raw HTML or CSS source.
+ */
+export function checkNoFontCdn(source: string): FontCdnResult {
+  const violations: FontCdnViolation[] = []
+
+  let match: RegExpExecArray | null
+  while ((match = URL_RE.exec(source)) !== null) {
+    const url = match[2] ?? match[4]
+    if (!url) continue
+
+    const host = KNOWN_FONT_CDN_HOSTS.find((candidate) => url.includes(candidate))
+    if (host) {
+      violations.push({
+        host,
+        url,
+        message:
+          `Found a reference to font CDN "${host}" ("${url}"). ` +
+          `Self-host the font file instead (e.g. under public/fonts) and serve it ` +
+          `same-origin via @font-face, so the CSP font-src can stay 'self'.`,
+      })
+    }
+  }
+
+  return { ok: violations.length === 0, violations }
+}


### PR DESCRIPTION
## Summary

Adds CI-enforced guards against reintroducing a third-party font-CDN dependency. This is defense-in-depth: the app already self-hosts its typography (system-ui stack) and the CSP already restricts `font-src` to `'self'`, but nothing previously stopped a future PR from adding one back.

## Threat being mitigated

Loading fonts from a third-party CDN (Google Fonts, Adobe Fonts/Typekit, Bunny Fonts, etc.) sends every visitor's IP address, User-Agent, and Referer header to that third party on *every page load*, before a single glyph renders — a passive tracking channel independent of any script on the page. This holds even if the tag carries a valid SRI hash: `integrity` only rejects tampered bytes after the request has already leaked to the CDN; it doesn't prevent the request. A font CDN is also an availability dependency (corporate proxies/ad-blockers routinely block them, degrading to invisible or unstyled text) and it silently grows the CSP's trusted-origin surface.

Note: no such CDN reference currently exists in this codebase (confirmed by full-repo search) — this PR is proactive hardening, not a fix for a live exploit.

## Changes

- `src/lib/fontCdnCheck.ts`: scans HTML/CSS source for `<link>`, `@import`, and `@font-face` references to known font-CDN hosts.
- `src/lib/fontCdnCheck.test.ts`: negative tests proving the checker catches each known host, plus a regression test that scans the real `index.html` and every `src/**/*.css` file so CI fails if one is ever reintroduced.
- `src/config/security.test.ts`: pins `CSP`/`CSP_DIRECTIVES` `font-src` to `'self'` only, catching a future CSP loosening.

## Cost

Test-only / CI-time check — not on any runtime hot path. No production bundle or runtime cost.

## Test plan

- [x] `npx vitest run src/lib/fontCdnCheck.test.ts src/config/security.test.ts` — 26/26 pass
- [x] Confirmed negative tests fail without the implementation (stubbed the checker to always pass → 7/12 failed) and pass with it restored
- [x] `npx eslint` / `npx prettier --check` clean on all touched files
- [x] Full `npm test` / `npm run build` / `npm run lint`: identical pre-existing failure counts before and after this change (unrelated to this PR) — zero regressions introduced

Closes #611
