### PR TITLE
feat(uiux): add richer transaction-success feedback with explorer link

### DIFF
--- a/src/components/CreateBondFlow.tsx
+++ b/src/components/CreateBondFlow.tsx
@@ -55,7 +55,7 @@ interface CreateBondFlowProps {
 export default function CreateBondFlow({ onComplete, onCancel }: CreateBondFlowProps = {}) {
   const prefersReducedMotion = useReducedMotion()
   const { addToast } = useToast()
-  const { isConnected, connect, reauth, isReauthRequired: checkIsReauthRequired } = useWallet()
+  const { isConnected, connect, reauth, isReauthRequired: checkIsReauthRequired, network: walletNetwork } = useWallet()
   const { balance, status: balanceStatus, error: balanceError, refetch: refetchBalance } =
     useUsdcBalance()
   const [step, setStep] = useState(1)
@@ -129,7 +129,12 @@ export default function CreateBondFlow({ onComplete, onCancel }: CreateBondFlowP
   }
 
   const handleConfirm = () => {
-    addToast('success', 'Bond created successfully.')
+    const unlockDate = duration ? calcUnlockDate(duration) : ''
+    const message = `Bond created. ${formatUsdc(Number(amount))} locked until ${unlockDate}.`
+    addToast('success', message, {
+      txHash: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+      network: walletNetwork ?? 'public',
+    })
     if (onComplete) {
       onComplete()
     } else {

--- a/src/components/Toast.css
+++ b/src/components/Toast.css
@@ -109,6 +109,47 @@
   opacity: 1;
 }
 
+.toast__action {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.25rem;
+  flex-wrap: wrap;
+}
+
+.toast__tx-hash {
+  font-family: var(--credence-font-mono, monospace);
+  font-size: 0.75rem;
+  opacity: 0.75;
+}
+
+.toast__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.toast__link:hover {
+  text-decoration-thickness: 2px;
+}
+
+.toast__link:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+  border-radius: 2px;
+  text-decoration: none;
+}
+
+.toast__link-arrow {
+  flex-shrink: 0;
+}
+
 @keyframes toast-in {
   from {
     opacity: 0;

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,8 +1,14 @@
 import { useEffect, useRef, useCallback, useState } from 'react'
 import type { ToastSeverity, ToastData } from '../events'
+import { explorerUrl } from '../lib/explorerUrl'
+import { truncateAddress } from '../lib/stellar'
 import './Toast.css'
 
 export type { ToastSeverity, ToastData }
+export interface ToastOptions {
+  txHash?: string
+  network?: string
+}
 
 const ICONS: Record<ToastSeverity, React.ReactNode> = {
   info: (
@@ -214,7 +220,34 @@ export default function Toast({ toast, onDismiss }: ToastProps) {
       </div>
       <div className="toast__content">
         <span className="toast__message">{toast.message}</span>
-        {/* toast.txHash functionality removed temporarily to fix build errors */}
+        {toast.txHash && (
+          <div className="toast__action">
+            <span className="toast__tx-hash">{truncateAddress(toast.txHash)}</span>
+            <a
+              href={explorerUrl(toast.network ?? 'public', toast.txHash)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="toast__link"
+              aria-label="View transaction on Stellar Explorer"
+            >
+              View on Explorer
+              <svg
+                width="12"
+                height="12"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+                className="toast__link-arrow"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </a>
+          </div>
+        )}
       </div>
       <button
         type="button"

--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useState, useCallback, useRef, type ReactNode } from 'react'
 import { useSettings } from '../context/SettingsContext'
 import { isWithinQuietHours, nowMinutesSinceMidnight } from '../lib/quietHours'
-import Toast, { type ToastData, type ToastSeverity } from './Toast'
+import Toast, { type ToastData, type ToastSeverity, type ToastOptions } from './Toast'
 import './Toast.css'
 
 const TIMEOUTS: Record<ToastSeverity, number> = {
@@ -15,7 +15,7 @@ const TIMEOUTS: Record<ToastSeverity, number> = {
 const MAX_TOASTS = 3
 
 interface ToastContextValue {
-  addToast: (severity: ToastSeverity, message: string) => void
+  addToast: (severity: ToastSeverity, message: string, options?: ToastOptions) => void
   removeToast: (id: string) => void
   removeAllToasts: () => void
   /** Broadcasts a visually-hidden message to screen readers. */
@@ -97,7 +97,7 @@ export default function ToastProvider({ children }: { children: ReactNode }) {
   }, [])
 
   const addToast = useCallback(
-    (severity: ToastSeverity, message: string) => {
+    (severity: ToastSeverity, message: string, options?: ToastOptions) => {
       const {
         toastsEnabled,
         autoDismiss,
@@ -142,7 +142,7 @@ export default function ToastProvider({ children }: { children: ReactNode }) {
       }
 
       const id = String(++idCounter.current)
-      const newToast: ToastData = { id, severity, message, durationMs: timeout > 0 ? timeout : 0 }
+      const newToast: ToastData = { id, severity, message, durationMs: timeout > 0 ? timeout : 0, ...options }
 
       // Enforce max toast limit: remove oldest if needed
       setToasts((prev: ToastData[]) => {

--- a/src/lib/explorerUrl.ts
+++ b/src/lib/explorerUrl.ts
@@ -7,7 +7,7 @@
  */
 export function explorerUrl(network: string, hash: string): string {
   const base =
-    network === 'testnet'
+    network === 'test'
       ? 'https://stellar.expert/explorer/testnet/tx'
       : 'https://stellar.expert/explorer/public/tx'
   return `${base}/${encodeURIComponent(hash)}`

--- a/src/pages/Bond.tsx
+++ b/src/pages/Bond.tsx
@@ -183,12 +183,16 @@ export default function Bond() {
     if (penaltyUsdc > 0) {
       addToast(
         'warning',
-        `Bond withdrawn. ${formatUsdc(penaltyUsdc)} was slashed per early withdrawal policy.`
+        `Bond withdrawn. ${formatUsdc(penaltyUsdc)} was slashed per early withdrawal policy.`,
+        { txHash: 'b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3', network: walletNetwork ?? 'public' }
       )
     } else {
-      addToast('success', 'Bond withdrawn successfully.')
+      addToast('success', 'Bond withdrawn successfully.', {
+        txHash: 'c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4',
+        network: walletNetwork ?? 'public',
+      })
     }
-  }, [withdrawTarget, withdrawBreakdown, addToast, isPendingWithdraw])
+  }, [withdrawTarget, withdrawBreakdown, addToast, isPendingWithdraw, walletNetwork])
 
   const slashExposureBond = useMemo(() => bonds.find((b) => getPenaltyRate(b.status) > 0), [bonds])
 


### PR DESCRIPTION
Closes #858

## Summary

Adds a richer success feedback system for bond transactions. Instead of a generic toast message, users now see a summary of what happened (amount locked, unlock date) with a link to verify the transaction on Stellar Expert explorer.

## Changes

- **ToastProvider** - Extended `addToast` signature to accept optional `{ txHash, network }` options parameter
- **Toast** - Added `ToastOptions` export; renders truncated tx hash + keyboard-accessible "View on Explorer" link (opens in new tab) when `txHash` is present
- **Toast.css** - New styles for action area, tx hash monospace display, and explorer link (matching Banner link pattern)
- **explorerUrl.ts** - Fixed network comparison (`testnet` to `test`) to align with app-wide `CredenceNetwork` type
- **CreateBondFlow** - Bond success toast now includes amount, unlock date, and mock tx hash
- **Bond** - Withdrawal success/warning toasts now include mock tx hash

## Verification
- Lint passes (all errors are pre-existing in files outside this change)
- Explorer link is aria-label ed, opens target="_blank" rel="noopener noreferrer"
- Toast uses role="status" for non-danger severities