### PR TITLE
fix(uiux): close dark-theme token override gaps for surfaces and borders

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -236,6 +236,23 @@
   --credence-text-primary: var(--credence-color-slate-50);
   --credence-text-secondary: var(--credence-color-slate-400);
   --credence-border-default: var(--credence-color-slate-700);
+  --credence-color-trust-surface: rgba(139, 92, 246, 0.15);
+  --credence-color-attestation-surface: rgba(34, 197, 94, 0.15);
+  --credence-color-danger-surface-strong: rgba(239, 68, 68, 0.25);
+  --credence-color-danger-action: #ef4444;
+  --credence-color-danger-text-muted: #fca5a5;
+  --credence-skeleton-gradient: linear-gradient(
+    90deg,
+    rgba(51, 65, 85, 0.4) 25%,
+    rgba(71, 85, 105, 0.5) 50%,
+    rgba(51, 65, 85, 0.4) 75%
+  );
+  /* Explicit legacy alias overrides */
+  --bg-page: var(--credence-surface-page);
+  --bg-card: var(--credence-surface-card);
+  --text-primary: var(--credence-text-primary);
+  --text-secondary: var(--credence-text-secondary);
+  --border-default: var(--credence-border-default);
   --slate-900: var(--credence-color-slate-50);
 }
 


### PR DESCRIPTION
## Overview

This PR audits and fixes the `[data-theme="dark"]` token override block in `src/index.css` to ensure every surface, card, border, and text token used by components has an explicit dark-mode override. Pages were mixing canonical `--credence-*` tokens with legacy aliases (`--bg-page`, `--bg-card`, `--border-default`), and several tokens used by components had no dark override at all.

## Related Issue

Closes #855

## Changes

### Dark-theme token overrides added

- **[FIX]** `src/index.css` — Added dark overrides for missing canonical tokens:
  - `--credence-color-trust-surface` (used by `EmptyState.tsx`)
  - `--credence-color-attestation-surface` (used by `EmptyState.tsx`)
  - `--credence-color-danger-surface-strong` (used by `ConfirmDialog`, `Button`, `ErrorState`, `NotFound`)
  - `--credence-color-danger-action` (used by `Button`, `ErrorState`, `Bond`, `CreateBondFlow`)
  - `--credence-color-danger-text-muted` (used by `ConfirmDialog`, `Button`, `ErrorState`)
  - `--credence-skeleton-gradient` (used by `LoadingSkeleton.tsx`)
- **[FIX]** `src/index.css` — Added explicit legacy alias overrides for robust maintainability:
  - `--bg-page`, `--bg-card`, `--text-primary`, `--text-secondary`, `--border-default`

## Token Coverage Matrix

| Token | Light Value | Dark Override Before | Dark Override After |
|---|---|---|---|
| `--credence-surface-page` | `#f8fafc` | ✅ `#0f172a` | ✅ (unchanged) |
| `--credence-surface-card` | `#ffffff` | ✅ `#1e293b` | ✅ (unchanged) |
| `--credence-text-primary` | `#0f172a` | ✅ `#f8fafc` | ✅ (unchanged) |
| `--credence-text-secondary` | `#64748b` | ✅ `#94a3b8` | ✅ (unchanged) |
| `--credence-border-default` | `#e2e8f0` | ✅ `#334155` | ✅ (unchanged) |
| `--credence-color-trust-surface` | `#ddd6fe` | ❌ Missing | ✅ `rgba(139,92,246,0.15)` |
| `--credence-color-attestation-surface` | `#d1fae5` | ❌ Missing | ✅ `rgba(34,197,94,0.15)` |
| `--credence-color-danger-surface-strong` | `#fee2e2` | ❌ Missing | ✅ `rgba(239,68,68,0.25)` |
| `--credence-color-danger-action` | `#dc2626` | ❌ Missing | ✅ `#ef4444` |
| `--credence-color-danger-text-muted` | `#7f1d1d` | ❌ Missing | ✅ `#fca5a5` |
| `--credence-skeleton-gradient` | Slate 100-200 | ❌ Missing | ✅ Dark slate gradient |
| `--bg-page` (legacy alias) | `var(--credence-surface-page)` | ⚠️ cascade only | ✅ Explicit override |
| `--bg-card` (legacy alias) | `var(--credence-surface-card)` | ⚠️ cascade only | ✅ Explicit override |
| `--text-primary` (legacy alias) | `var(--credence-text-primary)` | ⚠️ cascade only | ✅ Explicit override |
| `--text-secondary` (legacy alias) | `var(--credence-text-secondary)` | ⚠️ cascade only | ✅ Explicit override |
| `--border-default` (legacy alias) | `var(--credence-border-default)` | ⚠️ cascade only | ✅ Explicit override |

## Verification

- ✅ All surface/text/border tokens used across the codebase now have explicit dark overrides
- ✅ Legacy aliases explicitly set for robust maintainability
- ✅ Dark values follow existing patterns (rgba tinted surfaces, adjusted slate for gradients)

| Acceptance Criteria | Status |
|---|---|
| All surface/text/border tokens flip correctly in dark mode | ✅ |
| Legacy aliases resolve to dark values | ✅ |
| No hardcoded light colors leak in dark mode for audited tokens | ✅ |
