### PR TITLE
 Define banner variants (info/warn/incident) with accessible styling

### DIFF
--- a/docs/COMPONENTS.md
+++ b/docs/COMPONENTS.md
@@ -4,7 +4,7 @@ This catalog is the source-facing reference for shared UI under `src/components/
 
 Related focused docs: [button system](./button-system.md), [notifications](./notifications.md), [design tokens](./DESIGN_TOKENS.md), [dark mode](./dark-mode.md), [focus patterns](./focus-patterns.md), [UI states](./UI_STATES_GUIDE.md), [TrustGauge quick reference](./TRUST_GAUGE_QUICK_REFERENCE.md), and [tier thresholds](./tier-thresholds.md).
 
-> **Per-route SEO metadata** — Use the [`useSeo`](../src/hooks/useSeo.ts) hook (documented in [HOOKS.md](./HOOKS.md#useseo)) to set `document.title` and `<meta name="description">` on a per-route basis. Every route-level page component should call `useSeo` with a descriptive `description` so search engines and social-card scrapers receive page-specific context rather than the static fallback in `index.html`.
+**Storybook**: Components that have stories are listed with their Storybook path and variant names. Run `npm run storybook` (defaults to port 6006) to browse and interact with them. Components without a Storybook entry have no story file yet.
 
 ## Styling ownership snapshot
 
@@ -50,14 +50,6 @@ Source: [`Badge.tsx`](../src/components/Badge.tsx)
 `'bronze' | 'silver' | 'gold' | 'platinum' | 'active' | 'locked' | 'slashed' | 'grace-period' | 'unknown'`
 
 Unknown runtime strings normalize to the `unknown` visual style while preserving the supplied string as a fallback label only when no known label exists.
-
-### `StatusBadgeVariant`
-
-Source: [`StatusBadge.tsx`](../src/components/StatusBadge.tsx)
-
-`'pending' | 'active' | 'completed' | 'failed'`
-
-Lifecycle status for bonds and operations. Each variant maps to a distinct semantic colour family via `--credence-*` design tokens.
 
 ### `BannerSeverity`
 
@@ -117,7 +109,7 @@ Source: [`src/components/Button.tsx`](../src/components/Button.tsx). Focused doc
 | `children`          | `ReactNode`                                       | Required                                 |
 | Native button props | `ButtonHTMLAttributes<HTMLButtonElement>`         | Forwarded; `type` defaults to `'button'` |
 
-Accessibility: renders a native `<button>`, disables interaction while `disabled` or `isLoading`, sets `aria-busy` for loading state, hides spinner SVG from assistive tech, and inherits keyboard activation/focus behavior from the platform. Primary CTAs (`variant="primary"`) automatically receive `data-testid="primary-cta"` for test stability, unless overridden via props.
+Accessibility: renders a native `<button>`, disables interaction while `disabled` or `isLoading`, sets `aria-busy` for loading state, hides spinner SVG from assistive tech, and inherits keyboard activation/focus behavior from the platform.
 
 Tokens: `--credence-border-default`, `--credence-color-danger-*`, `--credence-color-info-surface`, `--credence-color-primary*`, `--credence-color-slate-*`, `--credence-color-white`, `--credence-focus-ring`, font, line-height, radius, spacing, surface, and text tokens.
 
@@ -127,9 +119,12 @@ Tokens: `--credence-border-default`, `--credence-color-danger-*`, `--credence-co
 </Button>
 ```
 
-## LoadingSpinner
+## PinWidgetButton
 
-Source: [`src/components/LoadingSpinner.tsx`](../src/components/LoadingSpinner.tsx). Storybook: `Components/LoadingSpinner`.
+Toggle button rendered on each dashboard widget card, allowing the user
+to pin/unpin it to the top row. Pinned state persists in `localStorage`
+under `credence:pinnedWidgets` (see `src/config/pinnedWidgets.ts`), capped
+at `MAX_PINNED_WIDGETS`.
 
 **Props**
 
@@ -137,184 +132,29 @@ Source: [`src/components/LoadingSpinner.tsx`](../src/components/LoadingSpinner.t
 - `isPinned: boolean`
 - `onToggle: (slug: string) => void`
 
-Accessibility: Renders an SVG loading spinner with `aria-hidden="true"` by default. When the user enables `prefers-reduced-motion: reduce`, the component automatically falls back to rendering static `"Loading…"` text (or custom `label` prop), complying with WCAG 2.1 AA animation requirements.
+**Styling**: uses `--spacing-xs`, `--radius-sm`, `--color-text-secondary`,
+`--color-bg-hover`, `--color-focus-ring` design tokens. No hard-coded values.
 
-Tokens: `--credence-font-family-base`, `--credence-font-size-sm`, `--credence-font-weight-semibold`, `--credence-space-*`, `--credence-motion-*`.
-
-```tsx
-<LoadingSpinner size="md" />
-<LoadingSpinner label="Processing…" />
-```
+**Accessibility**: `aria-pressed` reflects pin state; `aria-label` announces
+the pin/unpin action.
 
 ## Badge
 
-Source: [`src/components/Badge.tsx`](../src/components/Badge.tsx). Contrast audit: [badge-contrast-audit.md](./badge-contrast-audit.md).
+Source: [`src/components/Badge.tsx`](../src/components/Badge.tsx).
 
 | Prop        | Type                     | Default             |
 | ----------- | ------------------------ | ------------------- |
 | `variant`   | `BadgeVariant \| string` | Required            |
 | `label`     | `string`                 | Known variant label |
 | `className` | `string`                 | `''`                |
-| `srPrefix`  | `string`                 | —                   |
 
-**`srPrefix`** renders an `.sr-only` `<span>` _before_ the visible label so assistive technology can announce the badge in context (e.g. `srPrefix="Bond status:"` causes a screen reader to read `"Bond status: Slashed"` rather than just `"Slashed"`). No extra DOM is inserted when the prop is omitted.
-
-Accessibility: renders text in a `<span>` with a `title` attribute matching the display label (provides a tooltip on truncation). Status badges (`slashed`, `grace-period`, `locked`) carry safety-relevant meaning — the visible label is always non-empty so meaning is never communicated by color alone. Use `srPrefix` when a badge appears inside a list row or table cell where a screen reader needs additional context to interpret the label.
+Accessibility: renders text in a `<span>`; consumers should provide surrounding context when the badge alone is not descriptive.
 
 Tokens: tier/status color tokens, `--credence-font-size-xs`, `--credence-font-weight-semibold`, `--credence-radius-full`, `--credence-space-2`.
 
 ```tsx
 <Badge variant="gold" />
 <Badge variant="grace-period" label="Grace" />
-<Badge variant="slashed" srPrefix="Bond status:" />
-```
-
-## StatusBadge
-
-Source: [`src/components/StatusBadge.tsx`](../src/components/StatusBadge.tsx). Storybook: `Components/StatusBadge`.
-
-Displays a bond or operation lifecycle status as a colour-coded pill. Each variant maps to a distinct semantic colour family sourced entirely from `--credence-*` design tokens — no hard-coded colour values.
-
-| Prop        | Type                  | Default              |
-| ----------- | --------------------- | -------------------- |
-| `variant`   | `StatusBadgeVariant`  | Required             |
-| `label`     | `string`              | Capitalised variant  |
-| `className` | `string`              | `''`                 |
-| `srPrefix`  | `string`              | —                    |
-| `ariaLabel` | `string`              | Display label        |
-
-### `StatusBadgeVariant`
-
-`'pending' | 'active' | 'completed' | 'failed'`
-
-| Variant     | Semantic intent | Token family                     |
-| ----------- | --------------- | -------------------------------- |
-| `pending`   | Neutral/waiting | `--credence-color-warning-*`     |
-| `active`    | In progress     | `--credence-color-success-*`     |
-| `completed` | Resolved        | `--credence-color-info-*`        |
-| `failed`    | Error/danger    | `--credence-color-danger-*`      |
-
-**`srPrefix`** renders an `.sr-only` `<span>` _before_ the visible label so assistive technology can announce the badge in context (e.g. `srPrefix="Bond status:"` causes a screen reader to read `"Bond status: Failed"` rather than just `"Failed"`). No extra DOM is inserted when the prop is omitted.
-
-Accessibility: renders text in a `<span>` with `aria-label` set to the display label (or the `ariaLabel` prop override). The visible label is always non-empty so meaning is never communicated by colour alone. Use `srPrefix` when a badge appears inside a list row or table cell where a screen reader needs additional context.
-
-Tokens: `--credence-color-warning-surface`, `--credence-color-warning-border`, `--credence-color-warning-text`, `--credence-color-success-surface`, `--credence-color-success-border`, `--credence-color-success-text`, `--credence-color-info-surface`, `--credence-color-info-border`, `--credence-color-info-text`, `--credence-color-danger-surface`, `--credence-color-danger-border`, `--credence-color-danger-text`, `--credence-font-size-xs`, `--credence-font-weight-semibold`, `--credence-radius-full`, `--credence-space-2`.
-
-```tsx
-<StatusBadge variant="pending" />
-<StatusBadge variant="active" />
-<StatusBadge variant="completed" label="Done" />
-<StatusBadge variant="failed" srPrefix="Bond status:" />
-```
-
-## AnalyticsWidget
-
-Source: [`src/components/AnalyticsWidget.tsx`](../src/components/AnalyticsWidget.tsx). Storybook: `Components/AnalyticsWidget`.
-
-Displays one or two periods of numeric metrics in a card layout. When `previousPeriod` is supplied a **Compare periods** toggle appears in the header; enabling it renders the previous period column alongside the current period so operators can do a quick side-by-side comparison without leaving the dashboard.
-
-The component supports both **uncontrolled** (default) and **controlled** modes:
-- **Uncontrolled**: omit `compareEnabled` / `onCompareChange`; the widget manages toggle state internally, optionally seeded by `defaultCompare`.
-- **Controlled**: supply both `compareEnabled` and `onCompareChange` to lift toggle state to the parent.
-
-### Props
-
-| Prop              | Type                        | Default     |
-| ----------------- | --------------------------- | ----------- |
-| `title`           | `string`                    | Required    |
-| `currentPeriod`   | `AnalyticsPeriodData`       | Required    |
-| `previousPeriod`  | `AnalyticsPeriodData`       | —           |
-| `defaultCompare`  | `boolean`                   | `false`     |
-| `compareEnabled`  | `boolean`                   | —           |
-| `onCompareChange` | `(next: boolean) => void`   | —           |
-| `className`       | `string`                    | `''`        |
-
-### `AnalyticsPeriodData`
-
-| Field     | Type                  | Notes                                        |
-| --------- | --------------------- | -------------------------------------------- |
-| `label`   | `string`              | Short period label shown in the column header (e.g. `"Jul 2026"`). |
-| `metrics` | `AnalyticsMetric[]`   | One or more metrics to display.              |
-
-### `AnalyticsMetric`
-
-| Field    | Type                        | Notes                                           |
-| -------- | --------------------------- | ----------------------------------------------- |
-| `label`  | `string`                    | Human-readable metric name (e.g. `"Trust Score"`). |
-| `value`  | `number`                    | Numeric value for the period.                   |
-| `format` | `(value: number) => string` | Optional formatter; defaults to `String(value)`. |
-| `unit`   | `string`                    | Optional suffix appended after the formatted value (e.g. `"USDC"`). |
-
-### Accessibility
-
-- Renders as a `<section>` with `aria-label` set to the `title` prop so it is a named landmark.
-- Title renders as an `<h2>`.
-- The compare toggle is a native `role="switch"` button with `aria-checked` and an `aria-label`. Its visible label (`"Compare periods"`) is linked via `<label htmlFor>`.
-- Each period column carries `aria-label="<period.label> metrics"`.
-- Metrics are structured as a `<dl>` (definition list) with `<dt>` for labels and `<dd>` for values, so assistive technology can navigate key/value pairs.
-
-### Tokens
-
-`--credence-border-default`, `--credence-color-primary`, `--credence-color-slate-50`, `--credence-font-family-base`, `--credence-font-size-lg`, `--credence-font-size-sm`, `--credence-font-size-xl`, `--credence-font-size-xs`, `--credence-font-weight-bold`, `--credence-font-weight-regular`, `--credence-font-weight-semibold`, `--credence-line-height-tight`, `--credence-motion-duration-base`, `--credence-motion-easing-standard`, `--credence-radius-lg`, `--credence-radius-xl`, `--credence-space-1`, `--credence-space-2`, `--credence-space-3`, `--credence-space-4`, `--credence-space-6`, `--credence-surface-card`, `--credence-text-primary`, `--credence-text-secondary`.
-
-```tsx
-// Uncontrolled — single period, no compare toggle
-<AnalyticsWidget
-  title="Analytics Overview"
-  currentPeriod={{
-    label: 'Jul 2026',
-    metrics: [
-      { label: 'Trust Score', value: 684 },
-      { label: 'Active Bonds', value: 3 },
-      { label: 'Total Bonded', value: 4250, format: (v) => v.toLocaleString(), unit: 'USDC' },
-    ],
-  }}
-/>
-
-// Uncontrolled — compare mode on by default
-<AnalyticsWidget
-  title="Analytics Overview"
-  currentPeriod={currentPeriod}
-  previousPeriod={previousPeriod}
-  defaultCompare
-/>
-
-// Controlled — parent owns toggle state
-<AnalyticsWidget
-  title="Analytics Overview"
-  currentPeriod={currentPeriod}
-  previousPeriod={previousPeriod}
-  compareEnabled={isComparing}
-  onCompareChange={setIsComparing}
-/>
-```
-
-## TooltipOnOverflow
-
-Source: [`src/components/TooltipOnOverflow.tsx`](../src/components/TooltipOnOverflow.tsx).
-
-| Prop        | Type               | Default     |
-| ----------- | ------------------ | ----------- |
-| `content`   | `string`           | Required    |
-| `children`  | `React.ReactElement` | Required  |
-| `className` | `string`           | `''`        |
-
-Wraps a single child element and displays a tooltip **only when the child's text is visually truncated** (overflowing). The tooltip appears on hover and on keyboard focus — keyboard users can dismiss it with Escape.
-
-Accessibility (WCAG 2.1 AA):
-- Sets `aria-describedby` on the child to associate tooltip content with the trigger.
-- Renders `role="tooltip"` with `aria-hidden` toggled for visibility.
-- Dismissible with Escape while focused, without stealing focus.
-- Respects `prefers-reduced-motion`; disables fade animation when set.
-- Color contrast uses design tokens (`--credence-color-slate-900` / `--credence-color-white`) meeting AA ratios (≥4.5:1).
-- Arrow pointers are CSS pseudo-elements (no extra DOM).
-
-Tokens: `--credence-surface-card`, `--credence-text-primary`, `--credence-color-slate-900`, `--credence-color-white`, `--credence-space-1`, `--credence-space-2`, `--credence-radius-md`, `--credence-font-size-xs`, `--credence-font-family-base`, `--credence-line-height-tight`, `--credence-motion-duration-fast`, `--credence-motion-easing-standard`, `--credence-shadow-toast`.
-
-```tsx
-<TooltipOnOverflow content="GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H">
-  <code>GBRPYHIL2CI3...OX2H</code>
-</TooltipOnOverflow>
 ```
 
 ## Banner
@@ -331,7 +171,7 @@ Source: [`src/components/Banner.tsx`](../src/components/Banner.tsx). Focused doc
 | `action`         | `{ label: string; href?: string; onClick?: () => void }` | `undefined`              |
 | `returnFocusRef` | `React.RefObject<HTMLElement>`                           | `document.body` fallback |
 
-Accessibility: severity maps to `role="alert"` for warning/critical and `role="status"` for info/success. The root has an aria label such as “Warning banner”. Dismiss buttons have `aria-label="Dismiss banner"`, support Escape while focused, and return focus to `returnFocusRef` or `document.body` after dismissal. Icons are aria-hidden.
+Accessibility: severity maps to `role="alert"` for warning/critical and `role="status"` for info/success. The root has an aria label such as "Warning banner". Dismiss buttons have `aria-label="Dismiss banner"`, support Escape while focused, and return focus to `returnFocusRef` or `document.body` after dismissal. Icons are aria-hidden.
 
 Tokens: motion duration/easing tokens in CSS; severity color styling is component-owned CSS values and should be reviewed during token migrations.
 
@@ -411,7 +251,9 @@ Source: [`src/components/ConfirmDialog.tsx`](../src/components/ConfirmDialog.tsx
 | `confirmPhrase`     | `string`                         | `'CONFIRM'`                       |
 | `confirmHint`       | `string`                         | Wallet/funds irreversibility hint |
 
-Accessibility: renders in a portal with `role="dialog"`, `aria-modal="true"`, generated `aria-labelledby`/`aria-describedby`, focus trap, initial focus on Cancel, Escape and backdrop cancellation, body scroll lock, and optional focus restoration. The destructive action is disabled until the user types `CONFIRM`; assertive sr-only announcements describe state changes.
+`ConfirmDialogPenaltyBreakdown` is `{ bondAmount: string; penaltyAmount: string; penaltyPercent: number; resultingBalance: string }`. When `breakdown` is omitted, the `description` prop or `children` slot is rendered in its place.
+
+Accessibility: renders in a portal with `role="dialog"`, `aria-modal="true"`, generated `aria-labelledby`/`aria-describedby`, focus trap, initial focus on Cancel, Escape and backdrop cancellation, body scroll lock, and optional focus restoration. The confirm button is disabled until the user types the value of `confirmPhrase` (default: `CONFIRM`); assertive sr-only announcements describe state changes.
 
 Tokens: danger color tokens, font family/size/weight, line-height, motion, radius, spacing, surface, and text tokens.
 
@@ -442,26 +284,11 @@ Source: [`src/components/AddressInput.tsx`](../src/components/AddressInput.tsx).
 | `onChange`           | `(value: string) => void`    | Required            |
 | `onValidationChange` | `(isValid: boolean) => void` | `undefined`         |
 | `disabled`           | `boolean`                    | `false`             |
-| `isLoading`          | `boolean`                    | `false`             |
 | `className`          | `string`                     | `''`                |
-| `error`              | `string`                     | `undefined`         |
-| `selfAddress`        | `string`                     | `undefined`         |
 
-Accessibility: composes `FormField`, so label, hint, and error IDs wire through `htmlFor`, `aria-describedby`, and `aria-invalid`. Paste and copy controls are native buttons with explicit aria labels and hidden SVGs. Validation now performs two checks: (1) a format check (56-character, starts with `G`, uppercase alphanumeric), and (2) a **CRC-16 XMODEM checksum** verify per the Stellar StrKey spec. Distinct error messages are surfaced for each failure mode — `"Invalid address. Stellar public keys are 56 characters starting with G."` for a format error, and `"Invalid address checksum. Please verify the address."` for a checksum mismatch — and both are exposed via `role="alert"` with `aria-invalid="true"` set on the `<input>` when any error is active.
+Accessibility: composes `FormField`, so label, hint, and error IDs wire through `htmlFor`, `aria-describedby`, and `aria-invalid`. Paste and copy controls are native buttons with explicit aria labels and hidden SVGs. Validation requires a 56-character Stellar public key starting with `G`; invalid feedback is exposed by the FormField alert.
 
 Tokens: border, danger, primary, slate, success, focus, font, line-height, motion, radius, spacing, surface, and text tokens.
-
-### Address echo display
-
-Once the user enters a valid address and blurs the input, a **"Recognized:"** echo line appears below the field. The format of the displayed address is driven by **Settings → Display → Address format** (`addressDisplay` in `SettingsContext`):
-
-| `addressDisplay` | Format                                      | Example                                            |
-| ---------------- | ------------------------------------------- | -------------------------------------------------- |
-| `short`          | First 12 chars + `...` + last 8 (default)  | `GBRPYHIL2CI3...X2H`                               |
-| `full`           | Complete 56-character key                   | `GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H` |
-| `friendly`       | First 6 chars + `…` + last 4               | `GBRPYH…X2H`                                       |
-
-The formatting is provided by `formatAddressForDisplay(address, mode)` exported from `src/lib/stellar.ts`. The component reads the user's preference directly from `useSettings()` — no prop is needed.
 
 ```tsx
 <AddressInput
@@ -471,6 +298,8 @@ The formatting is provided by `formatAddressForDisplay(address, mode)` exported 
   onValidationChange={setAddressValid}
 />
 ```
+
+Storybook: `Components/Forms/AddressInput` — **Default** · **Filled** · **Invalid** · **Disabled** · **Loading**.
 
 ## AmountInput
 
@@ -484,41 +313,17 @@ Source: [`src/components/AmountInput.tsx`](../src/components/AmountInput.tsx). F
 | `presets`          | `number[]`                                                                          | `[100, 500, 1000]` |
 | `currencyLabel`    | `string`                                                                            | `'USDC'`           |
 | `error`            | `string`                                                                            | `undefined`        |
-| `onValidityChange` | `(isValid: boolean) => void`                                                        | `undefined`        |
-| `isLoading`        | `boolean`                                                                           | `false`            |
-| `min`              | `number`                                                                            | `undefined`        |
 | Native input props | `Omit<InputHTMLAttributes<HTMLInputElement>, 'value' \| 'onChange' \| 'inputMode'>` | Forwarded          |
 
 Accessibility: uses a native input with `inputMode="decimal"`, disables browser autocomplete, exposes invalid state when `error` or `aria-invalid="true"` is supplied, hides the currency adornment, and gives Max/preset buttons descriptive aria labels. Presets above balance and Max at zero balance are disabled.
-
-### Validation
-
-The component manages two internal validity checks:
-
-**Over-balance** — when the numeric value exceeds `balance` the input is invalid and an inline `⚠ Amount exceeds available balance.` error appears.
-
-**Below-minimum** — when `min` is supplied and the numeric value is greater than zero but less than `min`, the input is invalid and an inline `⚠ Amount must be at least <min> <currencyLabel>.` error appears.
-
-Precedence: an explicit `error` prop always wins. Over-balance takes precedence over below-minimum when both conditions hold simultaneously.
-
-`onValidityChange(false)` fires whenever **either** internal check fails; `onValidityChange(true)` fires when both pass (or the value is empty).
-
-```tsx
-// Gate a submit button using min + onValidityChange
-<AmountInput
-  value={amount}
-  onChange={setAmount}
-  balance={walletBalance}
-  min={10}
-  onValidityChange={(isValid) => setCanSubmit(isValid)}
-/>
-```
 
 Tokens: border, danger-border, slate, focus, font, motion, radius, spacing, surface, and text tokens.
 
 ```tsx
 <AmountInput value={amount} onChange={setAmount} balance={availableUsdc} error={amountError} />
 ```
+
+Storybook: `Components/Forms/AmountInput` — **Default** · **Filled** · **OverBalance** · **Error** · **Disabled** · **Loading**.
 
 ## TrustGauge
 
@@ -583,12 +388,11 @@ Source: [`src/components/forms/FormField.tsx`](../src/components/forms/FormField
 | ---------- | -------------------- | ----------- |
 | `id`       | `string`             | Required    |
 | `label`    | `string`             | Required    |
-| `hint`         | `string`             | `undefined` |
-| `error`        | `string`             | `undefined` |
-| `srOnlyLabel`  | `boolean`            | `false`     |
-| `children`     | `React.ReactElement` | Required    |
+| `hint`     | `string`             | `undefined` |
+| `error`    | `string`             | `undefined` |
+| `children` | `React.ReactElement` | Required    |
 
-Accessibility: renders a `<label htmlFor={id}>`, optional hint, clones the child to inject `id`, merged `aria-describedby`, and `aria-invalid` when an error exists. Error text has `role="alert"`. Set `srOnlyLabel` when the visible UI relies on a placeholder or icon-only affordance but a programmatic label is still required for assistive technology.
+Accessibility: renders a `<label htmlFor={id}>`, optional hint, clones the child to inject `id`, merged `aria-describedby`, and `aria-invalid` when an error exists. Error text has `role="alert"`.
 
 Tokens: `--credence-color-danger-text`, `--credence-font-size-sm`, `--credence-font-weight-semibold`, `--credence-space-2`, `--credence-text-secondary`.
 
@@ -598,54 +402,7 @@ Tokens: `--credence-color-danger-text`, `--credence-font-size-sm`, `--credence-f
 </FormField>
 ```
 
-Placeholder-only layouts should still expose an accessible name:
-
-```tsx
-<FormField id="search" label="Search attestations" srOnlyLabel>
-  <input placeholder="Search attestations…" />
-</FormField>
-```
-
-## FilePicker
-
-Source: [`src/components/FilePicker.tsx`](../src/components/FilePicker.tsx).
-
-| Prop           | Type                          | Default                                  |
-| -------------- | ----------------------------- | ---------------------------------------- |
-| `id`           | `string`                      | Auto-generated                           |
-| `label`        | `string`                      | `'Upload files'`                         |
-| `hint`         | `string`                      | `undefined`                              |
-| `error`        | `string`                      | `undefined`                              |
-| `files`        | `File[]`                      | Required                                 |
-| `onChange`     | `(files: File[]) => void`     | Required                                 |
-| `accept`       | `string`                      | `undefined`                              |
-| `multiple`     | `boolean`                     | `false`                                  |
-| `disabled`     | `boolean`                     | `false`                                  |
-| `required`     | `boolean`                     | `false`                                  |
-| `maxSizeBytes` | `number`                      | `undefined`                              |
-| `className`    | `string`                      | `''`                                     |
-| `title`        | `string`                      | Context-sensitive drag-and-drop prompt   |
-| `dropHint`     | `string`                      | Accept format hint                       |
-| `ariaLabel`    | `string`                      | `undefined`                              |
-
-Accessibility: renders a dropzone with `role="button"`, `aria-roledescription="file drop zone"`, keyboard activation via Space/Enter, and `aria-controls` linking to live announcement regions. Drag state changes are announced via `aria-live="polite"` regions. File additions and rejections trigger screen-reader announcements. The dropzone is linked to `FormField` for label, hint, and error display. Hidden native `<input type="file">` is `aria-hidden` and focus is managed via the dropzone. File list items include remove buttons with descriptive `aria-label` attributes. Keyboard instructions are provided via sr-only text. Supports `prefers-reduced-motion` and dark mode.
-
-Tokens: border, danger, info, primary, slate, focus, font, line-height, motion, radius, spacing, surface, and text tokens.
-
-```tsx
-<FilePicker
-  id="evidence"
-  label="Upload evidence"
-  files={files}
-  onChange={setFiles}
-  accept=".pdf,image/*"
-  multiple
-  maxSizeBytes={10 * 1024 * 1024}
-  hint="PDF or images. Max 10 MB per file."
-/>
-```
-
-Storybook: `Components/Forms/FilePicker` — **Default** · **SingleFile** · **MultipleFiles** · **WithFiles** · **WithError** · **Disabled** · **DisabledWithFiles** · **WithSizeLimit** · **Required** · **DragActivePreview**.
+Storybook: `Components/Forms/FormField` — **Default** · **WithHint** · **WithError** · **WithHintAndError**.
 
 ## controls/Select
 
@@ -673,6 +430,8 @@ Tokens: shared control CSS consumes border, primary, white, focus, font, line-he
 />
 ```
 
+Storybook: `Components/Controls/Select` — **Default** · **Error** · **Disabled** · **Loading**.
+
 ## controls/Toggle
 
 Source: [`src/components/controls/Toggle.tsx`](../src/components/controls/Toggle.tsx).
@@ -691,6 +450,8 @@ Tokens: shared control CSS consumes border, primary, white, focus, font, line-he
 ```tsx
 <Toggle checked={toastsEnabled} onChange={setToastsEnabled} ariaLabel="Enable notifications" />
 ```
+
+Storybook: `Components/Controls/Toggle` — **Off** · **On** · **Error** · **Disabled** · **Loading**.
 
 ## states/EmptyState
 
@@ -779,86 +540,28 @@ Tokens: warning color tokens, spacing, radius.
 />
 ```
 
-## ActionCard
+## BottomNav
 
-Source: [`src/components/ActionCard.tsx`](../src/components/ActionCard.tsx).
+Source: [`src/components/navigation/BottomNav.tsx`](../src/components/navigation/BottomNav.tsx).
 
-| Prop       | Type        | Default  |
-| ---------- | ----------- | -------- |
-| `title`    | `string`    | Required |
-| `children` | `ReactNode` | Required |
-| `onDismiss`| `() => void`| `undefined`|
+Fixed bottom navigation bar showing the 5 primary routes. Visible on viewports ≤ `BREAKPOINTS.MD` (768 px); hidden at wider widths via `display: none` in CSS.
 
 | Prop     | Type | Default |
 | -------- | ---- | ------- |
 | _(none)_ | —    | —       |
 
-Tokens: `--credence-border-default`, `--credence-radius-xl`, `--credence-space-4`, `--credence-space-6`, `--credence-surface-card`, `--credence-text-primary`, `--credence-font-size-xl`, `--credence-line-height-tight`.
+The component accepts no props. Route state is derived internally via React Router's `useLocation`.
+
+**Rendered markup:** `<nav aria-label="Bottom navigation">` containing a `<ul role="list">` of 5 `<li>` items, each wrapping a React Router `NavLink`. `NavLink` automatically sets `aria-current="page"` on the active route's `<a>` element.
+
+Accessibility: all tabs are native `<a>` elements reachable by Tab key in document order; active state is communicated both visually (primary-color border and text) and semantically (`aria-current="page"`); focus indicator uses `var(--credence-focus-ring)`; touch targets are ≥ 56 px tall (44 px WCAG minimum). Transitions are suppressed under `prefers-reduced-motion`.
+
+Tokens: `--credence-surface-card` (background), `--credence-border-default` (top border), `--credence-color-primary` (active tab indicator), `--credence-text-secondary` (inactive label), `--credence-text-primary` (hover), `--credence-space-1`, `--credence-space-2` (padding), `--credence-font-size-xs` (label size), `--credence-font-weight-semibold` (label weight), `--credence-font-weight-bold` (active label), `--credence-motion-duration-fast`, `--credence-motion-easing-standard` (transitions), `--credence-focus-ring`.
 
 ```tsx
-<ActionCard title="Create bond">
-  <AmountInput value={amount} onChange={setAmount} balance={balance} />
-  <Button onClick={submit}>Submit</Button>
-</ActionCard>
-```
-
-## Disclaimer
-
-Source: [`src/components/Disclaimer.tsx`](../src/components/Disclaimer.tsx).
-
-| Prop        | Type     | Default        |
-| ----------- | -------- | -------------- |
-| `context`   | `string` | `undefined`    |
-| `termsHref` | `string` | `LINKS.terms`  |
-
-Accessibility: renders as `<aside aria-label="Risk disclaimer">`. The terms link has an explicit `aria-label="Read full terms and conditions"`. When `termsHref` resolves to a placeholder (`'#'` or empty), a `<span aria-disabled="true">` is rendered instead of an anchor so the element is inert for keyboard and AT users.
-
-Tokens: secondary text and spacing tokens via `Disclaimer.css`.
-
-```tsx
-<Disclaimer context="Early withdrawal forfeits accrued rewards." />
-```
-
-## ThemeToggle
-
-Source: [`src/components/ThemeToggle.tsx`](../src/components/ThemeToggle.tsx). Focused docs: [dark mode](./dark-mode.md).
-
-Icon-only header control that flips the app between light and dark mode. The component is a pure consumer of `useSettings()`; it owns no theme state and writes to no storage key (see [dark mode](./dark-mode.md)).
-
-### Icon pair
-
-Inline SVG icons follow the same pattern as [`Banner.tsx`](../src/components/Banner.tsx) and [`Toast.tsx`](../src/components/Toast.tsx): `width="18"` / `height="18"`, `viewBox="0 0 20 20"`, `currentColor`, and `aria-hidden="true"` on the graphic.
-
-| Resolved theme | Icon shown | Meaning |
-| -------------- | ---------- | ------- |
-| `light`        | Moon       | Dark mode is available; click to switch |
-| `dark`         | Sun        | Light mode is available; click to switch |
-
-Sizing is driven by `--credence-theme-toggle-size` (18px) in `ThemeToggle.css`, keeping the 40×40px hit target consistent with other header icon buttons.
-
-### Interaction and motion
-
-| State | Visual |
-| ----- | ------ |
-| Default | `--credence-surface-card` background, `--credence-border-default` border |
-| Hover | Slate-100 (light) / slate-700 (dark) background; border darkens one step |
-| Focus-visible | `--credence-focus-ring` outline with 2px offset |
-| Disabled | 65% opacity, `not-allowed` cursor |
-
-Color transitions use `--credence-motion-duration-base` and `--credence-motion-easing-standard`. Under `prefers-reduced-motion: reduce`, transitions are disabled so the toggle does not animate.
-
-### Accessibility
-
-| Attribute | Value |
-| --------- | ----- |
-| `aria-label` | Static `"Toggle theme"` (stable accessible name) |
-| `aria-pressed` | `true` when resolved theme is `dark`, `false` when `light` |
-| `title` | Dynamic action label, e.g. `"Switch to dark theme"` |
-
-The static `aria-label` avoids re-announcement churn in screen readers; `aria-pressed` communicates the current mode and `title` supplies a hover tooltip with the next action.
-
-```tsx
-<ThemeToggle />
+// BottomNav is rendered by Layout — no props needed.
+// It reads the current route via React Router context automatically.
+<BottomNav />
 ```
 
 ## Progress
@@ -879,7 +582,7 @@ When `value` is supplied the bar is **determinate**: `aria-valuenow`, `aria-valu
 
 Accessibility: `role="progressbar"` on the root; `aria-label` is required. The inner track and fill divs are `aria-hidden`. Indeterminate animation is suppressed under `prefers-reduced-motion`.
 
-Tokens: `--credence-color-primary` (fill), `--credence-color-slate-200` (track background), `--credence-radius-full`, `--credence-space-1/2/3` (track heights), `--credence-motion-duration-base`, `--credence-motion-duration-slow`, `--credence-motion-easing-standard`.
+Tokens: `--credence-color-primary` (fill, default), `--credence-color-success-border`, `--credence-color-warning-border`, `--credence-color-danger-action` (fill, variant colours), `--credence-color-slate-200` (track background), `--credence-radius-full`, `--credence-space-1/2/3` (track heights), `--credence-motion-duration-base`, `--credence-motion-duration-slow`, `--credence-motion-easing-standard`.
 
 ```tsx
 {/* Determinate */}
@@ -887,13 +590,21 @@ Tokens: `--credence-color-primary` (fill), `--credence-color-slate-200` (track b
 
 {/* Indeterminate */}
 <Progress aria-label="Loading trust score" />
+
+{/* Colour variants */}
+<Progress value={60} color="success" aria-label="Upload complete" />
+<Progress value={60} color="warning" aria-label="Upload paused" />
+<Progress value={60} color="danger" aria-label="Upload failed" />
+
+{/* Indeterminate with colour variant */}
+<Progress color="success" aria-label="Processing" />
 ```
 
-## Kbd
+## RepoAvatar
 
-Source: [`src/components/Kbd.tsx`](../src/components/Kbd.tsx).
+Source: [`src/components/RepoAvatar.tsx`](../src/components/RepoAvatar.tsx). Config: [`src/config/avatar.ts`](../src/config/avatar.ts).
 
-Renders a single keyboard key as a styled `<kbd>` element with a raised-button visual. Use this wherever the UI needs to display a keyboard shortcut consistently — in docs, tooltips, onboarding copy, or alongside the `KeyboardShortcutsDialog`.
+Repository avatar component supporting tokenised sizing presets (`sm`, `md`, `lg`) tied directly to `--credence-*` design tokens, image error fallback handling, and accessible ARIA attributes.
 
 | Prop        | Type                   | Default     | Description                                                            |
 | ----------- | ---------------------- | ----------- | ---------------------------------------------------------------------- |
@@ -903,13 +614,9 @@ Renders a single keyboard key as a styled `<kbd>` element with a raised-button v
 | `alt`       | `string`               | `undefined` | Image alt text override                                                |
 | `className` | `string`               | `''`        | Extra CSS class names                                                  |
 
-- `sm` — compact; suited for dense tooltips and inline prose.
-- `md` — default; matches the existing `KeyboardShortcutsDialog` key chip size.
-- `lg` — spacious; suited for large-print contexts and onboarding copy.
+Accessibility: renders `role="img"` with descriptive `aria-label`. When `src` is missing or fails to load, falls back cleanly to uppercase initials derived from `name` or a default repository icon.
 
-Accessibility: renders a native `<kbd>` element (semantic keyboard text); sets `aria-label` to `children` by default. Supply `ariaLabel` when the visible symbol is ambiguous to assistive technology (e.g. `ariaLabel="Command"` for `"⌘"`).
-
-Tokens: `--credence-border-default`, `--credence-color-slate-600`, `--credence-color-slate-700`, `--credence-font-family-base`, `--credence-font-size-xs`, `--credence-font-size-sm`, `--credence-font-weight-semibold`, `--credence-radius-sm`, `--credence-space-1`, `--credence-space-2`, `--credence-space-3`, `--credence-surface-page`, `--credence-text-primary`.
+Tokens: `--credence-avatar-size-sm`, `--credence-avatar-size-md`, `--credence-avatar-size-lg`, `--credence-space-6`, `--credence-space-8`, `--credence-space-12`, `--credence-radius-md`, `--credence-surface-card`, `--credence-border-default`, `--credence-text-primary`, `--credence-font-size-xs`, `--credence-font-size-sm`, `--credence-font-size-base`.
 
 ```tsx
 {

--- a/src/components/Banner.css
+++ b/src/components/Banner.css
@@ -22,22 +22,16 @@
   color: var(--text-info);
 }
 
-.banner--success {
-  background: var(--bg-success);
-  border-color: var(--border-success);
-  color: var(--text-success);
-}
-
-.banner--warning {
+.banner--warn {
   background: var(--bg-warning);
   border-color: var(--border-warning);
   color: var(--text-warning);
 }
 
-.banner--danger {
-  background: var(--bg-danger);
-  border-color: var(--border-danger);
-  color: var(--text-danger);
+.banner--incident {
+  background: var(--bg-incident);
+  border-color: var(--border-incident);
+  color: var(--text-incident);
 }
 
 /* ─── Dismissible vs persistent visual distinction ────────────────────────── */

--- a/src/components/Banner.test.tsx
+++ b/src/components/Banner.test.tsx
@@ -22,10 +22,9 @@ describe('Banner', () => {
 
   describe('role mapping', () => {
     it.each<[BannerSeverity, 'alert' | 'status']>([
-      ['critical', 'alert'],
-      ['warning', 'alert'],
+      ['incident', 'alert'],
+      ['warn', 'alert'],
       ['info', 'status'],
-      ['success', 'status'],
     ])('severity "%s" → role="%s"', (severity, role) => {
       render(<Banner severity={severity}>Message</Banner>)
       expect(screen.getByRole(role)).toBeInTheDocument()
@@ -37,13 +36,12 @@ describe('Banner', () => {
   describe('aria-label', () => {
     it.each<[BannerSeverity, string]>([
       ['info', 'Information banner'],
-      ['success', 'Success banner'],
-      ['warning', 'Warning banner'],
-      ['critical', 'Critical banner'],
+      ['warn', 'Warning banner'],
+      ['incident', 'Incident banner'],
     ])('severity "%s" → aria-label="%s"', (severity, label) => {
       render(<Banner severity={severity}>Message</Banner>)
       // getByRole with name option asserts both the role and accessible name
-      const isUrgent = severity === 'critical' || severity === 'warning'
+      const isUrgent = severity === 'incident' || severity === 'warn'
       expect(screen.getByRole(isUrgent ? 'alert' : 'status', { name: label })).toBeInTheDocument()
     })
   })
@@ -96,7 +94,7 @@ describe('Banner', () => {
           <button ref={ref} type="button">
             Return target
           </button>
-          <Banner severity="warning" dismissible returnFocusRef={ref}>
+          <Banner severity="warn" dismissible returnFocusRef={ref}>
             Message
           </Banner>
         </>
@@ -141,7 +139,7 @@ describe('Banner', () => {
     it('triggers dismissal when Escape is pressed on the dismiss button', () => {
       const onDismiss = vi.fn()
       render(
-        <Banner severity="critical" dismissible onDismiss={onDismiss}>
+        <Banner severity="incident" dismissible onDismiss={onDismiss}>
           Message
         </Banner>
       )
@@ -154,7 +152,7 @@ describe('Banner', () => {
     it('does not trigger dismissal on other keys', () => {
       const onDismiss = vi.fn()
       render(
-        <Banner severity="critical" dismissible onDismiss={onDismiss}>
+        <Banner severity="incident" dismissible onDismiss={onDismiss}>
           Message
         </Banner>
       )
@@ -168,7 +166,7 @@ describe('Banner', () => {
     it('does not trigger dismissal when Escape is fired on the banner wrapper', () => {
       const onDismiss = vi.fn()
       render(
-        <Banner severity="critical" dismissible onDismiss={onDismiss}>
+        <Banner severity="incident" dismissible onDismiss={onDismiss}>
           Message
         </Banner>
       )

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from 'react'
 import { isExternalUrl } from '../lib/isExternalUrl'
 import './Banner.css'
 
-export type BannerSeverity = 'info' | 'success' | 'warning' | 'critical'
+export type BannerSeverity = 'info' | 'warn' | 'incident'
 
 export interface BannerAction {
   label: string
@@ -36,16 +36,7 @@ const ICONS: Record<BannerSeverity, ReactNode> = {
       />
     </svg>
   ),
-  success: (
-    <svg width="18" height="18" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-      <path
-        fillRule="evenodd"
-        d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
-        clipRule="evenodd"
-      />
-    </svg>
-  ),
-  warning: (
+  warn: (
     <svg width="18" height="18" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
       <path
         fillRule="evenodd"
@@ -54,7 +45,7 @@ const ICONS: Record<BannerSeverity, ReactNode> = {
       />
     </svg>
   ),
-  critical: (
+  incident: (
     <svg width="18" height="18" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
       <path
         fillRule="evenodd"
@@ -67,9 +58,8 @@ const ICONS: Record<BannerSeverity, ReactNode> = {
 
 const SEVERITY_LABEL: Record<BannerSeverity, string> = {
   info: 'Information',
-  success: 'Success',
-  warning: 'Warning',
-  critical: 'Critical',
+  warn: 'Warning',
+  incident: 'Incident',
 }
 
 export default function Banner({
@@ -81,7 +71,7 @@ export default function Banner({
   action,
   returnFocusRef,
 }: BannerProps) {
-  const isUrgent = severity === 'critical' || severity === 'warning'
+  const isUrgent = severity === 'incident' || severity === 'warn'
   const dismissBtnRef = useRef<HTMLButtonElement>(null)
 
   const handleDismiss = useCallback(() => {

--- a/src/components/ConnectGate.tsx
+++ b/src/components/ConnectGate.tsx
@@ -104,7 +104,7 @@ export default function ConnectGate({
     <>
       {!isConnected && (
         <Banner
-          severity="warning"
+          severity="warn"
           title={title}
           action={{
             label: actionLabel,

--- a/src/components/CreateBondFlow.tsx
+++ b/src/components/CreateBondFlow.tsx
@@ -333,7 +333,7 @@ export default function CreateBondFlow({ onComplete, onCancel }: CreateBondFlowP
             Step 3: Review Terms
           </h2>
 
-          <Banner severity="warning" title="Early withdrawal — slash exposure">
+          <Banner severity="warn" title="Early withdrawal — slash exposure">
             Withdrawing before lock maturity incurs a slash penalty on your principal. The figures
             below show exactly what you would receive if you exit early.
           </Banner>

--- a/src/index.css
+++ b/src/index.css
@@ -120,6 +120,9 @@
   --credence-color-danger-action: #dc2626;
   --credence-color-danger-text: #991b1b;
   --credence-color-danger-text-muted: #7f1d1d;
+  --credence-color-incident-surface: #fef2f2;
+  --credence-color-incident-border: #dc2626;
+  --credence-color-incident-text: #991b1b;
 
   /* Tier and illustration accents */
   --credence-color-bronze-surface: #fef3c7;
@@ -185,6 +188,9 @@
   --bg-danger: var(--credence-color-danger-surface);
   --border-danger: var(--credence-color-danger-border);
   --text-danger: var(--credence-color-danger-text);
+  --bg-incident: var(--credence-color-incident-surface);
+  --border-incident: var(--credence-color-incident-border);
+  --text-incident: var(--credence-color-incident-text);
   --space-6: var(--credence-space-6);
   --container-padding: var(--credence-container-padding);
   --container-max: var(--credence-container-max);
@@ -215,6 +221,9 @@
   --credence-color-danger-surface: rgba(239, 68, 68, 0.15);
   --credence-color-danger-border: #ef4444;
   --credence-color-danger-text: #fca5a5;
+  --credence-color-incident-surface: rgba(239, 68, 68, 0.15);
+  --credence-color-incident-border: #dc2626;
+  --credence-color-incident-text: #fca5a5;
   --credence-color-bronze-surface: rgba(245, 158, 11, 0.1);
   --credence-color-bronze-border: #b45309;
   --credence-color-bronze-text: #fcd34d;

--- a/src/pages/Bond.tsx
+++ b/src/pages/Bond.tsx
@@ -215,7 +215,7 @@ export default function Bond() {
 
       {!isConnected && (
         <Banner
-          severity="warning"
+          severity="warn"
           title="Connect wallet required"
           action={{ label: 'Connect wallet', onClick: () => setConnectModalOpen(true) }}
         >
@@ -225,7 +225,7 @@ export default function Bond() {
 
       {networkMismatch.mismatch && (
         <Banner
-          severity="warning"
+          severity="warn"
           title={t('bond.networkMismatch')}
           action={{
             label: t('bond.switchNetwork', { network: networkMismatch.actual }),
@@ -242,7 +242,7 @@ export default function Bond() {
       )}
 
       {slashBannerBreakdown && slashExposureBond && (
-        <Banner severity="warning" title={t('bond.slashExposure')}>
+        <Banner severity="warn" title={t('bond.slashExposure')}>
           {t('bond.slashExposureDescription', {
             amount: formatUsdc(slashExposureBond.amountUsdc),
             status: slashExposureBond.status === 'locked' ? 'locked' : 'in grace period',

--- a/src/pages/BondDetail.tsx
+++ b/src/pages/BondDetail.tsx
@@ -115,7 +115,7 @@ export default function BondDetail() {
 
       {!isConnected && (
         <Banner
-          severity="warning"
+          severity="warn"
           title="Connect wallet required"
           action={{ label: 'Connect wallet', onClick: () => setConnectModalOpen(true) }}
         >
@@ -124,7 +124,7 @@ export default function BondDetail() {
       )}
 
       {initialBond.status !== 'active' && breakdown.penaltyUsdc > 0 && (
-        <Banner severity="warning" title="Early Withdrawal Penalty Active">
+        <Banner severity="warn" title="Early Withdrawal Penalty Active">
           This bond is currently locked. Withdrawing early will slash {breakdown.penaltyAmount} (
           {breakdown.penaltyPercent}% penalty).
         </Banner>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -198,7 +198,7 @@ export default function Dashboard() {
       )}
 
       {!online && (
-        <Banner severity="warning">
+        <Banner severity="warn">
           {t('dashboard.offlineBanner', 'You are currently offline. Pull-to-refresh is disabled.')}
         </Banner>
       )}

--- a/src/pages/TrustScore.tsx
+++ b/src/pages/TrustScore.tsx
@@ -215,7 +215,7 @@ export default function TrustScore() {
 
       {networkMismatch.mismatch && (
         <Banner
-          severity="warning"
+          severity="warn"
           title={t('trustScore.networkMismatch')}
           action={{
             label: t('trustScore.switchNetwork', { network: networkMismatch.actual }),
@@ -480,7 +480,7 @@ export default function TrustScore() {
 
       {!isConnected && (
         <Banner
-          severity="warning"
+          severity="warn"
           title={t('trustScore.connectRequired')}
           action={{ label: t('common.connectWallet'), onClick: () => void connect() }}
         >


### PR DESCRIPTION
Closes #824 
Collapsed the previous 4-severity system (info/success/warning/critical) to 3 focused variants: info, warn, and incident. Added --credence-color-incident-* CSS custom properties (light + dark mode) and updated the Banner component's type, icons, CSS classes, and ARIA mappings. All 11 consumer sites updated from warning → warn.