### PR TITLE
feat(uiux): refine app shell layout and content widths (#812)

### DIFF
--- a/src/components/Layout.css
+++ b/src/components/Layout.css
@@ -7,9 +7,11 @@
 }
 
 .appHeader {
-  padding: var(--credence-space-4) var(--credence-space-8);
+  padding-block: var(--credence-space-4);
   border-bottom: 1px solid var(--credence-border-default);
   background: var(--credence-surface-card);
+}
+.appHeader-inner {
   display: flex;
   align-items: center;
   gap: var(--credence-space-6);

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -111,6 +111,7 @@ export default function Layout() {
       <RouteAnnouncer />
 
       <header className="appHeader">
+        <div className="container appHeader-inner">
         {/* Mobile: hamburger toggle (hidden ≥640px via CSS) */}
         <MobileNav />
 
@@ -150,6 +151,7 @@ export default function Layout() {
           <span aria-hidden="true">?</span>
           <span className="sr-only">{t('layout.keyboardShortcuts')}</span>
         </button>
+        </div>
       </header>
 
       {showInstallPrompt && (


### PR DESCRIPTION
Description

Closes #812

Problem

.appMain (main content) and the footer's inner .container.footer-content were already correctly centered and width-constrained via the shared .container utility (max-width: 72rem, margin: 0 auto). But .appHeader had no such constraint — it was a raw full-bleed flex bar with only horizontal padding (--credence-space-8). On wide viewports, the header's logo and nav sit closer to the actual screen edges than the main content and footer do, so the three regions visibly drift out of horizontal alignment the wider the screen gets.

Fix
Wrapped the header's inner content in a new <div className="container appHeader-inner">, reusing the same .container utility class the footer already uses (className="container footer-content") — same pattern, same tokens, one shared source of truth for content width across header/main/footer.
.appHeader itself keeps its full-bleed background and border (only padding-block now, no horizontal padding — that's handled by .container's padding-inline).
New .appHeader-inner rule carries the display: flex; align-items: center; gap that used to live directly on .appHeader.

Net effect: header, main content, and footer are now all bounded by the exact same max-width: 72rem centered container at every breakpoint, instead of the header being independently full-bleed.

Also checked
PageHeader.tsx/PageHeader.css (the shared header component individual pages render inside .appMain) — has no competing max-width, width: 100vw, or negative-margin rules that would break it out of its parent container. It was already correctly inheriting .appMain's width, so no changes needed there. The misalignment was isolated to the global app-shell header.
Testing
npx eslint src/components/Layout.tsx: clean, no errors introduced by this change (3 pre-existing no-useless-assignment errors on unrelated lines/variables — launcherOpen, openShortcuts, closeLauncher — confirmed via git diff to be outside this PR's actual changes, not touched or introduced here).
npm run build: fails on a pre-existing, unrelated TypeScript/JSX syntax error in src/pages/TrustScore.tsx (unclosed ConnectGate tag, ~8 cascading parser errors) — confirmed via git status/git diff this file was never touched in this PR. Out of scope for an app-shell layout issue.
Manual visual QA at 375px/1280px wasn't performed (no browser available in this environment) — worth a pass before merge, though the fix is a straightforward CSS width-alignment change with low visual risk.
Notes for reviewers
The issue's suggested file scope was "app shell/layout components + global styles" — the actual fix only needed src/components/Layout.tsx + Layout.css; PageHeader.tsx was investigated and found to already be correct (see above), so it wasn't touched to avoid unnecessary diff noise.
TrustScore.tsx's build-breaking bug is unrelated and out of scope here, but worth its own issue/PR — happy to file it separately if useful.