### PR TITLE
feat(uiux): replace broken emoji with token-based SVG icons in state components

### DIFF
--- a/src/components/states/ErrorState.tsx
+++ b/src/components/states/ErrorState.tsx
@@ -11,6 +11,86 @@ interface ErrorStateProps {
   icon?: ReactNode
 }
 
+/**
+ * Inline SVG icons for each error type.
+ * All icons use `currentColor` and `aria-hidden="true"` — the accessible name
+ * comes from the surrounding title/message text, matching Banner.tsx / EmptyState.tsx.
+ */
+const ERROR_ICONS: Record<NonNullable<ErrorStateProps['type']>, ReactNode> = {
+  network: (
+    <svg
+      viewBox="0 0 24 24"
+      width="24"
+      height="24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <line x1="1" y1="1" x2="23" y2="23" />
+      <path d="M16.72 11.06A10.94 10.94 0 0 1 19 12.55" />
+      <path d="M5 12.55a10.94 10.94 0 0 1 5.17-2.39" />
+      <path d="M10.71 5.05A16 16 0 0 1 22.58 9" />
+      <path d="M1.42 9a15.91 15.91 0 0 1 4.7-2.88" />
+      <path d="M8.53 16.11a6 6 0 0 1 6.95 0" />
+      <line x1="12" y1="20" x2="12.01" y2="20" />
+    </svg>
+  ),
+  backend: (
+    <svg
+      viewBox="0 0 24 24"
+      width="24"
+      height="24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+      <line x1="12" y1="9" x2="12" y2="13" />
+      <line x1="12" y1="17" x2="12.01" y2="17" />
+    </svg>
+  ),
+  validation: (
+    <svg
+      viewBox="0 0 24 24"
+      width="24"
+      height="24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <line x1="15" y1="9" x2="9" y2="15" />
+      <line x1="9" y1="9" x2="15" y2="15" />
+    </svg>
+  ),
+  generic: (
+    <svg
+      viewBox="0 0 24 24"
+      width="24"
+      height="24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="10" />
+      <line x1="12" y1="8" x2="12" y2="12" />
+      <line x1="12" y1="16" x2="12.01" y2="16" />
+    </svg>
+  ),
+}
+
 export default function ErrorState({
   type = 'generic',
   title,
@@ -37,7 +117,7 @@ export default function ErrorState({
     alignItems: 'center',
     justifyContent: 'center',
     margin: '0 auto var(--credence-space-4)',
-    fontSize: '1.5rem',
+    color: 'var(--credence-color-danger-text)',
   } as const
 
   const errorTitleStyle = {
@@ -51,22 +131,18 @@ export default function ErrorState({
     network: {
       title: 'Connection issue',
       message: 'Unable to connect to the network. Check your internet connection and try again.',
-      emoji: 'ðŸŒ',
     },
     backend: {
       title: 'Service unavailable',
       message: 'Our service is temporarily unavailable. Please try again in a few moments.',
-      emoji: 'âš ï¸',
     },
     validation: {
       title: 'Invalid input',
       message: 'Please check your input and try again.',
-      emoji: 'âŒ',
     },
     generic: {
       title: 'Something went wrong',
       message: 'An unexpected error occurred. Please try again.',
-      emoji: 'âš ï¸',
     },
   }
 
@@ -74,7 +150,7 @@ export default function ErrorState({
 
   return (
     <div style={errorPanelStyle}>
-      <div style={errorIconStyle}>{icon || config.emoji}</div>
+      <div style={errorIconStyle}>{icon || ERROR_ICONS[type]}</div>
       <h3 style={errorTitleStyle}>{title || config.title}</h3>
       <p
         style={{


### PR DESCRIPTION
## Summary
- ErrorState.tsx rendered mojibake (`ðŸŒ`, `âšï¸`, `âŒ`) instead of intended emoji due to corrupted source bytes
- Replaces the emoji approach with inline SVG icons per error type (network, backend, validation, generic), matching the pattern already used in `EmptyState.tsx` and `Banner.tsx`
- Icons use `currentColor` and `aria-hidden="true"`; accessible name comes from the surrounding title/message text
- Note: `EmptyState.tsx` was already fixed on `main` (SVG icons for bond/trust/dispute/attestation/activity illustrations), so this PR only covers the remaining `ErrorState.tsx` half of the original ask

## Test plan
- [x] `npx eslint src/components/states/ErrorState.tsx` — clean
- [ ] Visual QA at 375px and 1280px (icons centered, no clipping)
- Note: `npm run build` / full `npm run lint` / `npm run test` currently fail on `main` for unrelated pre-existing reasons (broken JSX in `Attestations.tsx` / `TrustScore.tsx`, undefined `defaultLocale` in `src/i18n/config.ts`) — verified these failures exist before this change too

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #817