### PR TITLE
feat(uiux): standardize address/amount formatting and copy affordances

### DIFF
--- a/docs/uiux/address-amount-formatting.md
+++ b/docs/uiux/address-amount-formatting.md
@@ -1,0 +1,87 @@
+# Address & Amount Formatting Rules
+
+Defines how Stellar addresses, transaction hashes, and USDC amounts are
+displayed and copied across Credence, so every surface (Bond, Trust,
+Attestations, Transactions, Settings, and future dashboard pages) reads the
+same way.
+
+## Typography
+
+All addresses, hashes, and amounts render in the shared monospace stack so
+digits and characters align predictably:
+
+```css
+font-family: var(--credence-font-family-mono);
+```
+
+`--credence-font-family-mono` is the only mono token — it is defined once in
+`src/index.css`. A second, undefined token (`--credence-font-mono`) had crept
+into `AddressDisplay.css`, `CopyableHash.css`, and `Toast.css`; it silently
+fell back to the browser default font (or, in `AddressDisplay.css`, had no
+fallback at all) instead of the monospace stack. All three call sites now
+point at `--credence-font-family-mono`. Don't reintroduce a second mono
+token — if a component needs monospace text, reference
+`--credence-font-family-mono` directly.
+
+## Stellar addresses
+
+Truncation rules live in `src/lib/stellar.ts` and are shared by every
+component — don't hand-roll `slice()` truncation in a component.
+
+| Mode | Rule | Example |
+|---|---|---|
+| `full` | Untruncated, 56 chars | `GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H` |
+| `short` (default) | First 12 + `...` + last 8 | `GBRPYHIL2CI3...X2H` |
+| `friendly` | First 6 + `…` + last 4 | `GBRPYH…X2H` |
+
+- `truncateAddress(address)` — the `short` rule; leaves addresses ≤ 20 chars
+  unchanged.
+- `formatAddressForDisplay(address, mode)` — pick `full` / `short` / `friendly`
+  explicitly.
+
+Addresses ≤ 20 characters (e.g. test fixtures) are shown unchanged in every
+mode — never truncate something already short enough to read at a glance.
+
+## Transaction hashes
+
+`CopyableHash` truncates transaction hashes with a distinct, shorter rule
+(first 6 + `…` + last 4) since tx hashes are 64 hex chars and don't need the
+address component's longer preview to stay unambiguous. Set `kind="address"`
+on `CopyableHash` to use the shared address truncation rules instead.
+
+## Amounts
+
+USDC amounts use `formatUsdc()` / `formatUSDC()` from `src/lib/format.ts`:
+`en-US` thousands separators, up to 2 decimal places, `" USDC"` suffix. Don't
+call `toLocaleString()` directly in a component — go through `format.ts` so
+every amount on screen uses the same locale and precision rules.
+
+## Copy-to-clipboard affordance
+
+Both addresses and amounts follow the same interaction pattern, via the
+shared `useCopyToClipboard` hook:
+
+- A trailing icon-only button, `aria-label="Copy address"` / `"Copy amount"`,
+  swapping to `aria-label="Copied"` with a checkmark glyph for ~2s after a
+  successful copy (`useCopyToClipboard`'s default `timeoutMs`).
+- Clicking copies the **raw, untruncated** value — the full 56-char address,
+  or the plain numeric amount (not the `"1,234.50 USDC"` label).
+- A successful copy raises a toast (`"Address copied to clipboard"` /
+  `"Amount copied to clipboard"`) via `ToastProvider`; a failed copy does not
+  raise a toast (the button's own `aria-label` state is the failure signal
+  for `CopyableHash`-style consumers that track `copyError`).
+- The copy icon is `aria-hidden="true"` — the button's `aria-label` carries
+  the accessible name, the icon is decorative.
+
+## Components
+
+| Component | Use for | Truncation | Copy |
+|---|---|---|---|
+| `AddressDisplay` | A Stellar address as the primary content of a row/card | `short`, reveals full address on hover/focus | Yes |
+| `CopyableHash` | A tx hash or address alongside an explorer link | `short` (address) or head/tail-6/4 (tx) | Yes |
+| `AmountDisplay` | A USDC amount that a user may want to copy (e.g. exact value for an invoice or dispute) | N/A — full formatted amount always shown | Yes |
+| `formatUsdc()` | Inline amount text with no copy affordance (summaries, table cells, labels) | N/A | No |
+
+Use `AmountDisplay` when the amount is a standalone, copyable value (mirrors
+`AddressDisplay`). Keep using bare `formatUsdc()` for amounts embedded in
+prose, table cells, or summaries where a copy button would be visual noise.

--- a/src/components/AmountDisplay.css
+++ b/src/components/AmountDisplay.css
@@ -1,26 +1,19 @@
-.address-display {
+.amount-display {
   display: inline-flex;
   align-items: center;
   gap: var(--credence-space-2);
 }
 
-.address-display__address {
+.amount-display__amount {
   font-family: var(--credence-font-family-mono);
   font-size: var(--credence-font-size-sm);
   padding: var(--credence-space-1) var(--credence-space-2);
   border-radius: var(--credence-radius-sm);
   background-color: var(--credence-color-surface-hover);
   color: var(--credence-text-primary);
-  transition: background-color var(--credence-motion-duration-fast) var(--credence-motion-easing-standard);
-  outline: none;
 }
 
-.address-display__address:hover,
-.address-display__address:focus {
-  background-color: var(--credence-color-surface-active);
-}
-
-.address-display__copy-btn {
+.amount-display__copy-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -33,12 +26,12 @@
   transition: all var(--credence-motion-duration-fast) var(--credence-motion-easing-standard);
 }
 
-.address-display__copy-btn:hover {
+.amount-display__copy-btn:hover {
   background-color: var(--credence-color-surface-hover);
   color: var(--credence-text-primary);
 }
 
-.address-display__copy-btn:focus-visible {
+.amount-display__copy-btn:focus-visible {
   outline: 2px solid var(--credence-color-primary);
   outline-offset: 2px;
 }

--- a/src/components/AmountDisplay.test.tsx
+++ b/src/components/AmountDisplay.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import AmountDisplay from './AmountDisplay'
+import * as CopyHookModule from '../hooks/useCopyToClipboard'
+import * as ToastModule from './ToastProvider'
+
+vi.mock('../hooks/useCopyToClipboard', () => ({
+  default: vi.fn(),
+}))
+
+vi.mock('./ToastProvider', () => ({
+  useToast: vi.fn(),
+}))
+
+describe('AmountDisplay', () => {
+  const mockCopy = vi.fn()
+  const mockAddToast = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockCopy.mockResolvedValue(true)
+    vi.mocked(CopyHookModule.default).mockReturnValue({
+      copy: mockCopy,
+      copied: false,
+      reset: vi.fn(),
+    })
+
+    vi.mocked(ToastModule.useToast).mockReturnValue({
+      addToast: mockAddToast,
+      removeToast: vi.fn(),
+      removeAllToasts: vi.fn(),
+      announce: vi.fn(),
+    })
+  })
+
+  describe('rendering', () => {
+    it('renders the amount formatted with the USDC suffix', () => {
+      render(<AmountDisplay amount={1234.5} />)
+
+      expect(screen.getByText('1,234.5 USDC')).toBeInTheDocument()
+    })
+
+    it('renders a copy button by default', () => {
+      render(<AmountDisplay amount={100} />)
+
+      expect(screen.getByRole('button', { name: 'Copy amount' })).toBeInTheDocument()
+    })
+
+    it('hides the copy button when showCopyButton is false', () => {
+      render(<AmountDisplay amount={100} showCopyButton={false} />)
+
+      expect(screen.queryByRole('button')).not.toBeInTheDocument()
+    })
+
+    it('applies a custom className', () => {
+      render(<AmountDisplay amount={100} className="my-custom-class" />)
+
+      const container = document.querySelector('.amount-display')
+      expect(container).toHaveClass('my-custom-class')
+    })
+
+    it('shows a checkmark icon and updated label when copied state is true', () => {
+      vi.mocked(CopyHookModule.default).mockReturnValue({
+        copy: mockCopy,
+        copied: true,
+        reset: vi.fn(),
+      })
+
+      render(<AmountDisplay amount={100} />)
+
+      expect(screen.getByRole('button', { name: 'Copied' })).toBeInTheDocument()
+      const btn = screen.getByRole('button', { name: 'Copied' })
+      expect(btn.querySelector('svg polyline')).toBeInTheDocument()
+    })
+  })
+
+  describe('copy button', () => {
+    it('calls copy with the raw numeric amount on click', () => {
+      render(<AmountDisplay amount={1234.5} />)
+
+      const btn = screen.getByRole('button', { name: 'Copy amount' })
+      fireEvent.click(btn)
+
+      expect(mockCopy).toHaveBeenCalledWith('1234.5')
+    })
+
+    it('shows a success toast after a successful copy', async () => {
+      mockCopy.mockResolvedValue(true)
+
+      render(<AmountDisplay amount={1234.5} />)
+
+      const btn = screen.getByRole('button', { name: 'Copy amount' })
+      fireEvent.click(btn)
+
+      await waitFor(() => {
+        expect(mockAddToast).toHaveBeenCalledWith('success', 'Amount copied to clipboard')
+      })
+    })
+
+    it('does not show a success toast when copy fails', () => {
+      mockCopy.mockResolvedValue(false)
+
+      render(<AmountDisplay amount={1234.5} />)
+
+      const btn = screen.getByRole('button', { name: 'Copy amount' })
+      fireEvent.click(btn)
+
+      expect(mockCopy).toHaveBeenCalledWith('1234.5')
+      expect(mockAddToast).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/components/AmountDisplay.tsx
+++ b/src/components/AmountDisplay.tsx
@@ -1,0 +1,74 @@
+import { formatUsdc } from '../lib/format'
+import useCopyToClipboard from '../hooks/useCopyToClipboard'
+import { useToast } from './ToastProvider'
+import './AmountDisplay.css'
+
+export interface AmountDisplayProps {
+  /** Raw numeric amount, e.g. `1234.5` */
+  amount: number
+  className?: string
+  showCopyButton?: boolean
+}
+
+/**
+ * Displays a formatted USDC amount in monospace with a copy-to-clipboard
+ * affordance, matching AddressDisplay's pattern (same hook, same toast,
+ * same token usage) so addresses and amounts share one formatting language.
+ * The copy button copies the raw numeric value, not the "1,234.50 USDC" label.
+ */
+export default function AmountDisplay({
+  amount,
+  className = '',
+  showCopyButton = true,
+}: AmountDisplayProps) {
+  const { copy, copied } = useCopyToClipboard()
+  const { addToast } = useToast()
+
+  const handleCopy = async () => {
+    const success = await copy(String(amount))
+    if (success) {
+      addToast('success', 'Amount copied to clipboard')
+    }
+  }
+
+  return (
+    <div className={`amount-display ${className}`}>
+      <code className="amount-display__amount">{formatUsdc(amount)}</code>
+      {showCopyButton && (
+        <button
+          type="button"
+          className="amount-display__copy-btn"
+          onClick={handleCopy}
+          aria-label={copied ? 'Copied' : 'Copy amount'}
+        >
+          {copied ? (
+            <svg
+              viewBox="0 0 24 24"
+              width="16"
+              height="16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              aria-hidden="true"
+            >
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
+          ) : (
+            <svg
+              viewBox="0 0 24 24"
+              width="16"
+              height="16"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              aria-hidden="true"
+            >
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+              <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+            </svg>
+          )}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/components/CopyableHash.css
+++ b/src/components/CopyableHash.css
@@ -2,7 +2,7 @@
   display: inline-flex;
   align-items: center;
   gap: var(--credence-spacing-xs, 0.25rem);
-  font-family: var(--credence-font-mono, monospace);
+  font-family: var(--credence-font-family-mono);
   font-size: 0.9em;
   color: var(--credence-color-text, inherit);
 }

--- a/src/components/Toast.css
+++ b/src/components/Toast.css
@@ -177,7 +177,7 @@
 }
 
 .toast__tx-hash {
-  font-family: var(--credence-font-mono, monospace);
+  font-family: var(--credence-font-family-mono);
   font-size: 0.75rem;
   opacity: 0.75;
 }


### PR DESCRIPTION
## Summary
- Fixes a broken `--credence-font-mono` CSS variable that was never defined anywhere in the design tokens (`src/index.css` only defines `--credence-font-family-mono`) — it was silently dropping the monospace font on `AddressDisplay.css` (no fallback at all), `CopyableHash.css`, and `Toast.css` (both fell back to generic `monospace`, losing the brand stack). All three now point at the canonical `--credence-font-family-mono` token.
- Adds `AmountDisplay`, mirroring `AddressDisplay`'s pattern (`useCopyToClipboard`, `ToastProvider`, same token usage), so USDC amounts get the same monospace + copy-to-clipboard affordance that addresses already have — previously only addresses/hashes had a copy affordance, not amounts.
- Documents the consolidated formatting + copy-affordance rules (truncation modes, typography token, copy interaction contract, when to use `AmountDisplay` vs bare `formatUsdc()`) in `docs/uiux/address-amount-formatting.md`.
- Existing address truncation utilities (`truncateAddress`, `formatAddressForDisplay`) and USDC formatters (`formatUsdc` et al.) in `src/lib/` were already solid and are left as-is — this PR fixes the token bug, closes the address/amount copy-affordance gap, and writes down the rules as a single source of truth.

## Test plan
- [x] New `AmountDisplay.test.tsx` (8 tests) passes, alongside existing `AddressDisplay.test.tsx` (17 tests)
- [x] `npx eslint` clean on all new/changed TS/TSX files
- [ ] Visual QA at 375px and 1280px
- Note: full-repo `npm run build` / `npm run lint` / `npm run test` currently fail on `main` for unrelated pre-existing reasons (broken JSX in `Attestations.tsx` / `TrustScore.tsx`, undefined `defaultLocale` in `src/i18n/config.ts`) — confirmed via `git stash` that these failures predate this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #833