### PR TITLE
feat(hooks): document useDebouncedValue & useOnceMounted; add timer-injection options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-<<<<<<< Updated upstream
 ### Refactored
+
 - **`useLocalStorage<T>` hook** (`src/hooks/useLocalStorage.ts`): generic hook that encapsulates the read/parse/fallback pattern for localStorage. SSR-safe (`window` guard), corrupt-JSON-tolerant, and treats falsy-but-valid stored values (`false`, `0`, `""`) correctly. Returns a stable `[value, setValue]` tuple where `setValue` writes through to localStorage synchronously. Pure helpers `resolveStoredValue` and `writeToStorage` are also exported for testing.
 - **`SettingsContext`**: replaced the ad-hoc `loadSavedSettings` + five `useState` lazy-init blocks with a single `useLocalStorage<PersistedSettings>` call so the parse-on-mount happens once. Also extracted a `useMigrateLegacyTheme` hook that runs synchronously (before the first `useLocalStorage` read) to absorb any orphaned `theme` key into `credence:settings`. Public `SettingsState` shape and `STORAGE_KEY` are unchanged.
 
 ### Added
+
 - `src/lib/penalty.ts`: extracted `BondStatus`, `MockBond`, `getPenaltyRate`, and `computeWithdrawBreakdown` into a shared module, making the penalty math the single source of truth for Bond.tsx and ConfirmDialog.
 - `src/lib/penalty.test.ts`: unit tests for all penalty rates and breakdown arithmetic (active/grace-period/locked, zero-penalty path, fractional amounts).
+- Added a reusable infinite-query wrapper for cursor-based feeds in [`src/hooks/useInfiniteQuery.ts`](src/hooks/useInfiniteQuery.ts).
+- Documented the new pagination helper in the main README and docs index.
+- **`useDebouncedValue` documentation** (`docs/HOOKS.md`): catalog entry covering the central-place search/filter debouncer — signature, parameter table, behavior notes (restart-on-change, `delayMs <= 0` short-circuit, referential stability, testable via injected timers), SSR/cleanup contract, and a Trust-search example.
+- **`useOnceMounted` documentation** (`docs/HOOKS.md`): catalog entry covering the StrictMode-safe run-once guard — signature, behavior notes (StrictMode double-invoke via `calledRef`, true-remount rebinds, latest-callback-wins via ref, optional cleanup, synchronous error propagation), and an analytics `route_view` example.
+- **CHANGELOG merge conflict markers removed**: the long-standing `<<<<<<< Updated upstream` / `=======` / `>>>>>>> Stashed changes` block under `[Unreleased]` is resolved by taking the union of both sides (they were non-overlapping additions from different PRs).
 
 ### Changed
+
 - `Bond.tsx`: imports penalty helpers from `src/lib/penalty.ts`; `slashBannerBreakdown` is now memoized with `useMemo` to avoid recomputing on unrelated renders.
-=======
-### Added
-- Added a reusable infinite-query wrapper for cursor-based feeds in [src/hooks/useInfiniteQuery.ts](src/hooks/useInfiniteQuery.ts).
-- Documented the new pagination helper in the main README and docs index.
->>>>>>> Stashed changes
+- **`useDebouncedValue<T>`** (`src/hooks/useDebouncedValue.ts`): added an optional third `options` argument exposing `setTimeoutImpl` / `clearTimeoutImpl` — the same injectable-timer pattern already used by `useCopyToClipboard`. Backwards-compatible (defaults preserve the existing global-timer behaviour); enables per-test assertion of timer scheduling without `vi.mock` of the module. The implementations are captured in refs so the effect only re-runs on `value` / `delayMs` changes (callers may pass inline function literals without thrashing the effect). Errors from a throwing `clearTimeoutImpl` are caught so a broken test double cannot crash the render path.
 
 ## [1.0.0] - 2026-04-28
 
 ### Added
+
 - **Project Initialization**
   - Set up React 18 application with TypeScript and Vite
   - Configured ESLint, Prettier for code quality
@@ -80,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - API proxy setup for backend communication
 
 ### Design Principles Implemented
+
 - User-first approach with clear, encouraging messaging
 - Actionable empty and error states
 - Consistent patterns across all views
@@ -87,10 +92,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Performant animations and transitions
 
 ### Next Steps
+
 - Integrate with Credence backend API
 - Add wallet connection functionality
 - Implement Soroban contract calls
 - Add unit tests for components
 - Conduct accessibility audit
-- Create Figma mockups and link in design specs</content>
-<parameter name="filePath">c:\Users\User 2\Desktop\Credence-Frontend\CHANGELOG.md
+- Create Figma mockups and link in design specs

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -24,6 +24,8 @@ behavior notes, and a minimal usage example linking to source.
   - [`useFocusTrap`](#usefocustrap)
   - [`useDocumentTitle`](#usedocumenttitle)
   - [`useForwardRef`](#useforwardref)
+  - [`useDebouncedValue`](#usedebouncedvalue)
+  - [`useOnceMounted`](#useoncemounted)
   - [`useMediaQuery`](#usemediaquery)
   - [`useApiQuery`](#useapiquery)
   - [`useQuery`](#usequery)
@@ -234,6 +236,125 @@ const FancyInput = forwardRef<HTMLInputElement, FancyInputProps>(function FancyI
     </label>
   )
 })
+```
+
+---
+
+### `useDebouncedValue`
+
+Source: [`src/hooks/useDebouncedValue.ts`](../src/hooks/useDebouncedValue.ts)
+
+```ts
+function useDebouncedValue<T>(value: T, delayMs: number, options?: UseDebouncedValueOptions): T
+
+interface UseDebouncedValueOptions {
+  setTimeoutImpl?: typeof setTimeout // default: global setTimeout (for tests / fake timers)
+  clearTimeoutImpl?: typeof clearTimeout // default: global clearTimeout
+}
+```
+
+Returns a debounced copy of `value` that only updates after the input has remained stable
+for `delayMs` milliseconds. The single source of truth for search-input and filter debouncing
+across the app — components should never call `setTimeout` directly for this purpose. Pairs
+with `useDebouncedAutoSave` when a debounced _side effect_ is needed instead of a debounced
+_value_.
+
+**Parameters**
+
+| Parameter | Required | Description                                                                                  |
+| --------- | :------: | -------------------------------------------------------------------------------------------- |
+| `value`   |    ✓     | The source value to debounce. Generics preserve reference identity when the value is stable. |
+| `delayMs` |    ✓     | Debounce window in milliseconds. `<= 0` short-circuits to a synchronous pass-through.        |
+| `options` |          | Optional `setTimeoutImpl` / `clearTimeoutImpl` injection for tests or alternate runtimes.    |
+
+**Behavior notes**
+
+- **Restart on change:** every change to `value` (or `delayMs`) cancels the prior timer and
+  starts a fresh `delayMs` window, collapsing rapid bursts into the final value.
+- **`delayMs <= 0` short-circuit:** when non-positive, the hook returns the raw `value`
+  synchronously on every render — useful for tests and for consumer-controllable debounce
+  windows (e.g. "Search immediately").
+- **No unmount warnings:** the pending timer is always cleared on unmount, so a later
+  `setState` on an unmounted component is impossible.
+- **Referential stability:** when the input `value` reference is unchanged, the returned
+  value is the same reference as the previous render — safe as a `useEffect` dependency.
+- **Testable without mocking the import:** the optional `setTimeoutImpl` / `clearTimeoutImpl`
+  injection lets individual tests assert that timers are scheduled and cleared without
+  `vi.mock('@/hooks/useDebouncedValue')`. Errors from `clearTimeoutImpl` are swallowed so a
+  broken test double cannot crash the render path.
+- **SSR-safe / cleanup:** all timer work happens inside `useEffect`; the effect cleanup
+  always clears the pending timer.
+
+```tsx
+import { useEffect, useState } from 'react'
+import { useDebouncedValue } from '../hooks/useDebouncedValue'
+
+function TrustLookupSearch() {
+  const [query, setQuery] = useState('')
+  // Settle for 300ms before triggering an API call so we don't slam the backend
+  // on every keystroke.
+  const debouncedQuery = useDebouncedValue(query, 300)
+
+  useEffect(() => {
+    if (debouncedQuery) searchAPI(debouncedQuery)
+  }, [debouncedQuery])
+
+  return <input value={query} onChange={(e) => setQuery(e.target.value)} />
+}
+```
+
+---
+
+### `useOnceMounted`
+
+Source: [`src/hooks/useOnceMounted.ts`](../src/hooks/useOnceMounted.ts)
+
+```ts
+function useOnceMounted(callback: () => void | (() => void)): void
+```
+
+Runs the provided callback exactly once per component mount, even under React 18 StrictMode
+where effects are intentionally double-invoked in development. Use this for actions that should
+fire **once and only once** when a component becomes alive — analytics page views, one-shot
+feature flags, telemetry, single-run side effects.
+
+**Parameters**
+
+| Parameter  | Required | Description                                                                                                                     |
+| ---------- | :------: | ------------------------------------------------------------------------------------------------------------------------------- |
+| `callback` |    ✓     | Function invoked on mount. May return a cleanup function, which will be invoked on unmount (or StrictMode's simulated unmount). |
+
+**Behavior notes**
+
+- **StrictMode-safe:** React 18 StrictMode in development intentionally mounts → unmounts →
+  remounts every component to surface lifecycle bugs. A `calledRef` guard persists across
+  that simulated unmount, so the callback only fires **once** despite the double-invoke.
+- **True remount rebinds:** a true unmount followed by a remount (different component
+  instance) starts fresh and fires the callback again — the right semantics for "run once
+  per lifetime of _this_ instance".
+- **Latest callback wins:** the `callback` is captured via a ref that is refreshed every
+  render, so callers do not need to wrap it in `useCallback` or include it in dependency
+  arrays.
+- **Optional cleanup:** if the callback returns a function, it is stored and invoked on
+  unmount. Under StrictMode, cleanup also runs on the simulated unmount, but the callback
+  itself still only fires once.
+- **Synchronous errors propagate** out of the mount effect — wrap your callback in a
+  `try/catch` if swallowing is desired.
+- **SSR-safe / cleanup:** runs inside `useEffect`; the cleanup function returned by the
+  callback is invoked on unmount.
+
+```tsx
+import { useOnceMounted } from '../hooks/useOnceMounted'
+
+function BondPage() {
+  // Fires exactly once when BondPage mounts, even under StrictMode's
+  // double-invoke, and never again while the page stays mounted.
+  useOnceMounted(() => {
+    analytics.track('route_view', { route: 'bond' })
+  })
+
+  return <main>…</main>
+}
 ```
 
 ---

--- a/src/hooks/useDebouncedValue.test.ts
+++ b/src/hooks/useDebouncedValue.test.ts
@@ -274,3 +274,144 @@ describe('useDebouncedValue', () => {
     expect(result.current).toBe(42)
   })
 })
+
+describe('useDebouncedValue — options injection', () => {
+  it('uses the injected setTimeout / clearTimeout implementations', () => {
+    const setTimeoutImpl = vi.fn().mockReturnValue(42 as unknown as ReturnType<typeof setTimeout>)
+    const clearTimeoutImpl = vi.fn()
+
+    const { rerender } = renderHook(
+      ({ value, delayMs, options }) => useDebouncedValue(value, delayMs, options),
+      { initialProps: { value: 'a', delayMs: 200, options: { setTimeoutImpl, clearTimeoutImpl } } }
+    )
+
+    // Initial render schedules a debounce via the injected setTimeout
+    expect(setTimeoutImpl).toHaveBeenCalledTimes(1)
+    expect(setTimeoutImpl).toHaveBeenCalledWith(expect.any(Function), 200)
+
+    // A value change should cancel the previous timer and schedule a new one
+    rerender({ value: 'b', delayMs: 200, options: { setTimeoutImpl, clearTimeoutImpl } })
+    expect(clearTimeoutImpl).toHaveBeenCalledWith(42)
+    expect(setTimeoutImpl).toHaveBeenCalledTimes(2)
+  })
+
+  it('passes the injected setTimeout result through to clearTimeout on unmount', () => {
+    const setTimeoutImpl = vi.fn().mockReturnValue(99 as unknown as ReturnType<typeof setTimeout>)
+    const clearTimeoutImpl = vi.fn()
+
+    const { unmount } = renderHook(() =>
+      useDebouncedValue('a', 200, { setTimeoutImpl, clearTimeoutImpl })
+    )
+
+    expect(setTimeoutImpl).toHaveBeenCalled()
+    unmount()
+
+    expect(clearTimeoutImpl).toHaveBeenCalledWith(99)
+  })
+
+  it('does not crash when clearTimeoutImpl throws on cancellation', () => {
+    const setTimeoutImpl = vi.fn().mockReturnValue(1 as unknown as ReturnType<typeof setTimeout>)
+    const clearTimeoutImpl = vi.fn(() => {
+      throw new Error('boom')
+    })
+
+    expect(() => {
+      const { rerender } = renderHook(
+        ({ value }) => useDebouncedValue(value, 200, { setTimeoutImpl, clearTimeoutImpl }),
+        { initialProps: { value: 'a' } }
+      )
+      rerender({ value: 'b' })
+    }).not.toThrow()
+  })
+
+  it('does not crash when clearTimeoutImpl throws on unmount cleanup', () => {
+    const setTimeoutImpl = vi.fn().mockReturnValue(1 as unknown as ReturnType<typeof setTimeout>)
+    const clearTimeoutImpl = vi.fn(() => {
+      throw new Error('boom')
+    })
+
+    expect(() => {
+      const { unmount } = renderHook(() =>
+        useDebouncedValue('a', 200, { setTimeoutImpl, clearTimeoutImpl })
+      )
+      unmount()
+    }).not.toThrow()
+  })
+
+  it('does not call setTimeoutImpl when delayMs is <= 0 (short-circuit path)', () => {
+    const setTimeoutImpl = vi.fn().mockReturnValue(1 as unknown as ReturnType<typeof setTimeout>)
+    const clearTimeoutImpl = vi.fn()
+
+    const { result, rerender } = renderHook(
+      ({ value, delayMs }) =>
+        useDebouncedValue(value, delayMs, { setTimeoutImpl, clearTimeoutImpl }),
+      { initialProps: { value: 'a', delayMs: 0 } }
+    )
+    expect(result.current).toBe('a')
+    expect(setTimeoutImpl).not.toHaveBeenCalled()
+
+    rerender({ value: 'b', delayMs: -1 })
+    expect(result.current).toBe('b')
+    expect(setTimeoutImpl).not.toHaveBeenCalled()
+  })
+
+  it('fires the injected setTimeoutImpl callback and updates the debounced value', () => {
+    // vi.advanceTimersByTime only fires timers created via vitest's controlled
+    // setTimeout — when the caller injects their own setTimeoutImpl, the timer
+    // is registered with that impl, so we capture the scheduled callback and
+    // invoke it manually to simulate the timer firing.
+    let scheduled: (() => void) | null = null
+    const setTimeoutImpl = vi.fn((cb: () => void, _ms: number) => {
+      scheduled = cb
+      return 7 as unknown as ReturnType<typeof setTimeout>
+    })
+    const clearTimeoutImpl = vi.fn()
+
+    const { result, rerender } = renderHook(
+      ({ value, delayMs }) =>
+        useDebouncedValue(value, delayMs, { setTimeoutImpl, clearTimeoutImpl }),
+      { initialProps: { value: 'a', delayMs: 200 } }
+    )
+
+    expect(result.current).toBe('a')
+    rerender({ value: 'b', delayMs: 200 })
+    // Still pending — value has not been committed yet
+    expect(result.current).toBe('a')
+    expect(scheduled).not.toBeNull()
+
+    act(() => {
+      scheduled?.()
+    })
+    expect(result.current).toBe('b')
+  })
+
+  it('does not re-run the effect when only the injected impl references change', () => {
+    // The implementation objects are kept in refs; changing the references
+    // across renders must NOT cancel and reschedule the timer.
+    const impl1 = {
+      set: vi.fn().mockReturnValue(1 as unknown as ReturnType<typeof setTimeout>),
+      clear: vi.fn(),
+    }
+    const impl2 = {
+      set: vi.fn().mockReturnValue(2 as unknown as ReturnType<typeof setTimeout>),
+      clear: vi.fn(),
+    }
+
+    const { rerender } = renderHook(
+      ({ value, options }) => useDebouncedValue(value, 200, options),
+      {
+        initialProps: {
+          value: 'a',
+          options: { setTimeoutImpl: impl1.set, clearTimeoutImpl: impl1.clear },
+        },
+      }
+    )
+    expect(impl1.set).toHaveBeenCalledTimes(1)
+
+    // Same value, but new impl references — effect must NOT re-run.
+    rerender({ value: 'a', options: { setTimeoutImpl: impl2.set, clearTimeoutImpl: impl2.clear } })
+    expect(impl1.set).toHaveBeenCalledTimes(1)
+    expect(impl1.clear).not.toHaveBeenCalled()
+    expect(impl2.set).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/useDebouncedValue.ts
+++ b/src/hooks/useDebouncedValue.ts
@@ -1,6 +1,26 @@
 import { useEffect, useRef, useState } from 'react'
 
 /**
+ * Optional configuration for `useDebouncedValue`.
+ */
+export interface UseDebouncedValueOptions {
+  /**
+   * Injectable `setTimeout` for tests or alternate runtimes. Defaults to the
+   * global `setTimeout`. The implementation is captured in a ref so the
+   * `useEffect` does not re-run when the caller passes an inline function.
+   */
+  setTimeoutImpl?: typeof setTimeout
+  /**
+   * Injectable `clearTimeout` for tests or alternate runtimes. Defaults to
+   * the global `clearTimeout`. The implementation is captured in a ref so the
+   * `useEffect` does not re-run when the caller passes an inline function.
+   * Errors thrown by this implementation are silently swallowed so an
+   * unmount-time cleanup can never crash the render path.
+   */
+  clearTimeoutImpl?: typeof clearTimeout
+}
+
+/**
  * Returns a debounced copy of `value` that only updates after the input has
  * remained stable for `delayMs` milliseconds.
  *
@@ -16,6 +36,7 @@ import { useEffect, useRef, useState } from 'react'
  *
  * @param value  The source value to debounce.
  * @param delayMs  Debounce window in milliseconds. `<= 0` means no debounce.
+ * @param options  Optional timer-injection knobs (see `UseDebouncedValueOptions`).
  *
  * @returns The debounced (or raw, when `delayMs <= 0`) value.
  *
@@ -33,9 +54,23 @@ import { useEffect, useRef, useState } from 'react'
  * }
  * ```
  */
-export function useDebouncedValue<T>(value: T, delayMs: number): T {
+export function useDebouncedValue<T>(
+  value: T,
+  delayMs: number,
+  options?: UseDebouncedValueOptions
+): T {
+  const { setTimeoutImpl = setTimeout, clearTimeoutImpl = clearTimeout } = options ?? {}
+
   const [debouncedValue, setDebouncedValue] = useState(value)
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Capture the timer impls in refs so the effect only re-runs on `value` /
+  // `delayMs` changes — callers can pass inline function literals without
+  // thrashing the effect every render.
+  const setTimeoutImplRef = useRef(setTimeoutImpl)
+  setTimeoutImplRef.current = setTimeoutImpl
+  const clearTimeoutImplRef = useRef(clearTimeoutImpl)
+  clearTimeoutImplRef.current = clearTimeoutImpl
 
   useEffect(() => {
     if (delayMs <= 0) {
@@ -44,19 +79,31 @@ export function useDebouncedValue<T>(value: T, delayMs: number): T {
     }
 
     if (timeoutRef.current !== null) {
-      clearTimeout(timeoutRef.current)
+      safeClearTimeout(clearTimeoutImplRef.current, timeoutRef.current)
     }
 
-    timeoutRef.current = setTimeout(() => {
+    timeoutRef.current = setTimeoutImplRef.current(() => {
       setDebouncedValue(value)
     }, delayMs)
 
     return () => {
       if (timeoutRef.current !== null) {
-        clearTimeout(timeoutRef.current)
+        safeClearTimeout(clearTimeoutImplRef.current, timeoutRef.current)
       }
     }
   }, [value, delayMs])
 
   return delayMs <= 0 ? value : debouncedValue
+}
+
+/**
+ * Defensive `clearTimeout` wrapper — swallows throws so a broken test double
+ * cannot crash the render path during unmount cleanup.
+ */
+function safeClearTimeout(impl: typeof clearTimeout, handle: ReturnType<typeof setTimeout>): void {
+  try {
+    impl(handle)
+  } catch {
+    // Ignore — a broken timer impl should not crash React.
+  }
 }


### PR DESCRIPTION
# feat(hooks): document `useDebouncedValue` & `useOnceMounted`; add timer-injection options to `useDebouncedValue`

Closes #652
Closes #656

## Why

Both `useDebouncedValue` and `useOnceMounted` already ship in `src/hooks/` and have comprehensive unit-test coverage — but until this PR they were missing from `docs/HOOKS.md`, the canonical catalog of reusable primitives referenced by reviewers and newcomers alike. The "documented where it is observable" acceptance criterion from both issues was therefore unmet.

In addition, `useDebouncedValue` had a hidden correctness wart: the only way to test its timer behaviour was to `vi.mock('@/hooks/useDebouncedValue')` wholesale, which discards the real implementation under test. This PR adds an opt-in `options.setTimeoutImpl` / `options.clearTimeoutImpl` injection that follows the same pattern already established by `src/hooks/useCopyToClipboard.ts`, and the implementation is refactored to capture the impls in refs so inline function literals do not thrash the `useEffect`.

`useOnceMounted` itself was already complete and StrictMode-safe; it gets docs only, no behavioural change.

A long-standing merge-conflict block (`<<<<<<< Updated upstream` / `=======` / `>>>>>>> Stashed changes`) under `## [Unreleased]` in `CHANGELOG.md` is also resolved in passing — the two sides were non-overlapping additions from different PRs, so the union is the right merge.

## What

### `docs/HOOKS.md`
- New `useDebouncedValue` catalog entry (signature, parameter table, behavior notes, SSR/cleanup contract, `TrustLookupSearch` example).
- New `useOnceMounted` catalog entry (signature, behavior notes covering `calledRef`-based StrictMode safety, true-remount rebinding, latest-callback-wins via ref, optional cleanup, synchronous error propagation; `BondPage` analytics example).
- `Contents` ToC updated in alphabetical order.

### `src/hooks/useDebouncedValue.ts`
- New `UseDebouncedValueOptions` interface (typed to `typeof setTimeout` / `typeof clearTimeout`).
- New optional third arg `options?: UseDebouncedValueOptions`.
- `setTimeoutImpl` / `clearTimeoutImpl` are captured in `useRef` slots that are refreshed every render; the `useEffect` only re-runs on `[value, delayMs]` changes. This is the key correctness improvement: callers can pass inline arrow functions without re-scheduling the timer on every render.
- A new private `safeClearTimeout(impl, handle)` helper wraps `clearTimeoutImpl` in a `try/catch` so a broken test double cannot crash React's render path on unmount.
- TSDoc expanded to document the new `options` arg, defaults, and contract.
- Public API is 100% backwards-compatible — every existing call site and existing test continues to pass without changes.

### `src/hooks/useDebouncedValue.test.ts`
- New `describe('useDebouncedValue — options injection')` block with 6 tests:
  1. Injected `setTimeoutImpl` / `clearTimeoutImpl` are used on rerender; the prior handle is cleared.
  2. The timer handle is passed to `clearTimeoutImpl` on unmount.
  3. A throwing `clearTimeoutImpl` on cancellation is swallowed.
  4. A throwing `clearTimeoutImpl` on unmount cleanup is swallowed.
  5. `setTimeoutImpl` is **not** called on the `delayMs <= 0` short-circuit path.
  6. The injected `setTimeoutImpl` callback actually fires and updates the debounced value (behaviour test, not just a call-args check).
  7. The effect does **not** re-run when only the impl references change (verifies the ref capture is working).
- 16 pre-existing `useDebouncedValue` tests are unchanged and continue to pass.
- 8 pre-existing `useOnceMounted` tests are unchanged and continue to pass.

### `CHANGELOG.md`
- The `<<<<<<< Updated upstream` / `=======` / `>>>>>>> Stashed changes` block under `## [Unreleased]` is resolved by taking the union of both sides (non-overlapping additions from different PRs).
- Two new bullets under `### Added` for the `useDebouncedValue` and `useOnceMounted` documentation.
- One new bullet under `### Changed` for the new `options` arg on `useDebouncedValue`.
- One new bullet documenting that the long-standing merge conflict markers have been removed.

## How (validation)

Run locally:
```bash
npm run lint
npm run test -- src/hooks/useDebouncedValue.test.ts src/hooks/useOnceMounted.test.tsx
npm run format:check
```

Results on this branch (after review-fixups):
- ✅ `npx vitest run src/hooks/useDebouncedValue.test.ts src/hooks/useOnceMounted.test.tsx` — **31/31 tests pass** (23 useDebouncedValue + 8 useOnceMounted)
- ✅ `npx prettier --check` on all 4 changed files — clean
- ✅ `npx eslint` on `src/hooks/useDebouncedValue.ts` and `src/hooks/useDebouncedValue.test.ts` — clean
- ⚠️ `npx tsc -b` reports 6 pre-existing errors in `src/pages/Attestations.tsx` and `src/pages/TrustScore.tsx` (unrelated JSX closing-tag / brace mismatches). I verified these exist on `origin/main` before my changes (`git stash` then `tsc -b` reproduces them) — out of scope for this PR. I left them untouched per the "unrelated refactors in adjacent files" rule in the issues.

## Diffstat
```
 CHANGELOG.md                        |  21 ++++--
 docs/HOOKS.md                       | 121 +++++++++++++++++++++++++++++++
 src/hooks/useDebouncedValue.test.ts | 141 ++++++++++++++++++++++++++++++++++++
 src/hooks/useDebouncedValue.ts      |  55 +++++++++++++-
 4 files changed, 326 insertions(+), 12 deletions(-)
```

## Acceptance-criteria checklist (per the issue template)

- [x] The change matches the summary in both issues.
- [x] No regression in the existing test suite (16 pre-existing `useDebouncedValue` tests + 8 `useOnceMounted` tests all pass unchanged).
- [x] The change is documented where observable — `docs/HOOKS.md` gets new entries; TSDoc on `useDebouncedValue` is expanded; `CHANGELOG.md` is updated.
- [x] Lint passes; the affected unit tests pass; `tsc` reports only pre-existing unrelated errors in untouched files.
- [x] PR description references both issues with `Closes #652` and `Closes #656`.

## Out of scope (per the issues' explicit guidance)

- Unrelated refactors in adjacent files (the pre-existing tsc errors in `src/pages/Attestations.tsx` and `src/pages/TrustScore.tsx` are left for a separate fix).
- Migrating the existing `vi.mock('@/hooks/useDebouncedValue')` shim in `src/components/AddressInput.test.tsx` to the new options-injection pattern — that is a worthwhile follow-up but expanding scope here would inflate the diff and risk unrelated regressions.
- Stylistic-only changes.

## Review notes

- The `setTimeoutImplRef.current = setTimeoutImpl` assignment happens during render, which is the canonical pattern when you need "latest value, no re-run" inside a `useEffect`. The same pattern is used by `useCopyToClipboard.ts` in this repo.
- The `safeClearTimeout` helper is intentionally a free function (not a hook) so it can be tested as a pure function and reused by future timer-based hooks.
- The new tests under `useDebouncedValue — options injection` are deterministic and do not require `vi.useFakeTimers` for the behaviour assertion; they capture the scheduled callback via the injected mock and invoke it explicitly, which is the only reliable way to assert "the injected `setTimeoutImpl` actually fires" (since `vi.advanceTimersByTime` only fires timers that vitest itself scheduled, not those registered with a mock impl).
