### PR TITLE
ci: add check for accidental console.log in production bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@
 #   2. npm run lint          — ESLint
 #   3. npm run build         — TypeScript compile + Vite production build
 #   4. npm run test          — Vitest unit / component tests
+#   5. node scripts/check-console-log.mjs — Production-bundle console.log check
 
 name: CI
 
@@ -51,3 +52,7 @@ jobs:
       # ── 4. Tests ─────────────────────────────────────────────────────────────
       - name: Run tests (Vitest)
         run: npm run test
+
+      # ── 5. Console-log check ─────────────────────────────────────────────────
+      - name: Check for console.log in production bundle
+        run: node scripts/check-console-log.mjs

--- a/scripts/check-console-log.mjs
+++ b/scripts/check-console-log.mjs
@@ -1,0 +1,76 @@
+/**
+ * Checks the production build output for accidental console.log calls.
+ *
+ * Searches all JavaScript bundles in dist/ for console.log references
+ * and exits with a non-zero code if any are found.
+ *
+ * Usage: node scripts/check-console-log.mjs [build-dir]
+ * Default build-dir: dist
+ */
+
+import { readFileSync, readdirSync, statSync, existsSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+const buildDir = resolve(process.argv[2] ?? "dist");
+
+if (!existsSync(buildDir)) {
+  console.error(`❌ Build directory not found: ${buildDir}`);
+  console.error("   Run 'npm run build' first, then this check.");
+  process.exit(1);
+}
+
+/**
+ * Recursively collect all .js files in a directory.
+ */
+function collectJSFiles(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectJSFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith(".js")) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+const jsFiles = collectJSFiles(buildDir);
+let foundIssues = false;
+
+for (const file of jsFiles) {
+  // Skip source maps
+  if (file.endsWith(".map")) continue;
+
+  const content = readFileSync(file, "utf-8");
+
+  // Match console.log, console.warn, console.error, console.info, console.debug calls
+  // that are NOT part of a comment or string that contains the word "console"
+  // We use a simple regex approach: look for `console.<method>(` patterns
+  const matches = content.matchAll(
+    /(?<![\"'`]\s*)(?<!\/\/\s*)(?<!\*\s*)console\.(log|warn|error|info|debug)\s*\(/g,
+  );
+
+  const fileMatches = [];
+  for (const match of matches) {
+    fileMatches.push(match[0]);
+  }
+
+  if (fileMatches.length > 0) {
+    console.error(`⚠️  ${file.replace(buildDir, buildDir)}`);
+    for (const m of fileMatches) {
+      console.error(`   Found: ${m}`);
+    }
+    foundIssues = true;
+  }
+}
+
+if (foundIssues) {
+  console.error(
+    "\n❌ console.log (or console.warn/error/info/debug) calls found in production bundle.",
+  );
+  console.error("   Remove them before shipping to production.");
+  process.exit(1);
+} else {
+  console.log("✅ No console.log calls found in production bundle.");
+}


### PR DESCRIPTION
## Summary

Adds a CI check that prevents accidental `console.log` (and related methods) from being shipped in production bundles, as specified in #966.

## Changes

- **New script: `scripts/check-console-log.mjs`**
  - Recursively scans all `.js` files in the production build output (`dist/`)
  - Detects `console.log`, `console.warn`, `console.error`, `console.info`, and `console.debug` calls
  - Exits with a non-zero code if any matches are found, blocking the CI pipeline
  - Provides clear file paths and the matched pattern for each finding
  - Gracefully handles missing build directory with a helpful error message

- **Updated CI workflow: `.github/workflows/ci.yml`**
  - Added quality gate #5: `Check for console.log in production bundle`
  - Runs after the build step, ensuring the check operates on the actual built output
  - Updated header comment to document the new gate

## Acceptance criteria

- [x] The change matches the summary above
- [x] Lint, type-check, and tests pass locally

## How to test locally

```bash
npm run build
node scripts/check-console-log.mjs
```

Closes #966
