### PR TITLE
feat(uiux): clarify placeholder footer and disclaimer link states

### DIFF
--- a/src/components/Disclaimer.tsx
+++ b/src/components/Disclaimer.tsx
@@ -46,7 +46,7 @@ export default function Disclaimer({
           <>
             {' '}
             {/* optional learn more link */}{' '}
-            {learnMoreHref === '#' || !learnMoreHref ? (
+            {learnMoreHref === '#' ? (
               <span
                 aria-disabled="true"
                 className="disclaimer-terms-disabled"

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -9,16 +9,12 @@ import WalletConnect from './WalletConnect'
 import MobileNav from './navigation/MobileNav'
 import BottomNav from './navigation/BottomNav'
 import RouteAnnouncer from './RouteAnnouncer'
-import ThemeToggle from './ThemeToggle'
-import NetworkIndicator from './NetworkIndicator'
 import Banner from './Banner'
 import KeyboardShortcutsDialog from './KeyboardShortcutsDialog'
 import ActionLauncher from './ActionLauncher'
 import WhatsNewDialog from './WhatsNewDialog'
 import BackToTop from './BackToTop'
-import Banner from './Banner'
 import LINKS from '../config/links'
-import { PRELOADS_BY_PATH } from '../config/routes'
 import { hasHandledInstallPrompt, markInstallPromptHandled } from '../config/installPrompt'
 import { isExternalUrl } from '../lib/isExternalUrl'
 import { useKeyboardShortcut } from '../hooks/useKeyboardShortcut'
@@ -26,7 +22,22 @@ import { DOM_EVENTS } from '../events'
 import './Layout.css'
 
 function FooterLink({ label, href }: { label: string; href: string }) {
+  const isPlaceholder = !href || href === '#'
   const isExternal = isExternalUrl(href)
+
+  if (isPlaceholder) {
+    return (
+      <span
+        className="footer-link footer-link--disabled"
+        aria-disabled="true"
+        title="Coming soon"
+        tabIndex={-1}
+      >
+        {label}
+      </span>
+    )
+  }
+
   return (
     <a
       href={href}
@@ -43,7 +54,6 @@ export default function Layout() {
   const [shortcutsOpen, setShortcutsOpen] = useState(false)
   const [launcherOpen, setLauncherOpen] = useState(false)
   const [whatsNewOpen, setWhatsNewOpen] = useState(false)
-  const [launcherOpen, setLauncherOpen] = useState(false)
   const [showInstallPrompt, setShowInstallPrompt] = useState(false)
   const [installPromptDismissed, setInstallPromptDismissed] = useState(hasHandledInstallPrompt())
   // Refs so focus returns to the triggering button after each dialog closes
@@ -61,10 +71,8 @@ export default function Layout() {
 
   const openShortcuts = useCallback(() => setShortcutsOpen(true), [])
   const closeShortcuts = useCallback(() => setShortcutsOpen(false), [])
-  const openShortcuts = useCallback(() => setShortcutsOpen(true), [])
   const closeLauncher = useCallback(() => setLauncherOpen(false), [])
   const closeWhatsNew = useCallback(() => setWhatsNewOpen(false), [])
-  const closeLauncher = useCallback(() => setLauncherOpen(false), [])
 
   const dismissInstallPrompt = useCallback(() => {
     markInstallPromptHandled()

--- a/src/config/links.ts
+++ b/src/config/links.ts
@@ -4,9 +4,9 @@
 // - VITE_TERMS_URL
 // - VITE_PRIVACY_URL
 const defaults = {
-  docs: '/docs',
-  terms: '/legal/terms',
-  privacy: '/legal/privacy',
+  docs: '#',
+  terms: '#',
+  privacy: '#',
 } as const
 
 const envDocs =


### PR DESCRIPTION
## Overview

This PR replaces the dead `href="#"` placeholder links in the footer (`Documentation`, `Terms of Service`, `Privacy Policy`) and the disclaimer (`Full terms & conditions`) with clearly non-actionable disabled elements. The links were using route paths (`/docs`, `/legal/terms`, `/legal/privacy`) that don't exist in the app router and would 404. They are now rendered as `<span>` elements with `aria-disabled="true"`, `tabIndex={-1}`, and muted styling so users and screen readers understand they are "Coming soon" rather than interactable.

Also fixes pre-existing build-blocking bugs in `Layout.tsx` (duplicate imports and variable declarations).

## Related Issue

Closes #850

## Changes

### 🔗 Footer Link Treatment

* **[MODIFY]** `src/config/links.ts` — Changed default route paths (`/docs`, `/legal/terms`, `/legal/privacy`) to `#` to explicitly mark them as placeholders. Real URLs can be injected at build time via `VITE_DOCS_URL`, `VITE_TERMS_URL`, `VITE_PRIVACY_URL` env vars.

* **[MODIFY]** `src/components/Layout.tsx` — Updated `FooterLink` component to detect placeholder links (`#`) and render a `<span>` instead of an `<a>` tag with:
  - `aria-disabled="true"` — accessible disabled state
  - `tabIndex={-1}` — removed from tab order
  - `title="Coming soon"` — visual tooltip explanation
  - `className="footer-link footer-link--disabled"` — applies existing muted CSS (`opacity: 0.65`, `cursor: not-allowed`, no underline)

### ⚠️ Disclaimer Link Treatment

* **[MODIFY]** `src/components/Disclaimer.tsx` — Removed redundant `!learnMoreHref` guard inside `learnMoreHref === '#'` check (the outer `learnMoreHref &&` already guarantees truthiness).

### 🐛 Pre-existing Build Fixes

* **[FIX]** `src/components/Layout.tsx` — Removed duplicate `ThemeToggle` and `NetworkIndicator` imports, duplicate `PRELOADS_BY_PATH` import, duplicate `Banner` import, duplicate `launcherOpen`/`setLauncherOpen` state declarations, and duplicate `openShortcuts`/`closeLauncher` callback declarations.

## Verification Results

```
npm run build — blocked by pre-existing errors in upstream/main:
  - src/pages/TrustScore.tsx — missing closing JSX tags
  - src/pages/Attestations.tsx — missing closing JSX tags  
  - src/pages/Bond.tsx — await outside async function
(All are pre-existing in upstream/main and unrelated to this PR)
```

| Acceptance Criteria | Status |
| --- | --- |
| Placeholder links do not jump to top | Rendered as `<span>` not `<a>` |
| No misleading affordance | `aria-disabled="true"` + `cursor: not-allowed` |
| Removed from tab order | `tabIndex={-1}` |
| Tooltip explains state | `title="Coming soon"` |
| Consistent treatment between footer & disclaimer | Both use same pattern |
| CSS already had disabled link styles | `.footer-link--disabled` and `.disclaimer [aria-disabled='true']` |

## Timeline

- priscannanna85-lgtm committed