### PR TITLE
feat: expose the toast timeout as a config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,11 @@ VITE_PRIVACY=
 # defined in src/config/i18n.ts (currently: en). Invalid values fall
 # back to "en" and log a console error at startup.
 VITE_DEFAULT_LOCALE=en
+
+# Toast default timeout (milliseconds). Overrides the default dismiss delay
+# for info and success toasts. Must be a non-negative integer. Defaults to
+# 5000 (5s) when unset or invalid. Set to 0 to disable auto-dismiss for
+# info/success toasts. Warning toasts can be configured separately via
+# VITE_TOAST_TIMEOUT_WARNING (default: 8000).
+# Used by src/config/toast.ts.
+VITE_TOAST_TIMEOUT=5000

--- a/src/components/ToastProvider.tsx
+++ b/src/components/ToastProvider.tsx
@@ -2,17 +2,13 @@ import { createContext, useContext, useState, useCallback, useRef, type ReactNod
 import { useSettings } from '../context/SettingsContext'
 import { isWithinQuietHours, nowMinutesSinceMidnight } from '../lib/quietHours'
 import Toast, { type ToastData, type ToastSeverity, type ToastOptions } from './Toast'
+import { TOAST_CONFIG } from '../config/toast'
 import './Toast.css'
 
-const TIMEOUTS: Record<ToastSeverity, number> = {
-  info: 5000,
-  success: 5000,
-  warning: 8000,
-  danger: 0,
-}
+const TIMEOUTS: Record<ToastSeverity, number> = TOAST_CONFIG.timeouts
 
 // Maximum number of toasts displayed simultaneously
-const MAX_TOASTS = 3
+const MAX_TOASTS = TOAST_CONFIG.maxToasts
 
 interface ToastContextValue {
   addToast: (severity: ToastSeverity, message: string, options?: ToastOptions) => void

--- a/src/config/toast.test.ts
+++ b/src/config/toast.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+describe('TOAST_CONFIG', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllEnvs()
+  })
+
+  const setEnv = (key: string, value: string | undefined) => {
+    if (value === undefined) {
+      vi.stubEnv(key, undefined as unknown as string)
+    } else {
+      vi.stubEnv(key, value)
+    }
+  }
+
+  const getToastConfig = async () => {
+    return ((await vi.importActual('./toast')) as typeof import('./toast')).TOAST_CONFIG
+  }
+
+  it('should use default timeouts when no env vars are set', async () => {
+    const config = await getToastConfig()
+    expect(config.timeouts.info).toBe(5000)
+    expect(config.timeouts.success).toBe(5000)
+    expect(config.timeouts.warning).toBe(8000)
+    expect(config.timeouts.danger).toBe(0)
+  })
+
+  it('should use VITE_TOAST_TIMEOUT for info/success when set', async () => {
+    setEnv('VITE_TOAST_TIMEOUT', '10000')
+    const config = await getToastConfig()
+    expect(config.timeouts.info).toBe(10000)
+    expect(config.timeouts.success).toBe(10000)
+    expect(config.timeouts.warning).toBe(8000) // unaffected
+    expect(config.timeouts.danger).toBe(0) // unaffected
+  })
+
+  it('should use VITE_TOAST_TIMEOUT_WARNING for warning when set', async () => {
+    setEnv('VITE_TOAST_TIMEOUT_WARNING', '15000')
+    const config = await getToastConfig()
+    expect(config.timeouts.info).toBe(5000) // default
+    expect(config.timeouts.warning).toBe(15000)
+  })
+
+  it('should fall back to defaults when env var is empty string', async () => {
+    setEnv('VITE_TOAST_TIMEOUT', '')
+    const config = await getToastConfig()
+    expect(config.timeouts.info).toBe(5000)
+    expect(config.timeouts.success).toBe(5000)
+  })
+
+  it('should fall back to defaults when env var is whitespace', async () => {
+    setEnv('VITE_TOAST_TIMEOUT', '   ')
+    const config = await getToastConfig()
+    expect(config.timeouts.info).toBe(5000)
+  })
+
+  it('should fall back to defaults when env var is negative', async () => {
+    setEnv('VITE_TOAST_TIMEOUT', '-100')
+    const config = await getToastConfig()
+    expect(config.timeouts.info).toBe(5000)
+  })
+
+  it('should fall back to defaults when env var is NaN', async () => {
+    setEnv('VITE_TOAST_TIMEOUT', 'not-a-number')
+    const config = await getToastConfig()
+    expect(config.timeouts.info).toBe(5000)
+  })
+
+  it('should accept zero as a valid timeout (no auto-dismiss)', async () => {
+    setEnv('VITE_TOAST_TIMEOUT', '0')
+    const config = await getToastConfig()
+    expect(config.timeouts.info).toBe(0)
+    expect(config.timeouts.success).toBe(0)
+  })
+
+  it('should export maxToasts constant', async () => {
+    const config = await getToastConfig()
+    expect(config.maxToasts).toBe(3)
+  })
+})

--- a/src/config/toast.ts
+++ b/src/config/toast.ts
@@ -1,0 +1,34 @@
+// Default toast timeout values (in milliseconds).
+// Can be overridden at build/runtime via Vite env vars:
+// - VITE_TOAST_TIMEOUT       Overrides the default timeout for info/success toasts
+// - VITE_TOAST_TIMEOUT_WARNING  Overrides the warning toast timeout
+const DEFAULT_TIMEOUTS = {
+  info: 5000,
+  success: 5000,
+  warning: 8000,
+  danger: 0,
+} as const
+
+function parseEnvTimeout(raw: string | undefined): number | null {
+  if (!raw) return null
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  const parsed = Number(trimmed)
+  return Number.isFinite(parsed) && parsed >= 0 ? Math.round(parsed) : null
+}
+
+export const TOAST_CONFIG = {
+  /** Timeout per severity (milliseconds). 0 = no auto-dismiss. */
+  timeouts: {
+    info: parseEnvTimeout(import.meta.env.VITE_TOAST_TIMEOUT) ?? DEFAULT_TIMEOUTS.info,
+    success: parseEnvTimeout(import.meta.env.VITE_TOAST_TIMEOUT) ?? DEFAULT_TIMEOUTS.success,
+    warning: parseEnvTimeout(import.meta.env.VITE_TOAST_TIMEOUT_WARNING) ?? DEFAULT_TIMEOUTS.warning,
+    danger: DEFAULT_TIMEOUTS.danger,
+  },
+  /** Maximum number of toasts displayed simultaneously. */
+  maxToasts: 3,
+} as const
+
+export type ToastConfig = typeof TOAST_CONFIG
+
+export default TOAST_CONFIG


### PR DESCRIPTION
Closes #989

Exposes the default toast timeout as a configurable environment variable, following the project's existing pattern (cf. `src/config/sentry.ts`).

### Changes
- **`src/config/toast.ts`** (new): Centralized config module for toast defaults. Reads `VITE_TOAST_TIMEOUT` (info/success) and `VITE_TOAST_TIMEOUT_WARNING` (warning) from Vite env vars, falling back to the original hardcoded values (5000/8000ms).
- **`src/config/toast.test.ts`** (new): 9 tests covering env override, fallback, zero, negative, NaN, and whitespace cases.
- **`src/components/ToastProvider.tsx`**: Replaced inline `TIMEOUTS` and `MAX_TOASTS` constants with imports from `src/config/toast.ts`.
- **`.env.example`**: Documented `VITE_TOAST_TIMEOUT` with usage notes.

### Testing
- ✅ 9 new config tests pass
- ✅ All 13 existing ToastProvider tests pass
- ✅ No type-check regressions