### PR TITLE
feat: cap evidence message field at 2,000 characters

### DIFF
--- a/src/components/AttestationForm.test.tsx
+++ b/src/components/AttestationForm.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, within, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
 import AttestationForm from './AttestationForm'
@@ -88,10 +88,26 @@ describe('AttestationForm', () => {
       const evidenceTextarea = screen.getByRole('textbox', { name: /evidence/i })
       const countEl = document.querySelector('[aria-live="polite"]')
 
-      expect(countEl?.textContent?.trim()).toBe('0 / 28 bytes')
+      expect(countEl?.textContent?.trim()).toBe('0 / 2,000 chars')
 
       await user.type(evidenceTextarea, 'hello')
-      expect(countEl?.textContent?.trim()).toBe('5 / 28 bytes')
+      expect(countEl?.textContent?.trim()).toBe('5 / 2,000 chars')
+    })
+
+    it('rejects evidence exceeding 2,000 characters', async () => {
+      const user = userEvent.setup()
+      renderForm()
+
+      const addressInput = screen.getByRole('textbox', { name: /subject address/i })
+      const evidenceTextarea = screen.getByRole('textbox', { name: /evidence/i })
+      const submitButton = screen.getByRole('button', { name: /submit attestation/i })
+
+      await user.type(addressInput, VALID_KEY)
+      // Use fireEvent for the long string to avoid userEvent timeout
+      fireEvent.change(evidenceTextarea, { target: { value: 'A'.repeat(2001) } })
+      await user.click(submitButton)
+
+      expect(screen.getByText(/Evidence cannot exceed 2,000 characters/)).toBeInTheDocument()
     })
   })
 

--- a/src/components/AttestationForm.tsx
+++ b/src/components/AttestationForm.tsx
@@ -28,7 +28,7 @@ export interface AttestationFormProps {
  * AttestationForm handles the input and validation for submitting attestations.
  * Validation Contract:
  * - A valid Stellar subject public key address is required.
- * - Evidence text is required and cannot exceed 500 characters.
+ * - Evidence text is required and cannot exceed 2,000 characters.
  * - Confirms the submission using a customized ConfirmDialog.
  */
 export default function AttestationForm({
@@ -74,8 +74,8 @@ export default function AttestationForm({
 
     if (!evidence.trim()) {
       newErrors.evidence = 'Evidence is required.'
-    } else if (new TextEncoder().encode(evidence).length > 28) {
-      newErrors.evidence = 'Evidence cannot exceed 28 bytes.'
+    } else if (evidence.length > 2000) {
+      newErrors.evidence = 'Evidence cannot exceed 2,000 characters.'
     }
 
     setErrors(newErrors)
@@ -142,7 +142,7 @@ export default function AttestationForm({
           <FormField
             id="evidence-input"
             label="Evidence"
-            hint="Add supporting proof or description (max 28 bytes)"
+            hint="Add supporting proof or description (max 2,000 chars)"
             error={errors.evidence}
             required
           >
@@ -163,7 +163,7 @@ export default function AttestationForm({
             }}
             aria-live="polite"
           >
-            {new TextEncoder().encode(evidence).length} / 28 bytes
+            {evidence.length} / 2,000 chars
           </div>
         </div>
 


### PR DESCRIPTION
Changes the evidence textarea limit from 28 bytes to 2,000 characters.

- Updated hint text from "max 28 bytes" to "max 2,000 chars"
- Changed character counter from bytes to character count
- Updated validation error message to reference 2,000 characters
- Updated JSDoc to reflect the new limit
- Added test for the 2,000-character rejection path

Closes #986