### PR TITLE
fix: harden wipe form state on logout (Closes #987)

### DIFF
--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -5,6 +5,7 @@ import { useWallet as useWalletState, type UseWalletState } from '../hooks/useWa
 import { useIdleTimeout } from '../hooks/useIdleTimeout'
 import { useToast } from '../components/ToastProvider'
 import SessionTimeoutDialog from '../components/SessionTimeoutDialog'
+import { clearAppLocalStorage } from '../lib/clearAppLocalStorage'
 
 export type WalletContextValue = UseWalletState & {
   connected: boolean
@@ -61,6 +62,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
   }, [wallet.isConnected, lastReauthTime])
 
   const handleLogout = useCallback(() => {
+    clearAppLocalStorage()
     wallet.disconnect()
     setShowWarning(false)
     setLastReauthTime(null)


### PR DESCRIPTION
## Summary

Call `clearAppLocalStorage()` when the user logs out to ensure any form state, recent lookups, onboarding progress, and other ephemeral data is wiped from `localStorage`.

## Background

The existing `clearAppLocalStorage()` utility was already defined in `src/lib/clearAppLocalStorage.ts` and tested, but it was never wired into the logout flow. This means that when a user disconnects their wallet, sensitive cached data (recent address lookups, onboarding progress, pinned widgets, etc.) remains in `localStorage`.

## Changes

- **src/context/WalletContext.tsx**: Import `clearAppLocalStorage` and call it in `handleLogout` before `wallet.disconnect()`

## Testing

- `src/lib/clearAppLocalStorage.test.ts` — 3 tests pass (existing tests for the utility)
- `src/context/WalletContext.test.tsx` — 1 test passes (existing test for WalletProvider)

Closes #987