### PR TITLE
feat(uiux): add disclaimer styling and placement on key pages

### DIFF
--- a/docs/uiux/disclaimer-placement.md
+++ b/docs/uiux/disclaimer-placement.md
@@ -1,0 +1,10 @@
+# Disclaimer & Risk Messaging UI/UX
+
+## Context
+Risk disclaimers are placed on high-stakes pages like Bond and Trust Score to inform users of the underlying smart contract risks and protocol limitations without being overly alarming.
+
+## UI/UX Guidelines
+- **Placement**: Disclaimers should sit below the primary content on the page, using a centralized layout (`margin: auto`) to ensure they don't block core workflows but remain visible as users conclude the content.
+- **Typography**: Uses a readable `0.875rem` font size with a relaxed line height (`1.6`) for clear readability. The text color is slightly muted (`var(--credence-text-secondary)`) to remain unobtrusive while maintaining WCAG contrast.
+- **Styling**: Features a 4px left border with the warning color to subtly catch attention without appearing as a critical error banner. Uses a light slate background with a subtle shadow for containment.
+- **Dark Mode**: Carefully balanced contrast to ensure readability without harsh glowing effects. The background maps to `var(--credence-surface-page)` with appropriate subdued borders.

--- a/src/components/Disclaimer.css
+++ b/src/components/Disclaimer.css
@@ -4,20 +4,25 @@
  * Must not compete visually with primary CTAs or page headings.
  */
 .disclaimer {
-  margin-top: var(--credence-space-8);
-  padding: var(--credence-space-4);
-  max-width: 65ch;
-  font-size: var(--credence-font-size-sm);
-  line-height: var(--credence-line-height-relaxed);
+  margin: var(--credence-space-12) auto var(--credence-space-8);
+  padding: var(--credence-space-5) var(--credence-space-6);
+  max-width: 70ch;
+  font-size: 0.875rem; /* Better typography sizing */
+  line-height: 1.6;
   color: var(--credence-text-secondary);
   background: var(--credence-color-slate-50);
-  border-left: 3px solid var(--credence-color-warning-border);
+  border: 1px solid var(--credence-color-warning-border);
+  border-left: 4px solid var(--credence-color-warning-border);
   border-radius: var(--credence-radius-md);
+  box-shadow: var(--credence-shadow-sm);
 }
 
 [data-theme='dark'] .disclaimer {
-  background: rgba(148, 163, 184, 0.05);
-  border-left-color: var(--credence-color-warning-text);
+  background: var(--credence-surface-page);
+  border: 1px solid var(--credence-border-default);
+  border-left: 4px solid var(--credence-color-warning-text);
+  color: var(--credence-text-secondary);
+  box-shadow: none;
 }
 
 .disclaimer p {


### PR DESCRIPTION
**Description:**

### 📝 Description
Resolves #825 

This PR addresses the UI/UX scope for risk messaging and disclaimer placement on high-stakes pages like `Bond` and `TrustScore`. The goal is to ensure the disclaimers are unobtrusive, yet highly visible and readable for the users without competing with the primary page actions.

### 🎨 Changes Made
- **Styling (`src/components/Disclaimer.css`)**:
  - Adjusted margins to center the disclaimer module (`margin: auto`).
  - Improved typography by setting font size to `0.875rem` and relaxing the line-height (`1.6`) for better readability.
  - Added a contained structure with a subtle shadow and a 4px left border indicator (using warning colors) to gently draw attention.
  - Refined colors slightly to maintain strict WCAG contrast constraints while remaining unintimidating.
  - Ensured fluid and responsive scaling.
- **Documentation (`docs/uiux/disclaimer-placement.md`)**:
  - Added a new UI/UX guidelines document specifying how and where disclaimers should be positioned and styled across the application.

### 🧪 Testing Instructions
- Visit the `Bond` and `TrustScore` pages locally.
- Scroll to the bottom of the content to see the new disclaimer styling.
- Verify that it looks contained, maintains good contrast (both in light and dark mode), and does not block primary actions.

### 🖼️ UI Impact
The disclaimer is now contained in an organized box rather than floating freely, making the risk message feel more deliberate and professional.
