### PR TITLE
Test wallet-connect flow when Freighter is unavailable

### DIFF
--- a/src/components/ConnectWalletDialog.test.tsx
+++ b/src/components/ConnectWalletDialog.test.tsx
@@ -116,6 +116,10 @@ describe('ConnectWalletDialog — error display', () => {
     mockError = { code: 'not_installed', message: 'Not installed' }
     renderModal()
     expect(screen.getByRole('alert')).toHaveTextContent(/Freighter is not installed/i)
+    expect(screen.getByRole('link', { name: /install freighter/i })).toHaveAttribute(
+      'href',
+      'https://www.freighter.app/'
+    )
   })
 
   it('renders a rejected error message', () => {

--- a/src/components/ConnectWalletDialog.tsx
+++ b/src/components/ConnectWalletDialog.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { useFocusTrap } from '../hooks/useFocusTrap'
 import { useScrollPreserver } from '../hooks/useScrollPreserver'
 import { useWallet } from '../context/WalletContext'
+import { FREIGHTER_INSTALL_URL } from '../lib/freighterClient'
 import Button from './Button'
 import './ConnectWalletDialog.css'
 
@@ -105,7 +106,17 @@ export default function ConnectWalletDialog({
 
           {errorMessage && (
             <div role="alert" className="connect-wallet-dialog__error">
-              {errorMessage}
+              <span>{errorMessage}</span>
+              {error?.code === 'not_installed' && (
+                <a
+                  href={FREIGHTER_INSTALL_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="connect-wallet-dialog__install-link"
+                >
+                  Install Freighter
+                </a>
+              )}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Add an accessible Freighter install link to the wallet-connect dialog when the extension is unavailable.
- Assert the missing-extension flow exposes the correct install destination.

## Verification
- `npm test -- --run src/components/ConnectWalletDialog.test.tsx` — 24 passed.
- Full `npm run lint -- --quiet` remains blocked by 24 pre-existing repository errors, including the existing `src/pages/Attestations.tsx` JSX parse error.

Closes #959