### PR TITLE
Refactor forms to share one error component

### DIFF
--- a/src/components/AddressInput.css
+++ b/src/components/AddressInput.css
@@ -320,9 +320,7 @@
   text-align: right;
 }
 
-/**
- * Form field wrapper styles (if not already defined)
- */
+/** Form field wrapper styles. */
 .form-field {
   display: flex;
   flex-direction: column;
@@ -339,15 +337,6 @@
   font-size: var(--credence-font-size-sm);
   color: var(--credence-text-secondary);
   margin-top: -var(--credence-space-1);
-}
-
-.form-error {
-  font-size: var(--credence-font-size-sm);
-  color: var(--credence-color-danger-text);
-  margin-top: -var(--credence-space-1);
-  display: flex;
-  align-items: flex-start;
-  gap: var(--credence-space-1);
 }
 
 /**

--- a/src/components/forms/FormError.css
+++ b/src/components/forms/FormError.css
@@ -1,0 +1,7 @@
+.form-error {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--credence-space-2);
+  color: var(--credence-color-danger-text);
+  font-size: var(--credence-font-size-sm);
+}

--- a/src/components/forms/FormError.test.tsx
+++ b/src/components/forms/FormError.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { FormError } from './FormError'
+
+describe('FormError', () => {
+  it('renders one shared alert shape for form validation messages', () => {
+    render(<FormError id="address-error">Address is invalid</FormError>)
+
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveAttribute('id', 'address-error')
+    expect(alert).toHaveTextContent('⚠ Address is invalid')
+  })
+})

--- a/src/components/forms/FormError.tsx
+++ b/src/components/forms/FormError.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react'
+import './FormError.css'
+
+interface FormErrorProps {
+  id: string
+  children: ReactNode
+}
+
+/** Shared accessible error message used by every form field primitive. */
+export function FormError({ id, children }: FormErrorProps) {
+  return (
+    <span id={id} className="form-error" role="alert">
+      ⚠ {children}
+    </span>
+  )
+}

--- a/src/components/forms/FormField.css
+++ b/src/components/forms/FormField.css
@@ -18,14 +18,6 @@
   font-size: var(--credence-font-size-sm);
 }
 
-.form-error {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--credence-space-2);
-  color: var(--credence-color-danger-text);
-  font-size: var(--credence-font-size-sm);
-}
-
 .form-success {
   display: inline-flex;
   align-items: center;

--- a/src/components/forms/FormField.tsx
+++ b/src/components/forms/FormField.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { FormError } from './FormError'
 import './FormField.css'
 
 export type FormFieldState = 'default' | 'error' | 'success'
@@ -68,11 +69,7 @@ export function FormField({
         'aria-required': required ? 'true' : children.props['aria-required'],
       })}
 
-      {error && (
-        <span id={errorId} className="form-error" role="alert">
-          ⚠ {error}
-        </span>
-      )}
+      {error && <FormError id={errorId}>{error}</FormError>}
 
       {successMessage && (
         <span id={successId} className="form-success" role="status">

--- a/src/components/forms/index.ts
+++ b/src/components/forms/index.ts
@@ -1,5 +1,6 @@
 export { FormField } from './FormField'
 export type { FormFieldState } from './FormField'
+export { FormError } from './FormError'
 export { Input } from './Input'
 export type { InputProps } from './Input'
 export { Textarea } from './Textarea'


### PR DESCRIPTION
## Summary
- Add a shared `FormError` primitive for the accessible alert markup and design tokens.
- Use it from `FormField` and remove the duplicate `.form-error` CSS from `AddressInput`.
- Add focused component coverage while preserving the existing FormField contract.

## Verification
- `npm test -- --run src/components/forms/FormError.test.tsx src/components/forms/FormField.test.tsx` — 17 passed.
- Targeted ESLint checks pass.

Closes #961