### PR TITLE
Harden query cache against PII retention

### DIFF
--- a/src/hooks/useApiQuery.test.ts
+++ b/src/hooks/useApiQuery.test.ts
@@ -59,6 +59,38 @@ describe('useApiQuery', () => {
     expect(result.current.isStale).toBe(false)
   })
 
+  it('scrubs PII before exposing and caching a query response', async () => {
+    apiFetchMock.mockResolvedValueOnce({
+      score: 720,
+      tier: 'gold',
+      email: 'holder@example.com',
+      profile: { fullName: 'Wallet Holder', score: 720 },
+    })
+
+    const { result, unmount } = renderHook(() =>
+      useApiQuery<MockData & { email: string; profile: { fullName: string; score: number } }>(
+        '/trust-score/GABC'
+      )
+    )
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    expect(result.current.data).toMatchObject({
+      score: 720,
+      email: '[REDACTED]',
+      profile: { fullName: '[REDACTED]', score: 720 },
+    })
+
+    unmount()
+    const { result: cachedResult } = renderHook(() =>
+      useApiQuery<MockData & { email: string; profile: { fullName: string; score: number } }>(
+        '/trust-score/GABC'
+      )
+    )
+    expect(cachedResult.current.data?.email).toBe('[REDACTED]')
+    expect(apiFetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('skips fetch when enabled=false', async () => {
     const { result } = renderHook(() =>
       useApiQuery<MockData>('/trust-score/GABC', { enabled: false })

--- a/src/hooks/useApiQuery.ts
+++ b/src/hooks/useApiQuery.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { apiFetch, ApiError } from '../api/client'
 import { WIDGET_CACHE_DEFAULTS } from '../config/widgetCache'
+import { scrubPII } from '../lib/piiScrub'
 
 // ── Cache ───────────────────────────────────────────────────────────────────
 
@@ -130,10 +131,14 @@ export function useApiQuery<T>(
         const result = await apiFetch<T>(currentPath, {
           signal: controller.signal,
         })
+        // Keep the cache as a safe boundary: callers receive the same
+        // sanitized value that is stored, so PII cannot leak through the
+        // query hook before it reaches the cache.
+        const sanitized = scrubPII(result)
 
         if (mountedRef.current && currentRunId === runIdRef.current) {
-          setData(result)
-          setCacheEntry(currentPath, result)
+          setData(sanitized)
+          setCacheEntry(currentPath, sanitized)
           setIsStale(false)
           setError(null)
         }


### PR DESCRIPTION
## Summary
Sanitize API query results before they are exposed by `useApiQuery` or stored in its in-memory cache. This reuses the existing deep scrubber, redacting known PII keys and email-shaped values at the single cache write boundary. Added coverage for top-level and nested sensitive fields and verified cached reads remain sanitized.

## Validation
The focused Vitest command was not run locally because dependencies are not installed in the checkout (`vitest: command not found`).

Closes #971