### PR TITLE
Use generated API types for transactions

### DIFF
--- a/src/hooks/useTransactions.ts
+++ b/src/hooks/useTransactions.ts
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { apiFetch, ApiError } from '../api/client'
-import type { Transaction, ApiListResponse } from '../api/types'
+import type { ApiResponse, operations, Transaction } from '../api/types'
 
 const PENDING_TXS_KEY = 'credence:pendingTransactions'
 const PAGE_SIZE = 20
+
+type TransactionsResponse = ApiResponse<operations['listTransactions']>
 
 function getPendingTransactions(): Transaction[] {
   try {
@@ -80,7 +82,7 @@ export function useTransactions(): UseTransactionsResult {
       params.set('cursor', cursor)
     }
 
-    const result = await apiFetch<ApiListResponse<Transaction>>(
+    const result = await apiFetch<TransactionsResponse>(
       `/transactions?${params.toString()}`,
       { signal }
     )


### PR DESCRIPTION
## Summary
Replace the hand-written `ApiListResponse<Transaction>` annotation in `useTransactions` with `ApiResponse<operations['listTransactions']>`, so the `/transactions` hook is checked against the OpenAPI-generated response contract while keeping the existing API client and pagination behavior unchanged.

## Validation
The focused typecheck was not run locally because dependencies are not installed in the checkout (`tsc: command not found`).

Closes #973