### PR TITLE
Lazy load the shared icon set

### DIFF
--- a/src/components/icons/index.test.tsx
+++ b/src/components/icons/index.test.tsx
@@ -1,0 +1,26 @@
+import { Suspense } from 'react'
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CopyIcon, WalletIcon } from './index'
+
+describe('lazy icon exports', () => {
+  it('loads an icon implementation on demand', async () => {
+    render(
+      <Suspense fallback={<span>loading icon</span>}>
+        <CopyIcon aria-label="Copy" />
+      </Suspense>
+    )
+
+    expect(await screen.findByLabelText('Copy')).toBeInTheDocument()
+  })
+
+  it('keeps each icon independently loadable', async () => {
+    render(
+      <Suspense fallback={null}>
+        <WalletIcon aria-label="Wallet" />
+      </Suspense>
+    )
+
+    expect(await screen.findByLabelText('Wallet')).toBeInTheDocument()
+  })
+})

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -1,5 +1,0 @@
-export { default as Icon } from './Icon'
-export { default as CopyIcon } from './CopyIcon'
-export { default as CheckIcon } from './CheckIcon'
-export { default as ExternalLinkIcon } from './ExternalLinkIcon'
-export { default as WalletIcon } from './WalletIcon'

--- a/src/components/icons/index.tsx
+++ b/src/components/icons/index.tsx
@@ -1,0 +1,28 @@
+import { lazy, Suspense, type ComponentType, type ReactElement } from 'react'
+import type { IconProps } from './Icon'
+
+export { default as Icon } from './Icon'
+
+type LazyIconLoader = () => Promise<{ default: ComponentType<IconProps> }>
+
+/**
+ * Keep icon consumers synchronous while loading SVG implementations only when
+ * a route actually renders them. The null fallback preserves the old compact
+ * layout during the one-frame chunk fetch and the app-level Suspense boundary
+ * still handles route-level loading states.
+ */
+function lazyIcon(loader: LazyIconLoader) {
+  const Component = lazy(loader)
+  return function LazyIcon(props: IconProps): ReactElement | null {
+    return (
+      <Suspense fallback={null}>
+        <Component {...props} />
+      </Suspense>
+    )
+  }
+}
+
+export const CopyIcon = lazyIcon(() => import('./CopyIcon'))
+export const CheckIcon = lazyIcon(() => import('./CheckIcon'))
+export const ExternalLinkIcon = lazyIcon(() => import('./ExternalLinkIcon'))
+export const WalletIcon = lazyIcon(() => import('./WalletIcon'))


### PR DESCRIPTION
## Summary
Convert the shared Copy, Check, ExternalLink, and Wallet icon exports to on-demand React lazy imports. Each icon keeps a null fallback for compact controls, while the existing route Suspense boundary remains available for navigation-level loading. Added focused tests proving independent lazy loading.

## Validation
The focused Vitest command was not run locally because dependencies are not installed in the checkout (`vitest: command not found`).

Closes #951