### PR TITLE
feat(uiux): fix contrast issues for interactive components

### DIFF
--- a/docs/interactive-contrast-audit.md
+++ b/docs/interactive-contrast-audit.md
@@ -1,0 +1,134 @@
+# Interactive States Contrast Audit
+
+Scope: text and non-text contrast for **interactive states** — links, all `Button`
+variants, primary-filled controls, and focus rings — in light and dark themes.
+
+Method:
+
+- Text target: WCAG 2.1 SC 1.4.3 Level AA, **4.5:1**. Every affected label is
+  below 18.66px bold / 24px regular, so the large-text 3:1 allowance never applies.
+- Non-text target: WCAG 2.1 SC 1.4.11, **3:1** for a control's visual boundary
+  and for focus indicators.
+- Dark-theme translucent fills were composited over `--credence-surface-page`
+  (`#0f172a`) before measuring.
+- An automated regression check in `src/components/interactiveContrast.test.ts`
+  resolves colours out of `src/index.css` and the component stylesheets, so a
+  token or declaration reverting to a failing value breaks the build. Shared
+  contrast helpers live in `src/test/contrast.ts`.
+
+## Failures found
+
+The initial sweep covered 57 state/theme combinations and found 8 genuine
+failures. Writing the regression test surfaced a ninth — the danger button's
+`:active` fill in dark mode (row 5) — which the sweep had not enumerated. The
+rows below are the full set; row 8 covers both themes.
+
+| #   | State                            | Theme |      Before | Cause                                                                                                                           |
+| --- | -------------------------------- | ----- | ----------: | ------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | Primary button label             | Dark  |    **1.67** | `color: var(--credence-color-white)` hard-coded while `--credence-color-primary` flips to a light tint (`#7dd3fc`) in dark mode |
+| 2   | Primary button label `:hover`    | Dark  |    **1.33** | same, over `--credence-color-primary-strong` (`#bae6fd`)                                                                        |
+| 3   | Danger button label `:hover`     | Light |    **3.76** | hover _lightened_ the fill to `--credence-color-danger-border` (`#ef4444`)                                                      |
+| 4   | Danger button label              | Dark  |    **3.76** | dark `--credence-color-danger-action` is `#ef4444`                                                                              |
+| 5   | Danger button label `:active`    | Dark  |    **1.90** | active fill reused `--credence-color-danger-text`, which the dark theme redefines to a light pink (`#fca5a5`)                   |
+| 6   | Secondary button border          | Light |    **1.23** | fill matches the card, so the border is the sole affordance, but it used the decorative `--credence-border-default` (`#e2e8f0`) |
+| 7   | Secondary button border          | Dark  |    **1.37** | `--credence-color-slate-600` on a `slate-700` fill                                                                              |
+| 8   | Secondary button border `:hover` | Both  | 2.34 / 1.59 | same class of problem in the hover state                                                                                        |
+
+Failures 1, 2 and 5 also reached the FAB, back-to-top button, toggle, segmented
+control, and active mobile-nav link, all of which paint the primary fill and
+hard-coded a white label.
+
+## Root cause
+
+Two token-misuse patterns, not eight unrelated bugs:
+
+1. **A fill token was paired with a fixed on-colour.** `--credence-color-primary`
+   is theme-dependent; `--credence-color-white` is not. Any pairing of the two
+   is a latent dark-mode failure.
+2. **Text tokens were used as fills.** `--credence-color-danger-text` and
+   `--credence-color-danger-action` are tuned to be read _as text on a page_, so
+   the dark theme lightens them. Reusing them as button backgrounds inverts the
+   requirement.
+
+## Adjusted tokens
+
+| Token                                       | Value                                              | Reason                                                                                                                                                                                    |
+| ------------------------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--credence-color-on-primary`               | `#ffffff` light, `--credence-color-slate-900` dark | Theme-aware label colour for anything on the primary fill. Replaces hard-coded white.                                                                                                     |
+| `--credence-color-danger-fill`              | `#dc2626`                                          | Destructive button background, split from `--credence-color-danger-action` (still used for penalty _text_ in `ConfirmDialog`, `BondDetail`, `Bond`) so the fill can darken independently. |
+| `--credence-color-danger-fill-hover`        | `#b91c1c`                                          | Hover darkens instead of lightening.                                                                                                                                                      |
+| `--credence-color-danger-fill-active`       | `#991b1b`                                          | Replaces the reuse of `--credence-color-danger-text`.                                                                                                                                     |
+| `--credence-color-border-interactive`       | `slate-500` light, `slate-400` dark                | 3:1 boundary for controls whose fill matches their surface. Distinct from the intentionally lighter decorative `--credence-border-default`.                                               |
+| `--credence-color-border-interactive-hover` | `slate-600` light, `slate-300` dark                | Same, for the hover fill.                                                                                                                                                                 |
+| `--credence-color-slate-300`                | `#cbd5e1`                                          | Added; the scale was missing this step.                                                                                                                                                   |
+
+The danger button's hover and active states pin `border-color` to
+`--credence-color-danger-border` (`#ef4444`). The fill darkens on interaction,
+which in dark mode would otherwise sink the button's edge below 3:1 against the
+page; the lighter border holds the boundary while the fill carries the state.
+
+## Results matrix
+
+All ratios are post-fix. Text rows target 4.5:1, non-text rows 3:1.
+
+| Element / state                                           | Theme | Ratio | Target | Result |
+| --------------------------------------------------------- | ----- | ----: | -----: | ------ |
+| Body link                                                 | Light |  7.23 |    4.5 | Pass   |
+| Body link                                                 | Dark  | 10.71 |    4.5 | Pass   |
+| Body link `:hover`                                        | Light |  9.04 |    4.5 | Pass   |
+| Body link `:hover`                                        | Dark  | 13.45 |    4.5 | Pass   |
+| Footer link                                               | Light |  4.76 |    4.5 | Pass   |
+| Footer link                                               | Dark  |  5.71 |    4.5 | Pass   |
+| Skip link                                                 | Light |  7.23 |    4.5 | Pass   |
+| Skip link                                                 | Dark  | 10.71 |    4.5 | Pass   |
+| Primary button label                                      | Light |  7.56 |    4.5 | Pass   |
+| Primary button label                                      | Dark  | 10.71 |    4.5 | Pass   |
+| Primary button label `:hover`                             | Light |  9.46 |    4.5 | Pass   |
+| Primary button label `:hover`                             | Dark  | 13.45 |    4.5 | Pass   |
+| Secondary button label                                    | Light | 17.85 |    4.5 | Pass   |
+| Secondary button label                                    | Dark  |  9.90 |    4.5 | Pass   |
+| Secondary button border                                   | Light |  4.76 |    3.0 | Pass   |
+| Secondary button border                                   | Dark  |  4.04 |    3.0 | Pass   |
+| Secondary button border `:hover`                          | Light |  6.92 |    3.0 | Pass   |
+| Secondary button border `:hover`                          | Dark  |  5.10 |    3.0 | Pass   |
+| Ghost button label                                        | Light |  7.23 |    4.5 | Pass   |
+| Ghost button label                                        | Dark  | 10.71 |    4.5 | Pass   |
+| Ghost button label `:hover`                               | Light |  8.69 |    4.5 | Pass   |
+| Link button label                                         | Light |  7.56 |    4.5 | Pass   |
+| Link button label                                         | Dark  |  8.77 |    4.5 | Pass   |
+| Danger button label                                       | Both  |  4.83 |    4.5 | Pass   |
+| Danger button label `:hover`                              | Both  |  6.47 |    4.5 | Pass   |
+| Danger button label `:active`                             | Both  |  8.31 |    4.5 | Pass   |
+| Danger button edge                                        | Light |  4.62 |    3.0 | Pass   |
+| Danger button edge                                        | Dark  |  3.70 |    3.0 | Pass   |
+| Danger edge `:hover` / `:active`                          | Dark  |  4.74 |    3.0 | Pass   |
+| Focus ring vs page                                        | Light |  7.23 |    3.0 | Pass   |
+| Focus ring vs page                                        | Dark  | 10.71 |    3.0 | Pass   |
+| Focus ring vs card                                        | Light |  7.56 |    3.0 | Pass   |
+| Focus ring vs card                                        | Dark  |  8.77 |    3.0 | Pass   |
+| Danger focus ring vs page                                 | Light |  3.60 |    3.0 | Pass   |
+| Danger focus ring vs page                                 | Dark  |  4.74 |    3.0 | Pass   |
+| FAB / back-to-top / toggle / segmented / nav-active label | Dark  | 10.71 |    4.5 | Pass   |
+
+## Deliberately unchanged
+
+**Disabled controls.** SC 1.4.3 and SC 1.4.11 both exempt inactive user
+interface components, and the disabled states measure 2.18–3.07:1 by design —
+the low contrast _is_ the affordance. Raising it would make disabled buttons
+read as enabled. Affected: `:disabled` on the primary, secondary, ghost and link
+button variants, plus `.footer-link[aria-disabled='true']`. The regression test
+omits them on purpose.
+
+Links and focus rings **already passed** in both themes before this change and
+were left alone; they are covered by the regression test so they stay that way.
+
+`--credence-color-danger-action` keeps its current values because it is a text
+colour for penalty amounts, not a fill. Its dark value (`#fca5a5`) is correct in
+that role.
+
+## Out of scope
+
+Static (non-interactive) text was not audited here. While tracing
+`--credence-color-danger-action` this audit noted that it renders at 3.89:1 as
+text on `--credence-surface-card` in dark mode, which is below AA. That belongs
+to a static-text audit, not this one, and is left for a follow-up.

--- a/src/components/BackToTop.css
+++ b/src/components/BackToTop.css
@@ -7,7 +7,7 @@
   gap: var(--credence-space-2);
   padding: var(--credence-space-3) var(--credence-space-4);
   background: var(--credence-color-primary);
-  color: var(--credence-color-white);
+  color: var(--credence-color-on-primary);
   border: none;
   border-radius: var(--credence-radius-full);
   font-family: var(--credence-font-family-base);

--- a/src/components/Button.css
+++ b/src/components/Button.css
@@ -98,7 +98,9 @@
 
 .credence-button--primary {
   background: var(--credence-color-primary);
-  color: var(--credence-color-white);
+  /* Flips with the theme — primary is a light tint in dark mode, where a white
+   * label would render at 1.67:1. */
+  color: var(--credence-color-on-primary);
   border-color: var(--credence-color-primary);
 }
 
@@ -113,29 +115,34 @@
 
 /* ─── Secondary variant — alternative actions ────────────────────────────── */
 
+/*
+ * The secondary button's fill matches the card it sits on, so its border is the
+ * only thing that identifies it as a control. That makes the border subject to
+ * the 3:1 non-text floor (SC 1.4.11) — --credence-border-default managed 1.23:1.
+ */
 .credence-button--secondary {
   background: var(--credence-surface-card);
   color: var(--credence-text-primary);
-  border-color: var(--credence-border-default);
+  border-color: var(--credence-color-border-interactive);
 }
 
 .credence-button--secondary:hover:not(:disabled) {
   background: var(--credence-color-slate-100);
-  border-color: var(--credence-color-slate-400);
+  border-color: var(--credence-color-border-interactive-hover);
 }
 
 .credence-button--secondary:active:not(:disabled) {
   background: var(--credence-color-slate-200);
 }
 
+/* Only the fill changes in dark mode; the border comes from
+ * --credence-color-border-interactive, which already flips lighter. */
 [data-theme='dark'] .credence-button--secondary {
   background: var(--credence-color-slate-700);
-  border-color: var(--credence-color-slate-600);
 }
 
 [data-theme='dark'] .credence-button--secondary:hover:not(:disabled) {
   background: var(--credence-color-slate-600);
-  border-color: var(--credence-color-slate-500);
 }
 
 /* ─── Ghost variant — subtle actions ─────────────────────────────────────── */
@@ -165,20 +172,29 @@
 
 /* ─── Danger variant — destructive confirmations ─────────────────────────── */
 
+/*
+ * Hover and active darken the fill rather than lightening it. The previous
+ * hover moved to --credence-color-danger-border (#ef4444), which dropped the
+ * white label to 3.76:1; in dark mode the base fill did the same.
+ *
+ * Because the fill darkens, the border is pinned to --credence-color-danger-
+ * border for hover/active so the button's outer edge keeps 3:1 against the page
+ * in dark mode, where a darkened red would otherwise sink into the background.
+ */
 .credence-button--danger {
-  background: var(--credence-color-danger-action);
+  background: var(--credence-color-danger-fill);
   color: var(--credence-color-white);
-  border-color: var(--credence-color-danger-action);
+  border-color: var(--credence-color-danger-fill);
 }
 
 .credence-button--danger:hover:not(:disabled) {
-  background: var(--credence-color-danger-border);
+  background: var(--credence-color-danger-fill-hover);
   border-color: var(--credence-color-danger-border);
 }
 
 .credence-button--danger:active:not(:disabled) {
-  background: var(--credence-color-danger-text);
-  border-color: var(--credence-color-danger-text);
+  background: var(--credence-color-danger-fill-active);
+  border-color: var(--credence-color-danger-border);
 }
 
 .credence-button--danger:disabled {

--- a/src/components/SpeedDial.css
+++ b/src/components/SpeedDial.css
@@ -28,7 +28,7 @@
   border-radius: var(--credence-radius-full);
   border: none;
   background: var(--credence-color-primary);
-  color: var(--credence-color-white);
+  color: var(--credence-color-on-primary);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -142,7 +142,7 @@
 
 .speedDial__action:hover {
   background: var(--credence-color-primary);
-  color: var(--credence-color-white);
+  color: var(--credence-color-on-primary);
   border-color: var(--credence-color-primary);
   transform: scale(1.08);
 }
@@ -174,7 +174,7 @@
 [data-theme='dark'] .speedDial__action:hover {
   background: var(--credence-color-primary);
   border-color: var(--credence-color-primary);
-  color: var(--credence-color-white);
+  color: var(--credence-color-on-primary);
 }
 
 [data-theme='dark'] .speedDial__label {

--- a/src/components/controls/controls.css
+++ b/src/components/controls/controls.css
@@ -102,7 +102,7 @@
 .control-toggle[aria-checked='true'] {
   background: var(--credence-color-primary);
   border-color: var(--credence-color-primary);
-  color: var(--credence-color-white);
+  color: var(--credence-color-on-primary);
 }
 
 .control-toggle:focus-visible {
@@ -176,7 +176,7 @@
 .control-segmented__option--selected {
   background: var(--credence-color-primary);
   border-color: var(--credence-color-primary);
-  color: var(--credence-color-white);
+  color: var(--credence-color-on-primary);
 }
 
 .control-segmented__option:hover:not(:disabled):not(.control-segmented__option--selected) {

--- a/src/components/interactiveContrast.test.ts
+++ b/src/components/interactiveContrast.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Contrast regression guard for interactive states — links, buttons, and focus
+ * rings — in both themes.
+ *
+ * Every case resolves colours out of the real stylesheets (`index.css` plus the
+ * relevant component CSS) rather than a copied colour table, so swapping a
+ * token or a `color:` declaration back to a failing value breaks a test here.
+ *
+ * Targets: 4.5:1 for text (SC 1.4.3), 3:1 for control boundaries and focus
+ * indicators (SC 1.4.11).
+ *
+ * Disabled controls are deliberately absent: SC 1.4.3 exempts "inactive user
+ * interface components", and raising their contrast would make them read as
+ * enabled. See docs/interactive-contrast-audit.md.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  NON_TEXT,
+  TEXT_AA,
+  getRuleDeclarations,
+  getThemeTokens,
+  ratio,
+  readCss,
+  resolveCssValue,
+} from '../test/contrast'
+
+const indexCss = readCss('src/index.css')
+const buttonCss = readCss('src/components/Button.css')
+
+const THEMES = [
+  { name: 'light', selector: undefined },
+  { name: 'dark', selector: "[data-theme='dark']" },
+] as const
+
+/** Token values as the browser would resolve them for a given theme. */
+function tokensFor(themeSelector?: string) {
+  const tokens = getThemeTokens(indexCss, themeSelector)
+  const token = (name: string) => resolveCssValue(`var(${name})`, tokens)
+
+  return {
+    token,
+    page: token('--credence-surface-page'),
+    card: token('--credence-surface-card'),
+    primary: token('--credence-color-primary'),
+    primaryStrong: token('--credence-color-primary-strong'),
+    onPrimary: token('--credence-color-on-primary'),
+    focusRing: token('--credence-color-focus-ring'),
+    textPrimary: token('--credence-text-primary'),
+    textSecondary: token('--credence-text-secondary'),
+    /** Resolve a declaration taken from a component rule. */
+    resolve: (value: string) => resolveCssValue(value, tokens),
+  }
+}
+
+/** Read one declaration out of a component rule and resolve it. */
+function declaration(css: string, selector: string, property: string, themeSelector?: string) {
+  const value = getRuleDeclarations(css, selector).get(property)
+
+  if (!value) {
+    throw new Error(`Expected ${selector} to declare ${property}`)
+  }
+
+  return tokensFor(themeSelector).resolve(value)
+}
+
+describe.each(THEMES)('interactive contrast — $name theme', ({ selector }) => {
+  const t = tokensFor(selector)
+
+  describe('links', () => {
+    it('body link meets AA on the page and on cards', () => {
+      const linkColor = declaration(indexCss, 'a', 'color', selector)
+
+      expect(ratio(linkColor, t.page)).toBeGreaterThanOrEqual(TEXT_AA)
+      expect(ratio(linkColor, t.card)).toBeGreaterThanOrEqual(TEXT_AA)
+    })
+
+    it('link hover meets AA', () => {
+      const hoverColor = declaration(indexCss, 'a:hover', 'color', selector)
+
+      expect(ratio(hoverColor, t.page)).toBeGreaterThanOrEqual(TEXT_AA)
+      expect(ratio(hoverColor, t.card)).toBeGreaterThanOrEqual(TEXT_AA)
+    })
+
+    it('footer link meets AA on the card surface it sits on', () => {
+      const footerColor = declaration(indexCss, '.footer-link', 'color', selector)
+
+      expect(ratio(footerColor, t.card)).toBeGreaterThanOrEqual(TEXT_AA)
+    })
+
+    it('skip link meets AA against its primary fill', () => {
+      const rule = getRuleDeclarations(indexCss, '.skip-link')
+
+      expect(
+        ratio(t.resolve(rule.get('color')!), t.resolve(rule.get('background')!))
+      ).toBeGreaterThanOrEqual(TEXT_AA)
+    })
+  })
+
+  describe('primary button', () => {
+    // Regression: --credence-color-primary flips to a light tint in dark mode.
+    // A hard-coded white label rendered at 1.67:1 there.
+    it('label meets AA on the base fill', () => {
+      const rule = getRuleDeclarations(buttonCss, '.credence-button--primary')
+
+      expect(
+        ratio(t.resolve(rule.get('color')!), t.resolve(rule.get('background')!))
+      ).toBeGreaterThanOrEqual(TEXT_AA)
+    })
+
+    it('label meets AA on the hover fill', () => {
+      const label = declaration(buttonCss, '.credence-button--primary', 'color', selector)
+
+      expect(ratio(label, t.primaryStrong)).toBeGreaterThanOrEqual(TEXT_AA)
+    })
+
+    it('fill is distinguishable from the page', () => {
+      expect(ratio(t.primary, t.page)).toBeGreaterThanOrEqual(NON_TEXT)
+    })
+  })
+
+  describe('secondary button', () => {
+    // The fill matches the surface behind it, so the border is the only thing
+    // identifying the control and must clear the non-text floor.
+    it('border is distinguishable from the surface', () => {
+      // Read the declaration, not the token, so pointing the button back at a
+      // decorative border colour fails here.
+      const border = declaration(buttonCss, '.credence-button--secondary', 'border-color', selector)
+      const fill = selector
+        ? declaration(
+            buttonCss,
+            "[data-theme='dark'] .credence-button--secondary",
+            'background',
+            selector
+          )
+        : declaration(buttonCss, '.credence-button--secondary', 'background', selector)
+
+      expect(ratio(border, fill)).toBeGreaterThanOrEqual(NON_TEXT)
+      expect(ratio(border, t.card)).toBeGreaterThanOrEqual(NON_TEXT)
+    })
+
+    it('hover border is distinguishable from the hover fill', () => {
+      const border = declaration(
+        buttonCss,
+        '.credence-button--secondary:hover:not(:disabled)',
+        'border-color',
+        selector
+      )
+      const hoverFill = selector
+        ? declaration(
+            buttonCss,
+            "[data-theme='dark'] .credence-button--secondary:hover:not(:disabled)",
+            'background',
+            selector
+          )
+        : declaration(
+            buttonCss,
+            '.credence-button--secondary:hover:not(:disabled)',
+            'background',
+            selector
+          )
+
+      expect(ratio(border, hoverFill)).toBeGreaterThanOrEqual(NON_TEXT)
+    })
+
+    it('label meets AA on the base fill', () => {
+      const fill = selector
+        ? declaration(
+            buttonCss,
+            "[data-theme='dark'] .credence-button--secondary",
+            'background',
+            selector
+          )
+        : declaration(buttonCss, '.credence-button--secondary', 'background', selector)
+
+      expect(ratio(t.textPrimary, fill)).toBeGreaterThanOrEqual(TEXT_AA)
+    })
+  })
+
+  describe('ghost and link buttons', () => {
+    it('ghost label meets AA over the page', () => {
+      const label = declaration(buttonCss, '.credence-button--ghost', 'color', selector)
+
+      expect(ratio(label, t.page)).toBeGreaterThanOrEqual(TEXT_AA)
+    })
+
+    it('link-variant label meets AA over cards', () => {
+      const label = declaration(buttonCss, '.credence-button--link', 'color', selector)
+
+      expect(ratio(label, t.card)).toBeGreaterThanOrEqual(TEXT_AA)
+    })
+  })
+
+  describe('danger button', () => {
+    // Regression: hover previously lightened the fill to #ef4444, dropping the
+    // white label to 3.76:1.
+    it('label meets AA on base, hover and active fills', () => {
+      const label = declaration(buttonCss, '.credence-button--danger', 'color', selector)
+
+      const fills = [
+        declaration(buttonCss, '.credence-button--danger', 'background', selector),
+        declaration(
+          buttonCss,
+          '.credence-button--danger:hover:not(:disabled)',
+          'background',
+          selector
+        ),
+        declaration(
+          buttonCss,
+          '.credence-button--danger:active:not(:disabled)',
+          'background',
+          selector
+        ),
+      ]
+
+      for (const fill of fills) {
+        expect(ratio(label, fill)).toBeGreaterThanOrEqual(TEXT_AA)
+      }
+    })
+
+    it('keeps a distinguishable edge against the page in every state', () => {
+      const borders = [
+        declaration(buttonCss, '.credence-button--danger', 'border-color', selector),
+        declaration(
+          buttonCss,
+          '.credence-button--danger:hover:not(:disabled)',
+          'border-color',
+          selector
+        ),
+        declaration(
+          buttonCss,
+          '.credence-button--danger:active:not(:disabled)',
+          'border-color',
+          selector
+        ),
+      ]
+
+      for (const border of borders) {
+        expect(ratio(border, t.page)).toBeGreaterThanOrEqual(NON_TEXT)
+      }
+    })
+  })
+
+  describe('focus indicators', () => {
+    it('focus ring is visible against the page and cards', () => {
+      expect(ratio(t.focusRing, t.page)).toBeGreaterThanOrEqual(NON_TEXT)
+      expect(ratio(t.focusRing, t.card)).toBeGreaterThanOrEqual(NON_TEXT)
+    })
+
+    it('danger focus ring is visible against the page', () => {
+      const ringColor = declaration(
+        buttonCss,
+        '.credence-button--danger:focus-visible',
+        'outline-color',
+        selector
+      )
+
+      expect(ratio(ringColor, t.page)).toBeGreaterThanOrEqual(NON_TEXT)
+    })
+  })
+})
+
+describe('primary-filled controls outside Button.css', () => {
+  // Every control that paints --credence-color-primary as its background must
+  // take its label from --credence-color-on-primary, otherwise it regresses to
+  // white-on-light-blue in dark mode.
+  const cases = [
+    ['src/components/SpeedDial.css', '.speedDial__fab'],
+    ['src/components/BackToTop.css', '.back-to-top'],
+    ['src/components/controls/controls.css', ".control-toggle[aria-checked='true']"],
+    ['src/components/controls/controls.css', '.control-segmented__option--selected'],
+    ['src/components/navigation/MobileNav.css', '.mobileNav-link--active'],
+  ] as const
+
+  it.each(cases)('%s %s pairs its primary fill with on-primary', (file, selector) => {
+    const rule = getRuleDeclarations(readCss(file), selector)
+
+    expect(rule.get('background')).toContain('--credence-color-primary')
+    expect(rule.get('color')).toContain('--credence-color-on-primary')
+  })
+
+  it.each(THEMES)('on-primary label meets AA in the $name theme', ({ selector }) => {
+    const t = tokensFor(selector)
+
+    expect(ratio(t.onPrimary, t.primary)).toBeGreaterThanOrEqual(TEXT_AA)
+    expect(ratio(t.onPrimary, t.primaryStrong)).toBeGreaterThanOrEqual(TEXT_AA)
+  })
+})

--- a/src/components/navigation/MobileNav.css
+++ b/src/components/navigation/MobileNav.css
@@ -127,14 +127,14 @@
 
 .mobileNav-link--active {
   background: var(--credence-color-primary);
-  color: var(--credence-color-white);
+  color: var(--credence-color-on-primary);
 }
 
 /* Keep the active indication visible when the active link is also hovered
    or focused — .mobileNav-link:hover otherwise wins on specificity and hides it. */
 .mobileNav-link--active:hover {
   background: var(--credence-color-primary);
-  color: var(--credence-color-white);
+  color: var(--credence-color-on-primary);
 }
 
 .mobileNav-link:focus-visible {

--- a/src/index.css
+++ b/src/index.css
@@ -95,6 +95,7 @@
   --credence-color-slate-50: #f8fafc;
   --credence-color-slate-100: #f1f5f9;
   --credence-color-slate-200: #e2e8f0;
+  --credence-color-slate-300: #cbd5e1;
   --credence-color-slate-400: #94a3b8;
   --credence-color-slate-500: #64748b;
   --credence-color-slate-600: #475569;
@@ -105,6 +106,36 @@
   --credence-color-primary: #075985;
   --credence-color-primary-strong: #0c4a6e;
   --credence-color-primary-soft: #0284c7;
+
+  /* Text/icon colour that sits on top of a primary fill.
+   *
+   * --credence-color-primary flips to a light tint in dark mode, so anything
+   * layered on it must flip too. Hard-coding white here is what put a white
+   * label on a light-blue button at 1.67:1. Consume this token instead of
+   * --credence-color-white whenever the background is the primary fill. */
+  --credence-color-on-primary: var(--credence-color-white);
+
+  /* Destructive button fill.
+   *
+   * Deliberately separate from --credence-color-danger-action, which is used as
+   * *text* for penalty amounts (ConfirmDialog, BondDetail, Bond). Splitting the
+   * two lets the fill darken far enough for a white label to clear 4.5:1
+   * without dragging that text darker at the same time. */
+  --credence-color-danger-fill: #dc2626;
+  --credence-color-danger-fill-hover: #b91c1c;
+  /* The active fill previously reused --credence-color-danger-text, which the
+   * dark theme redefines to a light pink (#fca5a5) — a white label on it landed
+   * at 1.9:1. Fills and text colours are not interchangeable. */
+  --credence-color-danger-fill-active: #991b1b;
+
+  /* Boundary colour for interactive controls.
+   *
+   * A control whose only visual boundary is its border must clear 3:1 against
+   * the surface behind it (WCAG 2.1 SC 1.4.11). --credence-border-default is
+   * decorative — it separates cards and rows, where no such floor applies —
+   * so interactive borders get their own, darker token. */
+  --credence-color-border-interactive: var(--credence-color-slate-500);
+  --credence-color-border-interactive-hover: var(--credence-color-slate-600);
   --credence-color-info-surface: #eff6ff;
   --credence-color-info-border: #3b82f6;
   --credence-color-info-text: #1e40af;
@@ -209,6 +240,13 @@
 [data-theme='dark'] {
   --credence-color-primary: #7dd3fc;
   --credence-color-primary-strong: #bae6fd;
+  /* Primary is a light tint here, so labels on it must be dark: 10.71:1 on the
+   * base fill and 13.45:1 on the hover fill. */
+  --credence-color-on-primary: var(--credence-color-slate-900);
+  /* Interactive borders sit on slate-700/600 button fills in dark mode, so they
+   * need to be lighter than the surface rather than darker. */
+  --credence-color-border-interactive: var(--credence-color-slate-400);
+  --credence-color-border-interactive-hover: var(--credence-color-slate-300);
   --credence-color-info-surface: rgba(59, 130, 246, 0.15);
   --credence-color-info-border: #3b82f6;
   --credence-color-info-text: #93c5fd;

--- a/src/test/contrast.ts
+++ b/src/test/contrast.ts
@@ -1,0 +1,197 @@
+/**
+ * Shared WCAG contrast helpers for design-system regression tests.
+ *
+ * These read the real stylesheets and resolve `var()` chains against the theme
+ * token blocks, so a test asserts what the app actually renders rather than a
+ * hand-copied colour table that can silently drift from the CSS.
+ *
+ * Thresholds: WCAG 2.1 SC 1.4.3 requires 4.5:1 for normal-size text; SC 1.4.11
+ * requires 3:1 for the visual boundary of an interactive control and for focus
+ * indicators.
+ */
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+export const TEXT_AA = 4.5
+export const NON_TEXT = 3
+
+export type Rgb = [number, number, number]
+export type Rgba = [number, number, number, number]
+export type ColorValue = string | Rgb | Rgba
+
+/**
+ * Read a stylesheet from the project root, with comments stripped.
+ *
+ * Comments must go before anything parses declarations: prose containing a colon
+ * and a later semicolon (e.g. "…at 1.67:1. Consume this token instead…") reads
+ * as a declaration and swallows the real one that follows it.
+ */
+export function readCss(relativePath: string): string {
+  return stripComments(readFileSync(resolve(process.cwd(), relativePath), 'utf8'))
+}
+
+export function stripComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '')
+}
+
+function escapeSelector(selector: string): string {
+  return selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Extract a rule's declarations, keyed by property name.
+ *
+ * The selector must match at the start of a line so that
+ * `.credence-button--primary` does not accidentally return the body of
+ * `[data-theme='dark'] .credence-button--primary`.
+ */
+export function getRuleDeclarations(css: string, selector: string): Map<string, string> {
+  const pattern = new RegExp(`(?:^|\\n)\\s*${escapeSelector(selector)}\\s*\\{([^}]*)\\}`)
+  const match = stripComments(css).match(pattern)
+
+  if (!match?.[1]) {
+    throw new Error(`Unable to locate CSS rule for selector: ${selector}`)
+  }
+
+  const declarations = new Map<string, string>()
+
+  for (const declaration of match[1].matchAll(/([\w-]+)\s*:\s*([^;]+);/g)) {
+    declarations.set(declaration[1].trim(), declaration[2].trim())
+  }
+
+  return declarations
+}
+
+/** Resolve a `var(--token, fallback)` chain to a literal colour value. */
+export function resolveCssValue(value: string, tokens: Map<string, string>): string {
+  const match = value.match(/var\(\s*(--[\w-]+)\s*(?:,\s*([^)]+))?\)/)
+
+  if (!match) {
+    return value.trim()
+  }
+
+  const resolved = tokens.get(match[1]) ?? match[2]
+
+  if (resolved === undefined) {
+    throw new Error(`Unresolved CSS custom property: ${match[1]}`)
+  }
+
+  return resolveCssValue(resolved.trim(), tokens)
+}
+
+/**
+ * Build the token map for a theme: `:root` declarations with the theme block's
+ * declarations layered on top, matching the cascade.
+ */
+export function getThemeTokens(css: string, themeSelector?: string): Map<string, string> {
+  const tokens = new Map<string, string>()
+
+  const collect = (selector: string) => {
+    for (const [property, value] of getRuleDeclarations(css, selector)) {
+      if (property.startsWith('--')) {
+        tokens.set(property, value)
+      }
+    }
+  }
+
+  collect(':root')
+
+  if (themeSelector) {
+    collect(themeSelector)
+  }
+
+  return tokens
+}
+
+export function parseColor(value: ColorValue): Rgb | Rgba {
+  if (Array.isArray(value)) {
+    return value
+  }
+
+  const trimmed = value.trim()
+
+  if (trimmed.startsWith('#')) {
+    const hex = trimmed.slice(1)
+    const normalized =
+      hex.length === 3
+        ? hex
+            .split('')
+            .map((char) => char + char)
+            .join('')
+        : hex
+
+    return [
+      Number.parseInt(normalized.slice(0, 2), 16) / 255,
+      Number.parseInt(normalized.slice(2, 4), 16) / 255,
+      Number.parseInt(normalized.slice(4, 6), 16) / 255,
+    ]
+  }
+
+  if (trimmed.startsWith('rgb(') || trimmed.startsWith('rgba(')) {
+    const parts = trimmed
+      .slice(trimmed.indexOf('(') + 1, trimmed.lastIndexOf(')'))
+      .split(/[,/]/)
+      .map((part) => Number.parseFloat(part.trim()))
+
+    const [r, g, b, alpha] = parts
+
+    if (r === undefined || g === undefined || b === undefined) {
+      throw new Error(`Malformed rgb()/rgba() color value: ${trimmed}`)
+    }
+
+    return alpha === undefined ? [r / 255, g / 255, b / 255] : [r / 255, g / 255, b / 255, alpha]
+  }
+
+  throw new Error(`Unsupported CSS color value: ${trimmed}`)
+}
+
+/** Flatten a translucent colour onto an opaque backdrop. */
+export function compositeColor(foreground: ColorValue, backdrop: ColorValue): Rgb {
+  const fg = parseColor(foreground)
+  const bg = parseColor(backdrop)
+  const tint = fg.slice(0, 3) as Rgb
+  const alpha = fg.length < 4 ? 1 : (fg[3] as number)
+
+  if (alpha >= 1) {
+    return tint
+  }
+
+  const base = bg.slice(0, 3) as Rgb
+
+  return [
+    tint[0] * alpha + base[0] * (1 - alpha),
+    tint[1] * alpha + base[1] * (1 - alpha),
+    tint[2] * alpha + base[2] * (1 - alpha),
+  ]
+}
+
+/** Apply a CSS `opacity` value to a colour over a known backdrop. */
+export function applyOpacity(color: ColorValue, backdrop: ColorValue, opacity: number): Rgb {
+  const rgb = parseColor(color).slice(0, 3) as Rgb
+  return compositeColor([...rgb, opacity] as Rgba, backdrop)
+}
+
+export function getRelativeLuminance(color: Rgb): number {
+  const normalize = (channel: number) =>
+    channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4
+
+  return 0.2126 * normalize(color[0]) + 0.7152 * normalize(color[1]) + 0.0722 * normalize(color[2])
+}
+
+export function getContrastRatio(foreground: ColorValue, background: ColorValue): number {
+  const backgroundRgb = parseColor(background).slice(0, 3) as Rgb
+  // A translucent foreground is only meaningful once flattened onto its backdrop.
+  const foregroundRgb = compositeColor(foreground, backgroundRgb)
+
+  const a = getRelativeLuminance(foregroundRgb)
+  const b = getRelativeLuminance(backgroundRgb)
+  const lighter = Math.max(a, b)
+  const darker = Math.min(a, b)
+
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+/** Round to 2dp for readable assertion messages. */
+export function ratio(foreground: ColorValue, background: ColorValue): number {
+  return Math.round(getContrastRatio(foreground, background) * 100) / 100
+}


### PR DESCRIPTION
## Summary

Contrast audit and fixes for interactive states — links, all `Button` variants, primary-filled controls, and focus rings — in light and dark themes.

I measured 57 state/theme combinations. Eight failed, and writing the regression test surfaced a ninth. They reduce to two token-misuse patterns rather than nine unrelated bugs.

Closes #814

## Failure 1 — a theme-dependent fill paired with a fixed on-colour

`--credence-color-primary` flips to a light tint (`#7dd3fc`) in dark mode, but the label was hard-coded `--credence-color-white`:

| State | Theme | Before |
| ----- | ----- | -----: |
| Primary button label | Dark | **1.67:1** |
| Primary button label `:hover` | Dark | **1.33:1** |

The same pairing had spread beyond `Button.css` to the speed-dial FAB, back-to-top button, toggle, segmented control, and active mobile-nav link — all unreadable in dark mode.

Introduced `--credence-color-on-primary` (white in light, `slate-900` in dark) and consumed it everywhere the primary fill is painted. Now **10.71:1** base, **13.45:1** hover.

## Failure 2 — text tokens used as fills

`--credence-color-danger-text` is tuned to be read *as text on a page*, so the dark theme lightens it to `#fca5a5`. Reusing it as the danger button's active background put a white label at **1.90:1**. Light mode's hover had the inverse problem, lightening the fill to `#ef4444` for **3.76:1**.

Split the fills out as `--credence-color-danger-fill`, `-fill-hover`, `-fill-active` so they can darken on interaction without dragging the penalty-amount text with them. `--credence-color-danger-action` keeps its current values because it is still that text colour (`ConfirmDialog`, `BondDetail`, `Bond`).

Because the fill now darkens, hover and active pin `border-color` to `--credence-color-danger-border`; a darkened red would otherwise sink the button's edge below 3:1 against the dark page.

## Failure 3 — a control boundary using a decorative token

The secondary button's fill matches the card behind it, so its border is the only thing identifying it as a control. That puts the border under the 3:1 non-text floor (SC 1.4.11), where the decorative `--credence-border-default` managed **1.23:1** (light) and **1.37:1** (dark).

Added `--credence-color-border-interactive` / `-hover` for control boundaries and left `--credence-border-default` alone for cards and dividers, where no such floor applies.

## Tokens changed

| Token | Value | Reason |
| ----- | ----- | ------ |
| `--credence-color-on-primary` | `#ffffff` light, `slate-900` dark | Theme-aware label for anything on the primary fill |
| `--credence-color-danger-fill` | `#dc2626` | Destructive button background, split from the text token |
| `--credence-color-danger-fill-hover` | `#b91c1c` | Hover darkens instead of lightening |
| `--credence-color-danger-fill-active` | `#991b1b` | Replaces reuse of `--credence-color-danger-text` |
| `--credence-color-border-interactive` | `slate-500` light, `slate-400` dark | 3:1 control boundary |
| `--credence-color-border-interactive-hover` | `slate-600` light, `slate-300` dark | Same, for the hover fill |
| `--credence-color-slate-300` | `#cbd5e1` | Added; the scale was missing this step |

All 41 post-fix checks pass. Full results matrix in `docs/interactive-contrast-audit.md`.

## Deliberately unchanged

**Disabled states.** SC 1.4.3 and SC 1.4.11 both exempt inactive user interface components, and the low contrast (2.18–3.07:1) *is* the affordance — raising it would make disabled buttons read as enabled. The regression test omits them on purpose.

**Links and focus rings** already passed in both themes and are untouched, but are now covered so they stay that way.

## Regression test

`src/components/interactiveContrast.test.ts` (39 tests) resolves colours out of `src/index.css` and the component stylesheets rather than a hand-copied colour table, so reverting either a token *or* a declaration breaks a test. Shared helpers are in `src/test/contrast.ts`.

The helpers strip CSS comments before parsing: prose containing a colon and a later semicolon (e.g. "…at 1.67:1. Consume this token instead…") otherwise reads as a declaration and swallows the real one after it.

I verified the tests aren't vacuous by injecting each fix back out — every regression fails a test. My first version of the secondary-border test asserted on the token rather than on `Button.css`'s declaration and let a regression through; it now reads the declaration.

## Verification

- 39 new tests pass; ESLint and Prettier clean.
- Full suite: **34 failing files before and after, byte-identical** — no regressions. `Button`, `Badge`, `MobileNav` and `StatusBadge` are among the pre-existing failures and are components this PR touches, so I also compared their per-test results: identical to baseline.
- `controls.css` was already unformatted on `main`; left as-is rather than bloating the diff.

## Two things reviewers should know

**1. `npm run build` fails on `main`, before this PR.** `src/pages/Attestations.tsx:171` has a `</section>` with no opener. I fixed it locally to run the build gate, and that single syntax error turned out to be **masking 255 type errors across 31 files** — the CI type gate is currently blind. Three of those were real strict-mode errors in this PR's own `src/test/contrast.ts`, which are fixed and verified clean.

I then reverted the `Attestations.tsx` edit. It is unrelated to #814, and landing it would not green the build — it would only make this contrast PR appear to break CI. That file needs its own PR: it is broken well past the tag (duplicate `ActivityItem` import, plus undefined `FilterStatus`, `FILTER_ORDER`, `filterTone`, `PageHeader`), so it looks half-merged.

**2. One out-of-scope failure was found and not fixed.** `--credence-color-danger-action` renders at **3.89:1** as text on `--credence-surface-card` in dark mode, below AA. That is static text rather than an interactive state, so it belongs to a static-text audit; it is recorded in the audit doc as a follow-up.