### PR TITLE
feat: add structured error logging for failed API fetches (Closes #949)

### DIFF
--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -324,3 +324,54 @@ describe('apiFetch rate limiting (defence-in-depth)', () => {
     })
   })
 })
+
+describe('apiFetch logging', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('logs an error with path and status when a fetch fails with a non-2xx response', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ message: 'Not found' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await apiFetch('/bonds/missing').catch(() => {})
+
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    const line = errorSpy.mock.calls[0]?.[0] ?? ''
+    expect(line).toMatch(/event=api_fetch_failed/)
+    expect(line).toContain('path=/bonds/missing')
+    expect(line).toMatch(/status=404/)
+    expect(line).toMatch(/error=Not found/)
+  })
+
+  it('logs an error with status 0 when a network error occurs', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    fetchMock.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await apiFetch('/bonds').catch(() => {})
+
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    const line = errorSpy.mock.calls[0]?.[0] ?? ''
+    expect(line).toMatch(/event=api_fetch_failed/)
+    expect(line).toContain('path=/bonds')
+    expect(line).toMatch(/status=0/)
+    expect(line).toMatch(/error=Failed to fetch/)
+  })
+
+  it('does not log when a fetch succeeds', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    fetchMock.mockResolvedValueOnce(jsonResponse({ ok: true }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    await apiFetch('/health')
+
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,3 +1,4 @@
+import { logError } from '../lib/log'
 import { ApiRateLimiter, DEFAULT_API_RATE_LIMIT, readApiRateLimitOverrides } from './rateLimit'
 
 export interface ApiFetchOptions extends Omit<RequestInit, 'body'> {
@@ -191,12 +192,18 @@ export async function apiFetch<T>(path: string, options: ApiFetchOptions = {}): 
       throw error
     }
     const message = error instanceof Error ? error.message : 'Network request failed'
+    logError('api_fetch_failed', { path, status: '0', error: message })
     throw new ApiError(0, message, error)
   }
 
   const payload = await parseResponse(response)
 
   if (!response.ok) {
+    logError('api_fetch_failed', {
+      path,
+      status: String(response.status),
+      error: errorMessage(response.status, payload),
+    })
     throw new ApiError(response.status, errorMessage(response.status, payload), payload)
   }
 


### PR DESCRIPTION
## Summary

Add structured  calls to the  function so every failed API request is captured with the request path, HTTP status, and error message in a machine-readable key=value format.

## Changes

- **src/api/client.ts** — Import  from the existing structured logger and emit:
  - On network failures (status 0): path + error message
  - On non-2xx responses: path + status + error message
- **src/api/client.test.ts** — 3 new tests:
  1. Non-2xx response logs path, status, and error
  2. Network error logs status 0 and error message
  3. Successful fetch does not log

## Verification

- ✅ All 53 API tests pass (24 client tests + 29 rate-limit/generated tests)
- ✅ Structured log output confirmed in test stderr (e.g. `event=api_fetch_failed path=/bonds status=404 error=Bond not found`)
- ✅ The existing logger's secret-scrubbing (PII, tokens) is inherited automatically

Closes #949