### PR TITLE
fix: preserve sidebar collapse state across route changes (Closes #914)

### DIFF
--- a/src/components/Layout.test.tsx
+++ b/src/components/Layout.test.tsx
@@ -39,6 +39,7 @@ function renderLayout(initialPath = '/') {
 describe('Layout Integration', () => {
   beforeEach(() => {
     document.body.style.overflow = ''
+    sessionStorage.clear()
   })
 
   it('renders skip link and main branding', () => {
@@ -146,6 +147,29 @@ describe('Layout Integration', () => {
     }
 
     expect(drawer).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('preserves sidebar collapse state across route changes', () => {
+    renderLayout('/dashboard')
+    const hamburger = screen.getByRole('button', { name: /open navigation menu/i })
+    const drawer = document.getElementById('mobile-nav-drawer') as HTMLElement
+
+    // Open the drawer
+    fireEvent.click(hamburger)
+    expect(drawer).toHaveAttribute('aria-hidden', 'false')
+
+    // Navigate to a different route via a desktop nav link (not inside the drawer)
+    // Desktop nav links are outside the drawer and don't trigger onClick={close}
+    const desktopDashboardLink = screen
+      .getAllByRole('link', { name: /dashboard/i })
+      .find((link) => !drawer.contains(link))
+    expect(desktopDashboardLink).toBeDefined()
+    if (desktopDashboardLink) {
+      fireEvent.click(desktopDashboardLink)
+    }
+
+    // The drawer should remain open after route change
+    expect(drawer).toHaveAttribute('aria-hidden', 'false')
   })
 
   // --- BottomNav integration ---

--- a/src/components/navigation/MobileNav.test.tsx
+++ b/src/components/navigation/MobileNav.test.tsx
@@ -19,6 +19,7 @@ function getDrawer() {
 describe('MobileNav', () => {
   beforeEach(() => {
     document.body.style.overflow = ''
+    sessionStorage.clear()
   })
 
   // --- render ---

--- a/src/components/navigation/MobileNav.tsx
+++ b/src/components/navigation/MobileNav.tsx
@@ -25,13 +25,6 @@ export default function MobileNav() {
 
   useScrollPreserver({ isActive: isOpen })
 
-  // Close on route change (SPA navigation) — but state survives full page reloads via sessionStorage
-  const prevPath = useRef(location.pathname)
-  if (prevPath.current !== location.pathname) {
-    prevPath.current = location.pathname
-    if (isOpen) setIsOpen(false)
-  }
-
   // Persist collapse state across full page reloads
   useEffect(() => {
     try {


### PR DESCRIPTION
## Summary

Fixes the sidebar (MobileNav drawer) collapse state being lost on route change. The sidebar now preserves its open/closed state when navigating between SPA routes.

## Changes

### 
- Removed the render-phase close logic that was forcing the sidebar to close on every route change
- The sidebar's open/closed state is now persisted via **sessionStorage** across both SPA route changes and full page reloads

### 
- Added  in  to fix test isolation (pre-existing issue)

### 
- Added  in  to fix test isolation
- Added new test: **preserves sidebar collapse state across route changes** — verifies the drawer stays open after navigating via a desktop nav link

## Testing

- [x] Lint passes
- [x] Tests pass (11/12 Layout tests, 19/19 MobileNav tests — the 1 Layout failure is pre-existing 'renders theme toggle button')
- [x] Build compiles (pre-existing tsc error in Attestations.tsx is unrelated)

Closes #914