### PR TITLE
refactor: rename Modal to Dialog with native <dialog> element (Closes #923)

### DIFF
--- a/src/components/AttestationDetailDrawer.tsx
+++ b/src/components/AttestationDetailDrawer.tsx
@@ -43,7 +43,7 @@ export interface AttestationDetailDrawerProps {
  * Right-rail / bottom-sheet drawer showing the full detail of an attestation
  * event: validator, transaction hash, evidence, metadata, and timestamp.
  *
- * Pattern is shared with `WhatsNewDialog` and `ConnectWalletModal`:
+ * Pattern is shared with `WhatsNewDialog` and `ConnectWalletDialog`:
  * - portal‑rendered into `document.body`,
  * - focus is trapped while open and is returned to the originating row on close,
  * - `Escape` and a backdrop click that *started outside* the drawer both close,

--- a/src/components/ConfirmDialog.css
+++ b/src/components/ConfirmDialog.css
@@ -1,21 +1,7 @@
-.confirm-dialog__backdrop {
+/* Native dialog base styles */
+.confirm-dialog {
   position: fixed;
   inset: 0;
-  z-index: 1000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--credence-space-4);
-  background: var(--credence-backdrop-light);
-  animation: confirm-dialog-fade-in var(--credence-motion-duration-fast)
-    var(--credence-motion-easing-decelerate);
-}
-
-[data-theme='dark'] .confirm-dialog__backdrop {
-  background: var(--credence-backdrop-dark);
-}
-
-.confirm-dialog {
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -27,6 +13,19 @@
   background: var(--credence-color-danger-surface);
   box-shadow: 0 20px 40px rgba(15, 23, 42, 0.2);
   color: var(--credence-color-danger-text);
+  /* Remove the default dialog padding */
+  padding: 0;
+}
+
+/* Native dialog backdrop */
+.confirm-dialog::backdrop {
+  background: var(--credence-backdrop-light);
+  animation: confirm-dialog-fade-in var(--credence-motion-duration-fast)
+    var(--credence-motion-easing-decelerate);
+}
+
+[data-theme='dark'] .confirm-dialog::backdrop {
+  background: var(--credence-backdrop-dark);
 }
 
 [data-theme='dark'] .confirm-dialog {
@@ -214,15 +213,12 @@
 }
 
 @media (max-width: 768px) {
-  .confirm-dialog__backdrop {
-    align-items: flex-end;
-    padding: 0;
-  }
-
   .confirm-dialog {
     max-width: none;
     max-height: 92vh;
     border-radius: var(--credence-radius-xl) var(--credence-radius-xl) 0 0;
+    /* Position at bottom on mobile */
+    margin-top: auto;
   }
 
   .confirm-dialog__footer {
@@ -237,10 +233,6 @@
 
 /* Very small screens (360px): ensure dialog fits without overflow */
 @media (max-width: 360px) {
-  .confirm-dialog__backdrop {
-    padding: var(--credence-space-2);
-  }
-
   .confirm-dialog {
     max-height: 95vh;
     border-radius: var(--credence-radius-lg) var(--credence-radius-lg) 0 0;

--- a/src/components/ConfirmDialog.test.tsx
+++ b/src/components/ConfirmDialog.test.tsx
@@ -80,11 +80,6 @@ describe('ConfirmDialog', () => {
       expect(screen.getByRole('dialog')).toBeInTheDocument()
     })
 
-    it('has aria-modal="true"', () => {
-      renderDialog()
-      expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true')
-    })
-
     it('renders the title', () => {
       renderDialog({ title: 'Withdraw Bond' })
       expect(screen.getByRole('heading', { name: 'Withdraw Bond' })).toBeInTheDocument()
@@ -210,16 +205,18 @@ describe('ConfirmDialog', () => {
     it('calls onCancel when backdrop is clicked', async () => {
       const user = userEvent.setup()
       const { onCancel } = renderDialog()
-      // The backdrop is the direct parent of the dialog element
-      const backdrop = screen.getByRole('dialog').parentElement!
-      await user.click(backdrop)
+      // With native <dialog>, clicking the dialog element itself simulates a
+      // backdrop click (the ::backdrop pseudo-element is rendered as part of the
+      // dialog's top-layer, so event.target === dialog element).
+      await user.click(screen.getByRole('dialog'))
       expect(onCancel).toHaveBeenCalledOnce()
     })
 
     it('does not call onCancel when clicking inside the dialog', async () => {
       const user = userEvent.setup()
       const { onCancel } = renderDialog()
-      await user.click(screen.getByRole('dialog'))
+      // Click a child element inside the dialog (not the dialog itself)
+      await user.click(screen.getByRole('heading', { name: 'Withdraw Bond' }))
       expect(onCancel).not.toHaveBeenCalled()
     })
   })

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useRef, useState, type RefObject } from 'react'
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
 import { useTranslation, Trans } from 'react-i18next'
 import { createPortal } from 'react-dom'
 import { useFocusTrap } from '../hooks/useFocusTrap'
@@ -36,7 +36,7 @@ export interface ConfirmDialogProps {
   children?: React.ReactNode
   onConfirm: () => void
   onCancel: () => void
-  returnFocusRef?: RefObject<HTMLElement | null>
+  returnFocusRef?: React.RefObject<HTMLElement | null>
   confirmLabel?: string
   confirmInputLabel?: React.ReactNode
   confirmInputHint?: React.ReactNode
@@ -81,7 +81,7 @@ export default function ConfirmDialog({
   const titleId = useId()
   const descId = useId()
   const announcementId = useId()
-  const dialogRef = useRef<HTMLDivElement>(null)
+  const dialogRef = useRef<HTMLDialogElement>(null)
   const cancelRef = useRef<HTMLButtonElement>(null)
   const confirmRef = useRef<HTMLButtonElement>(null)
   const [confirmText, setConfirmText] = useState('')
@@ -92,15 +92,49 @@ export default function ConfirmDialog({
     onCancel()
   }, [onCancel])
 
-  useScrollPreserver({ isActive: open })
+  // Open/close the native dialog element with showModal()/close()
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
 
+    if (open) {
+      // showModal() is idempotent — calling it on an already-open dialog is a no-op
+      try {
+        dialog.showModal()
+      } catch {
+        // dialog is already open
+      }
+    } else {
+      dialog.close()
+    }
+  }, [open])
+
+  // Handle native cancel event (Escape key)
+  // Prevent the default close behavior and call onCancel instead
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+
+    const handleNativeCancel = (e: Event) => {
+      e.preventDefault()
+      onCancel()
+    }
+
+    dialog.addEventListener('cancel', handleNativeCancel)
+    return () => dialog.removeEventListener('cancel', handleNativeCancel)
+  }, [onCancel])
+
+  // Focus trap for custom focus management (initialFocusRef, returnFocusRef)
   useFocusTrap({
-    containerRef: dialogRef,
+    containerRef: dialogRef as React.RefObject<HTMLElement | null>,
     isActive: open,
     initialFocusRef: cancelRef,
     returnFocusRef,
-    onEscape: handleCancel,
+    // Don't handle Escape via focus trap — the native dialog's cancel event handles it
+    onEscape: undefined,
   })
+
+  useScrollPreserver({ isActive: open })
 
   useEffect(() => {
     if (!open) {
@@ -136,113 +170,109 @@ export default function ConfirmDialog({
     onConfirm()
   }
 
-  const handleBackdropClick = (event: React.MouseEvent<HTMLDivElement>) => {
+  const handleBackdropClick = (event: React.MouseEvent<HTMLDialogElement>) => {
     if (isSubmitting) return
+    // In native <dialog>, clicking the ::backdrop fires a click event on the dialog element
+    // with event.target === dialog (backdrop is not a child element)
     if (event.target === event.currentTarget) {
       handleCancel()
     }
   }
 
-  if (!open) return null
-
   return createPortal(
-    <div className="confirm-dialog__backdrop" onClick={handleBackdropClick} aria-hidden={false}>
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={titleId}
-        aria-describedby={descId}
-        className={`confirm-dialog confirm-dialog--${variant}`}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div id={announcementId} className="sr-only" aria-live="assertive" aria-atomic="true">
-          {announcement}
-        </div>
-
-        <header className="confirm-dialog__header">
-          <h2 id={titleId} className="confirm-dialog__title">
-            {title}
-          </h2>
-          {subtitle && <p className="confirm-dialog__subtitle">{subtitle}</p>}
-        </header>
-
-        <div id={descId} className="confirm-dialog__body">
-          {breakdown ? (
-            <dl className="confirm-dialog__breakdown">
-              <div className="confirm-dialog__breakdown-row">
-                <dt>{t('confirmDialog.breakdown.bondAmount')}</dt>
-                <dd>{breakdown.bondAmount}</dd>
-              </div>
-              <div className="confirm-dialog__breakdown-row confirm-dialog__breakdown-row--penalty">
-                <dt>
-                  {t('confirmDialog.breakdown.slashPenalty', { percent: breakdown.penaltyPercent })}
-                </dt>
-                <dd>−{breakdown.penaltyAmount}</dd>
-              </div>
-              <div className="confirm-dialog__breakdown-row confirm-dialog__breakdown-row--total">
-                <dt>{t('confirmDialog.breakdown.youReceive')}</dt>
-                <dd>{breakdown.resultingBalance}</dd>
-              </div>
-            </dl>
-          ) : description ? (
-            <div className="confirm-dialog__description">{description}</div>
-          ) : null}
-
-          {children}
-
-          <div className="confirm-dialog__confirm-field">
-            <label htmlFor={`${titleId}-confirm-input`}>
-              {confirmInputLabel || (
-                <Trans
-                  i18nKey="confirmDialog.typeToConfirm"
-                  values={{
-                    phrase: confirmPhrase,
-                    action:
-                      confirmLabel !== 'Withdraw bond' ? confirmLabel.toLowerCase() : 'withdrawal',
-                  }}
-                  components={{ strong: <strong /> }}
-                />
-              )}
-            </label>
-            <input
-              id={`${titleId}-confirm-input`}
-              type="text"
-              value={confirmText}
-              onChange={(e) => setConfirmText(e.target.value)}
-              autoComplete="off"
-              spellCheck={false}
-              aria-required="true"
-              placeholder={confirmPhrase}
-            />
-            <p className="confirm-dialog__confirm-hint">{confirmInputHint || confirmHint}</p>
-          </div>
-        </div>
-
-        <footer className="confirm-dialog__footer">
-          <Button
-            ref={cancelRef}
-            type="button"
-            variant="secondary"
-            onClick={handleCancel}
-            disabled={isSubmitting}
-          >
-            Cancel
-          </Button>
-          <Button
-            ref={confirmRef}
-            type="button"
-            variant={variant === 'danger' ? 'danger' : 'primary'}
-            disabled={!isConfirmEnabled || isSubmitting}
-            isLoading={isSubmitting}
-            onClick={handleConfirm}
-            aria-disabled={!isConfirmEnabled || isSubmitting}
-          >
-            {confirmLabel}
-          </Button>
-        </footer>
+    <dialog
+      ref={dialogRef}
+      className={`confirm-dialog confirm-dialog--${variant}`}
+      aria-labelledby={titleId}
+      aria-describedby={descId}
+      onClick={handleBackdropClick}
+    >
+      <div id={announcementId} className="sr-only" aria-live="assertive" aria-atomic="true">
+        {announcement}
       </div>
-    </div>,
+
+      <header className="confirm-dialog__header">
+        <h2 id={titleId} className="confirm-dialog__title">
+          {title}
+        </h2>
+        {subtitle && <p className="confirm-dialog__subtitle">{subtitle}</p>}
+      </header>
+
+      <div id={descId} className="confirm-dialog__body">
+        {breakdown ? (
+          <dl className="confirm-dialog__breakdown">
+            <div className="confirm-dialog__breakdown-row">
+              <dt>{t('confirmDialog.breakdown.bondAmount')}</dt>
+              <dd>{breakdown.bondAmount}</dd>
+            </div>
+            <div className="confirm-dialog__breakdown-row confirm-dialog__breakdown-row--penalty">
+              <dt>
+                {t('confirmDialog.breakdown.slashPenalty', { percent: breakdown.penaltyPercent })}
+              </dt>
+              <dd>−{breakdown.penaltyAmount}</dd>
+            </div>
+            <div className="confirm-dialog__breakdown-row confirm-dialog__breakdown-row--total">
+              <dt>{t('confirmDialog.breakdown.youReceive')}</dt>
+              <dd>{breakdown.resultingBalance}</dd>
+            </div>
+          </dl>
+        ) : description ? (
+          <div className="confirm-dialog__description">{description}</div>
+        ) : null}
+
+        {children}
+
+        <div className="confirm-dialog__confirm-field">
+          <label htmlFor={`${titleId}-confirm-input`}>
+            {confirmInputLabel || (
+              <Trans
+                i18nKey="confirmDialog.typeToConfirm"
+                values={{
+                  phrase: confirmPhrase,
+                  action:
+                    confirmLabel !== 'Withdraw bond' ? confirmLabel.toLowerCase() : 'withdrawal',
+                }}
+                components={{ strong: <strong /> }}
+              />
+            )}
+          </label>
+          <input
+            id={`${titleId}-confirm-input`}
+            type="text"
+            value={confirmText}
+            onChange={(e) => setConfirmText(e.target.value)}
+            autoComplete="off"
+            spellCheck={false}
+            aria-required="true"
+            placeholder={confirmPhrase}
+          />
+          <p className="confirm-dialog__confirm-hint">{confirmInputHint || confirmHint}</p>
+        </div>
+      </div>
+
+      <footer className="confirm-dialog__footer">
+        <Button
+          ref={cancelRef}
+          type="button"
+          variant="secondary"
+          onClick={handleCancel}
+          disabled={isSubmitting}
+        >
+          Cancel
+        </Button>
+        <Button
+          ref={confirmRef}
+          type="button"
+          variant={variant === 'danger' ? 'danger' : 'primary'}
+          disabled={!isConfirmEnabled || isSubmitting}
+          isLoading={isSubmitting}
+          onClick={handleConfirm}
+          aria-disabled={!isConfirmEnabled || isSubmitting}
+        >
+          {confirmLabel}
+        </Button>
+      </footer>
+    </dialog>,
     document.body
   )
 }

--- a/src/components/ConnectWalletDialog.css
+++ b/src/components/ConnectWalletDialog.css
@@ -1,25 +1,8 @@
-/* ─── Backdrop ─────────────────────────────────────────────────────────────── */
-
-.connect-wallet-dialog__backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 1000;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--credence-space-4);
-  background: var(--credence-backdrop-light);
-  animation: connect-wallet-fade-in var(--credence-motion-duration-fast)
-    var(--credence-motion-easing-decelerate);
-}
-
-[data-theme='dark'] .connect-wallet-dialog__backdrop {
-  background: var(--credence-backdrop-dark);
-}
-
-/* ─── Dialog panel ─────────────────────────────────────────────────────────── */
+/* ─── Native dialog base ────────────────────────────────────────────────────── */
 
 .connect-wallet-dialog {
+  position: fixed;
+  inset: 0;
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -31,6 +14,19 @@
   color: var(--credence-text-primary);
   animation: connect-wallet-slide-up var(--credence-motion-duration-base)
     var(--credence-motion-easing-decelerate);
+  /* Remove default dialog padding */
+  padding: 0;
+}
+
+/* Native dialog backdrop */
+.connect-wallet-dialog::backdrop {
+  background: var(--credence-backdrop-light);
+  animation: connect-wallet-fade-in var(--credence-motion-duration-fast)
+    var(--credence-motion-easing-decelerate);
+}
+
+[data-theme='dark'] .connect-wallet-dialog::backdrop {
+  background: var(--credence-backdrop-dark);
 }
 
 [data-theme='dark'] .connect-wallet-dialog {
@@ -117,8 +113,8 @@
 /* ─── Reduced motion ───────────────────────────────────────────────────────── */
 
 @media (prefers-reduced-motion: reduce) {
-  .connect-wallet-dialog__backdrop,
-  .connect-wallet-dialog {
+  .connect-wallet-dialog,
+  .connect-wallet-dialog::backdrop {
     animation: none;
   }
 }
@@ -126,14 +122,10 @@
 /* ─── Mobile: bottom sheet ─────────────────────────────────────────────────── */
 
 @media (max-width: 767px) {
-  .connect-wallet-dialog__backdrop {
-    align-items: flex-end;
-    padding: 0;
-  }
-
   .connect-wallet-dialog {
     max-width: none;
     border-radius: var(--credence-radius-xl) var(--credence-radius-xl) 0 0;
+    margin-top: auto;
   }
 
   .connect-wallet-dialog__footer {

--- a/src/components/ConnectWalletDialog.test.tsx
+++ b/src/components/ConnectWalletDialog.test.tsx
@@ -29,7 +29,7 @@ vi.mock('../context/WalletContext', () => ({
 // Helpers
 // ---------------------------------------------------------------------------
 
-function renderModal(overrides: Partial<Parameters<typeof ConnectWalletDialog>[0]> = {}) {
+function renderDialog(overrides: Partial<Parameters<typeof ConnectWalletDialog>[0]> = {}) {
   const onClose = vi.fn()
   const props = { open: true, onClose, ...overrides }
   const result = render(<ConnectWalletDialog {...props} />)
@@ -63,22 +63,17 @@ afterEach(() => {
 
 describe('ConnectWalletDialog — rendering', () => {
   it('renders nothing when open is false', () => {
-    renderModal({ open: false })
+    renderDialog({ open: false })
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
   })
 
   it('renders the dialog when open is true', () => {
-    renderModal()
+    renderDialog()
     expect(screen.getByRole('dialog')).toBeInTheDocument()
   })
 
-  it('has aria-modal="true"', () => {
-    renderModal()
-    expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true')
-  })
-
   it('has an accessible title via aria-labelledby', () => {
-    renderModal()
+    renderDialog()
     const dialog = screen.getByRole('dialog')
     const labelId = dialog.getAttribute('aria-labelledby')
     expect(labelId).toBeTruthy()
@@ -87,7 +82,7 @@ describe('ConnectWalletDialog — rendering', () => {
   })
 
   it('has an accessible description via aria-describedby', () => {
-    renderModal()
+    renderDialog()
     const dialog = screen.getByRole('dialog')
     const descId = dialog.getAttribute('aria-describedby')
     expect(descId).toBeTruthy()
@@ -96,13 +91,13 @@ describe('ConnectWalletDialog — rendering', () => {
   })
 
   it('renders Cancel and Connect buttons', () => {
-    renderModal()
+    renderDialog()
     expect(screen.getByRole('button', { name: /^cancel$/i })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /^connect$/i })).toBeInTheDocument()
   })
 
   it('does not render an error alert by default', () => {
-    renderModal()
+    renderDialog()
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
   })
 })
@@ -114,19 +109,19 @@ describe('ConnectWalletDialog — rendering', () => {
 describe('ConnectWalletDialog — error display', () => {
   it('renders a not-installed error message', () => {
     mockError = { code: 'not_installed', message: 'Not installed' }
-    renderModal()
+    renderDialog()
     expect(screen.getByRole('alert')).toHaveTextContent(/Freighter is not installed/i)
   })
 
   it('renders a rejected error message', () => {
     mockError = { code: 'rejected', message: 'User declined' }
-    renderModal()
+    renderDialog()
     expect(screen.getByRole('alert')).toHaveTextContent(/declined/i)
   })
 
   it('falls back to error.message for unknown error codes', () => {
     mockError = { code: 'unknown', message: 'Something went wrong' }
-    renderModal()
+    renderDialog()
     expect(screen.getByRole('alert')).toHaveTextContent('Something went wrong')
   })
 })
@@ -138,13 +133,13 @@ describe('ConnectWalletDialog — error display', () => {
 describe('ConnectWalletDialog — connecting state', () => {
   it('disables Cancel while connecting', () => {
     mockIsConnecting = true
-    renderModal()
+    renderDialog()
     expect(screen.getByRole('button', { name: /^cancel$/i })).toBeDisabled()
   })
 
   it('shows loading state on Connect button while connecting', () => {
     mockIsConnecting = true
-    renderModal()
+    renderDialog()
     const connectBtn = screen.getByRole('button', { name: /connect/i })
     expect(connectBtn).toHaveAttribute('aria-busy', 'true')
   })
@@ -157,30 +152,33 @@ describe('ConnectWalletDialog — connecting state', () => {
 describe('ConnectWalletDialog — closing', () => {
   it('calls onClose when Cancel is clicked', async () => {
     const user = userEvent.setup()
-    const { onClose } = renderModal()
+    const { onClose } = renderDialog()
     await user.click(screen.getByRole('button', { name: /^cancel$/i }))
     expect(onClose).toHaveBeenCalledOnce()
   })
 
   it('calls onClose when the backdrop is clicked', async () => {
     const user = userEvent.setup()
-    const { onClose } = renderModal()
-    const backdrop = screen.getByRole('dialog').parentElement!
-    await user.click(backdrop)
+    const { onClose } = renderDialog()
+    // With native <dialog>, clicking the dialog element itself simulates a
+    // backdrop click (the ::backdrop pseudo-element is rendered as part of the
+    // dialog's top-layer, so event.target === dialog element).
+    await user.click(screen.getByRole('dialog'))
     expect(onClose).toHaveBeenCalledOnce()
   })
 
   it('calls onClose when Escape is pressed', async () => {
     const user = userEvent.setup()
-    const { onClose } = renderModal()
+    const { onClose } = renderDialog()
     await user.keyboard('{Escape}')
     expect(onClose).toHaveBeenCalledOnce()
   })
 
   it('does NOT call onClose when clicking inside the dialog panel', async () => {
     const user = userEvent.setup()
-    const { onClose } = renderModal()
-    await user.click(screen.getByRole('dialog'))
+    const { onClose } = renderDialog()
+    // Click a child element inside the dialog (not the dialog itself)
+    await user.click(screen.getByRole('heading', { name: 'Connect Freighter Wallet' }))
     expect(onClose).not.toHaveBeenCalled()
   })
 })
@@ -192,7 +190,7 @@ describe('ConnectWalletDialog — closing', () => {
 describe('ConnectWalletDialog — connect action', () => {
   it('calls connect() when Connect button is clicked', async () => {
     const user = userEvent.setup()
-    renderModal()
+    renderDialog()
     await user.click(screen.getByRole('button', { name: /^connect$/i }))
     expect(mockConnect).toHaveBeenCalledOnce()
   })
@@ -230,20 +228,20 @@ describe('ConnectWalletDialog — auto-close on wallet connect', () => {
 
 describe('ConnectWalletDialog — body scroll lock', () => {
   it('sets overflow to hidden when open', () => {
-    renderModal({ open: true })
+    renderDialog({ open: true })
     expect(document.body.style.overflow).toBe('hidden')
   })
 
   it('restores overflow on unmount', () => {
     document.body.style.overflow = 'auto'
-    const { unmount } = renderModal({ open: true })
+    const { unmount } = renderDialog({ open: true })
     expect(document.body.style.overflow).toBe('hidden')
     unmount()
     expect(document.body.style.overflow).toBe('auto')
   })
 
   it('does not lock scroll when open is false', () => {
-    renderModal({ open: false })
+    renderDialog({ open: false })
     expect(document.body.style.overflow).toBe('')
   })
 })
@@ -254,7 +252,7 @@ describe('ConnectWalletDialog — body scroll lock', () => {
 
 describe('ConnectWalletDialog — focus management', () => {
   it('initially focuses the Cancel button when opened', () => {
-    renderModal()
+    renderDialog()
     expect(document.activeElement).toBe(screen.getByRole('button', { name: /^cancel$/i }))
   })
 

--- a/src/components/ConnectWalletDialog.tsx
+++ b/src/components/ConnectWalletDialog.tsx
@@ -10,19 +10,20 @@ export interface ConnectWalletDialogProps {
   open: boolean
   onClose: () => void
   /**
-   * Element to return focus to when the modal closes.
-   * When omitted, focus returns to the element that was active before the modal opened.
+   * Element to return focus to when the dialog closes.
+   * When omitted, focus returns to the element that was active before the dialog opened.
    */
   returnFocusRef?: React.RefObject<HTMLElement | null>
 }
 
 /**
- * Modal dialog that explains the wallet connection step and surfaces
+ * Dialog that explains the wallet connection step and surfaces
  * connection status (connecting, error) without losing the user's focus context.
  *
  * - Portal-rendered into document.body.
+ * - Uses the native <dialog> element with showModal().
  * - Focus is trapped inside while open; returned to returnFocusRef on close.
- * - Escape and backdrop click close the modal.
+ * - Escape and backdrop click close the dialog.
  * - Body scroll is locked while open.
  * - Entrance animation is suppressed when prefers-reduced-motion: reduce is set.
  * - Auto-closes when the wallet connects successfully.
@@ -36,7 +37,7 @@ export default function ConnectWalletDialog({
 
   const titleId = useId()
   const descId = useId()
-  const dialogRef = useRef<HTMLDivElement>(null)
+  const dialogRef = useRef<HTMLDialogElement>(null)
   const cancelRef = useRef<HTMLButtonElement>(null)
 
   // Auto-close when wallet connects successfully
@@ -46,17 +47,47 @@ export default function ConnectWalletDialog({
     }
   }, [isConnected, open, onClose])
 
+  // Open/close the native dialog element
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+
+    if (open) {
+      try {
+        dialog.showModal()
+      } catch {
+        // dialog is already open
+      }
+    } else {
+      dialog.close()
+    }
+  }, [open])
+
+  // Handle native cancel event (Escape key)
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+
+    const handleNativeCancel = (e: Event) => {
+      e.preventDefault()
+      onClose()
+    }
+
+    dialog.addEventListener('cancel', handleNativeCancel)
+    return () => dialog.removeEventListener('cancel', handleNativeCancel)
+  }, [onClose])
+
   useScrollPreserver({ isActive: open })
 
   useFocusTrap({
-    containerRef: dialogRef,
+    containerRef: dialogRef as React.RefObject<HTMLElement | null>,
     isActive: open,
     initialFocusRef: cancelRef,
     returnFocusRef,
-    onEscape: onClose,
+    onEscape: undefined,
   })
 
-  const handleBackdropClick = (event: React.MouseEvent<HTMLDivElement>) => {
+  const handleBackdropClick = (event: React.MouseEvent<HTMLDialogElement>) => {
     if (event.target === event.currentTarget) {
       onClose()
     }
@@ -81,51 +112,47 @@ export default function ConnectWalletDialog({
   }
 
   return createPortal(
-    <div className="connect-wallet-dialog__backdrop" onClick={handleBackdropClick}>
-      <div
-        ref={dialogRef}
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={titleId}
-        aria-describedby={descId}
-        className="connect-wallet-dialog"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <header className="connect-wallet-dialog__header">
-          <h2 id={titleId} className="connect-wallet-dialog__title">
-            Connect Freighter Wallet
-          </h2>
-        </header>
+    <dialog
+      ref={dialogRef}
+      className="connect-wallet-dialog"
+      aria-labelledby={titleId}
+      aria-describedby={descId}
+      onClick={handleBackdropClick}
+    >
+      <header className="connect-wallet-dialog__header">
+        <h2 id={titleId} className="connect-wallet-dialog__title">
+          Connect Freighter Wallet
+        </h2>
+      </header>
 
-        <div className="connect-wallet-dialog__body">
-          <p id={descId} className="connect-wallet-dialog__description">
-            Freighter is a Stellar wallet browser extension. Clicking <strong>Connect</strong> will
-            open the Freighter extension and ask you to approve access for this session.
-          </p>
+      <div className="connect-wallet-dialog__body">
+        <p id={descId} className="connect-wallet-dialog__description">
+          Freighter is a Stellar wallet browser extension. Clicking <strong>Connect</strong> will
+          open the Freighter extension and ask you to approve access for this session.
+        </p>
 
-          {errorMessage && (
-            <div role="alert" className="connect-wallet-dialog__error">
-              {errorMessage}
-            </div>
-          )}
-        </div>
-
-        <footer className="connect-wallet-dialog__footer">
-          <Button
-            ref={cancelRef}
-            type="button"
-            variant="secondary"
-            onClick={onClose}
-            disabled={isConnecting}
-          >
-            Cancel
-          </Button>
-          <Button type="button" variant="primary" onClick={handleConnect} isLoading={isConnecting}>
-            Connect
-          </Button>
-        </footer>
+        {errorMessage && (
+          <div role="alert" className="connect-wallet-dialog__error">
+            {errorMessage}
+          </div>
+        )}
       </div>
-    </div>,
+
+      <footer className="connect-wallet-dialog__footer">
+        <Button
+          ref={cancelRef}
+          type="button"
+          variant="secondary"
+          onClick={onClose}
+          disabled={isConnecting}
+        >
+          Cancel
+        </Button>
+        <Button type="button" variant="primary" onClick={handleConnect} isLoading={isConnecting}>
+          Connect
+        </Button>
+      </footer>
+    </dialog>,
     document.body
   )
 }

--- a/src/components/KeyboardShortcutsDialog.tsx
+++ b/src/components/KeyboardShortcutsDialog.tsx
@@ -54,7 +54,7 @@ export function formatModifierKey(
 const GROUPED = groupShortcuts(KEYBOARD_SHORTCUTS)
 
 /**
- * Modal dialog listing all global keyboard shortcuts.
+ * Dialog dialog listing all global keyboard shortcuts.
  *
  * - Renders via a React portal into `document.body`.
  * - Focus is trapped inside while open; restored on close.

--- a/src/components/QRScannerDialog.tsx
+++ b/src/components/QRScannerDialog.tsx
@@ -11,7 +11,7 @@ interface QRScannerDialogProps {
 
 type ScannerState = 'requesting' | 'scanning' | 'error' | 'success'
 
-export default function QRScannerDialog({ open, onScan, onClose }: QRScannerModalProps) {
+export default function QRScannerDialog({ open, onScan, onClose }: QRScannerDialogProps) {
   const dialogRef = useRef<HTMLDivElement>(null)
   const closeButtonRef = useRef<HTMLButtonElement>(null)
   const videoRef = useRef<HTMLVideoElement>(null)

--- a/src/components/SessionTimeoutDialog.test.tsx
+++ b/src/components/SessionTimeoutDialog.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import SessionTimeoutDialog, { type SessionTimeoutDialogProps } from './SessionTimeoutDialog'
 
-function renderModal(overrides: Partial<SessionTimeoutDialogProps> = {}) {
+function renderDialog(overrides: Partial<SessionTimeoutDialogProps> = {}) {
   const onStayLoggedIn = vi.fn()
   const onLogout = vi.fn()
 
@@ -40,12 +40,12 @@ describe('SessionTimeoutDialog', () => {
 
   describe('rendering', () => {
     it('renders nothing when closed', () => {
-      renderModal({ open: false })
+      renderDialog({ open: false })
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
     })
 
     it('shows the initial time left when opened', () => {
-      renderModal({ timeLeftSeconds: 60 })
+      renderDialog({ timeLeftSeconds: 60 })
       expect(subtitleText()).toBe('Your session will expire in 60 seconds due to inactivity.')
     })
   })
@@ -56,7 +56,7 @@ describe('SessionTimeoutDialog', () => {
     })
 
     it('decrements the countdown by exactly one every second', () => {
-      renderModal({ timeLeftSeconds: 5 })
+      renderDialog({ timeLeftSeconds: 5 })
 
       for (const expected of [4, 3, 2, 1, 0]) {
         act(() => {
@@ -69,7 +69,7 @@ describe('SessionTimeoutDialog', () => {
     })
 
     it('does not decrement more than once per second', () => {
-      renderModal({ timeLeftSeconds: 5 })
+      renderDialog({ timeLeftSeconds: 5 })
 
       act(() => {
         vi.advanceTimersByTime(500)
@@ -78,7 +78,7 @@ describe('SessionTimeoutDialog', () => {
     })
 
     it('clamps at zero and never goes negative', () => {
-      renderModal({ timeLeftSeconds: 2 })
+      renderDialog({ timeLeftSeconds: 2 })
 
       act(() => {
         vi.advanceTimersByTime(10_000)
@@ -87,7 +87,7 @@ describe('SessionTimeoutDialog', () => {
     })
 
     it('resets the countdown when timeLeftSeconds changes while open', () => {
-      const { rerender } = renderModal({ timeLeftSeconds: 5 })
+      const { rerender } = renderDialog({ timeLeftSeconds: 5 })
 
       act(() => {
         vi.advanceTimersByTime(3000)
@@ -106,7 +106,7 @@ describe('SessionTimeoutDialog', () => {
     })
 
     it('stops counting down once closed', () => {
-      const { rerender, onStayLoggedIn, onLogout } = renderModal({ timeLeftSeconds: 5 })
+      const { rerender, onStayLoggedIn, onLogout } = renderDialog({ timeLeftSeconds: 5 })
 
       act(() => {
         vi.advanceTimersByTime(2000)
@@ -132,7 +132,7 @@ describe('SessionTimeoutDialog', () => {
   describe('CTA behaviour', () => {
     it('keeps "Stay logged in" disabled until STAY is typed', async () => {
       const user = userEvent.setup()
-      renderModal()
+      renderDialog()
 
       const stayButton = screen.getByRole('button', { name: 'Stay logged in' })
       expect(stayButton).toBeDisabled()
@@ -144,7 +144,7 @@ describe('SessionTimeoutDialog', () => {
 
     it('calls onStayLoggedIn only after typing STAY and clicking the CTA', async () => {
       const user = userEvent.setup()
-      const { onStayLoggedIn, onLogout } = renderModal()
+      const { onStayLoggedIn, onLogout } = renderDialog()
 
       const input = screen.getByRole('textbox', { name: /type.*stay/i })
       await user.type(input, 'STAY')
@@ -156,7 +156,7 @@ describe('SessionTimeoutDialog', () => {
 
     it('does not call onStayLoggedIn for a partial or incorrect phrase', async () => {
       const user = userEvent.setup()
-      const { onStayLoggedIn } = renderModal()
+      const { onStayLoggedIn } = renderDialog()
 
       const input = screen.getByRole('textbox', { name: /type.*stay/i })
       await user.type(input, 'stay')
@@ -167,7 +167,7 @@ describe('SessionTimeoutDialog', () => {
 
     it('calls onLogout when Cancel is clicked', async () => {
       const user = userEvent.setup()
-      const { onStayLoggedIn, onLogout } = renderModal()
+      const { onStayLoggedIn, onLogout } = renderDialog()
 
       await user.click(screen.getByRole('button', { name: 'Cancel' }))
 

--- a/src/components/SessionTimeoutDialog.tsx
+++ b/src/components/SessionTimeoutDialog.tsx
@@ -9,7 +9,7 @@ export interface SessionTimeoutDialogProps {
 }
 
 /**
- * Modal shown when the user's session is about to expire due to inactivity.
+ * Dialog shown when the user's session is about to expire due to inactivity.
  */
 export default function SessionTimeoutDialog({
   open,


### PR DESCRIPTION
## Summary

Convert dialog components from `<div role="dialog" aria-modal="true">` to the native `<dialog>` HTML element with `showModal()`/close()`. This improves accessibility and semantics.

## Changes

### Components converted to native `<dialog>`
- **ConfirmDialog.tsx** — replaced `<div role="dialog">` with `<dialog>`, added `showModal()`/close()` lifecycle via useEffect, cancel event handler for Escape key
- **ConnectWalletDialog.tsx** — same pattern

### CSS
- Replaced custom backdrop div ( / ) with native `::backdrop` pseudo-element
- Simplified mobile layout (removed backdrop alignment, used `margin-top: auto` for bottom-sheet positioning)

### Renames
- `QRScannerModalProps` → `QRScannerDialogProps` (type name fix)
- `renderModal` → `renderDialog` in test helpers
- `ConnectWalletModal` → `ConnectWalletDialog` in comments
- Various `Modal` → `Dialog` updates in JSDoc comments

### Test updates
- Removed `aria-modal="true"` assertions (native `<dialog>` doesn't use this attribute)
- Updated backdrop click tests to click the dialog element directly (native dialog backdrop is `::backdrop` pseudo-element, not a DOM element)
- Updated "click inside dialog" tests to click heading elements instead of the dialog element

## Testing

All tests pass locally. The native `<dialog>` element handles:
- Focus trapping (built-in)
- Backdrop overlay (`::backdrop` pseudo-element)
- Escape key handling (`cancel` event)
- Body scroll locking (built-in with `showModal()`)