### PR TITLE
ci: add no-console ESLint rule to catch accidental console.log in production (Closes #945)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,6 +39,12 @@ export default tseslint.config({
         allow: [],
       },
     ],
+    'no-console': [
+      'warn',
+      {
+        allow: ['warn', 'error'],
+      },
+    ],
   },
 }, {
   files: ['**/*.mjs'],


### PR DESCRIPTION
## Summary

Adds the ESLint `no-console` rule at `warn` level to prevent accidental `console.log` statements from reaching production bundles.

## Changes

- **eslint.config.js** — Added `no-console: ['warn', { allow: ['warn', 'error'] }]` rule

`console.warn` and `console.error` are intentionally allowed for legitimate diagnostic logging.

Closes #945