### PR TITLE
feat: harden wipe form state on logout (Closes #946)

### DIFF
--- a/src/context/WalletContext.tsx
+++ b/src/context/WalletContext.tsx
@@ -5,6 +5,7 @@ import { useWallet as useWalletState, type UseWalletState } from '../hooks/useWa
 import { useIdleTimeout } from '../hooks/useIdleTimeout'
 import { useToast } from '../components/ToastProvider'
 import SessionTimeoutDialog from '../components/SessionTimeoutDialog'
+import { clearSessionStorage } from '../lib/clearSessionStorage'
 
 export type WalletContextValue = UseWalletState & {
   connected: boolean
@@ -64,6 +65,7 @@ export function WalletProvider({ children }: { children: React.ReactNode }) {
     wallet.disconnect()
     setShowWarning(false)
     setLastReauthTime(null)
+    clearSessionStorage()
     navigate('/signin')
     addToast('warning', 'Logged out due to inactivity.')
   }, [wallet, navigate, addToast])

--- a/src/lib/clearSessionStorage.test.ts
+++ b/src/lib/clearSessionStorage.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { clearSessionStorage } from './clearSessionStorage'
+
+const PRESERVED_KEYS = ['credence:settings', 'credence:onboarding:onboardedAt', 'theme']
+const CLEARED_KEYS = [
+  'credence:recent-lookups',
+  'credence:onboarding:step',
+  'credence:pendingTransactions',
+  'credence:pinned_widgets',
+]
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('clearSessionStorage', () => {
+  it('removes form-state keys from localStorage', () => {
+    // Seed all keys
+    for (const key of [...PRESERVED_KEYS, ...CLEARED_KEYS]) {
+      localStorage.setItem(key, key)
+    }
+
+    clearSessionStorage()
+
+    // Cleared keys should be gone
+    for (const key of CLEARED_KEYS) {
+      expect(localStorage.getItem(key)).toBeNull()
+    }
+  })
+
+  it('preserves preference keys (settings, theme, onboarding completion) on logout', () => {
+    for (const key of [...PRESERVED_KEYS, ...CLEARED_KEYS]) {
+      localStorage.setItem(key, key)
+    }
+
+    clearSessionStorage()
+
+    // Preserved keys should still be in localStorage
+    for (const key of PRESERVED_KEYS) {
+      expect(localStorage.getItem(key)).toBe(key)
+    }
+  })
+
+  it('handles empty localStorage without throwing', () => {
+    expect(() => clearSessionStorage()).not.toThrow()
+  })
+
+  it('handles unavailable localStorage without throwing', () => {
+    // Simulate a storage-quota error or private-browsing restriction
+    const removeItem = vi
+      .spyOn(Storage.prototype, 'removeItem')
+      .mockImplementation(() => {
+        throw new Error('Storage quota exceeded')
+      })
+
+    expect(() => clearSessionStorage()).not.toThrow()
+    removeItem.mockRestore()
+  })
+})

--- a/src/lib/clearSessionStorage.ts
+++ b/src/lib/clearSessionStorage.ts
@@ -1,0 +1,31 @@
+import { ONBOARDING_STEP_STORAGE_KEY } from '../config/onboarding'
+import { PINNED_WIDGETS_STORAGE_KEY } from '../config/pinnedWidgets'
+
+/**
+ * Keys that carry user-specific form state and should be removed on logout.
+ * Preferences (theme, settings, onboarding completion) are intentionally preserved.
+ */
+const FORM_STATE_KEYS: string[] = [
+  'credence:recent-lookups',
+  ONBOARDING_STEP_STORAGE_KEY,
+  'credence:pendingTransactions',
+  PINNED_WIDGETS_STORAGE_KEY,
+]
+
+/**
+ * Clear user-specific form state from localStorage while preserving
+ * persistent preferences such as theme and settings.
+ *
+ * Call this on logout / session expiry to prevent stale form data
+ * from leaking across sessions.
+ */
+export function clearSessionStorage(): void {
+  if (typeof window === 'undefined') return
+  try {
+    for (const key of FORM_STATE_KEYS) {
+      window.localStorage.removeItem(key)
+    }
+  } catch {
+    // Storage may be unavailable (private browsing, storage quota, etc.)
+  }
+}


### PR DESCRIPTION
## Summary

Harden form state cleanup on logout. When a user logs out, user-specific form state from localStorage is now cleared while persistent preferences (theme, network, settings) are preserved.

### Threat model

Without this check, a shared/public computer retains:
- Recent trust score lookups (`credence:recent-lookups`)
- Pending transactions (`credence:pendingTransactions`)
- Pinned widgets (`credence:pinned_widgets`)
- Onboarding progress (`credence:onboarding:step`)

An attacker who gains access to the same machine after logout could reconstruct user activity history from these localStorage entries.

### Changes

1. **`src/lib/clearSessionStorage.ts`** — New utility that selectively removes user-specific form state keys from localStorage while preserving preference keys (`credence:settings`, `credence:onboarding:onboardedAt`, `theme`).
2. **`src/context/WalletContext.tsx`** — Call `clearSessionStorage()` inside `handleLogout` before navigating to `/signin`.
3. **`src/lib/clearSessionStorage.test.ts`** — 4 tests covering:
   - Happy path: form-state keys are removed
   - Preserved keys: settings/theme/onboarding completion survive
   - Empty localStorage: no-op without throwing
   - Storage unavailable: graceful error handling

### Testing

```bash
npm test -- src/lib/clearSessionStorage.test.ts
```

All 4 tests pass locally.

Closes #946
