### PR TITLE
feat: expose Sentry DSN as a runtime env (Closes #920)

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,12 @@
     <meta name="description" content="Credence — on-chain economic identity on Stellar. Stake USDC as a programmable reputation bond." />
     <title>Credence — Economic Trust</title>
     <script>
+      // Runtime config — injected by the server at deployment time.
+      // Overrides Vite build-time env vars without needing a rebuild.
+      // Example: window.__RUNTIME_CONFIG__ = { VITE_SENTRY_DSN: "https://..." }
+      window.__RUNTIME_CONFIG__ = window.__RUNTIME_CONFIG__ || {};
+    </script>
+    <script>
       (function() {
         try {
           var saved = JSON.parse(localStorage.getItem('credence:settings'));

--- a/src/config/sentry.test.ts
+++ b/src/config/sentry.test.ts
@@ -4,6 +4,8 @@ describe('SENTRY_CONFIG DSN resolution', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.unstubAllEnvs()
+    // Clear any runtime config from previous tests
+    delete (window as Record<string, unknown>).__RUNTIME_CONFIG__
   })
 
   const setEnv = (value: string | undefined) => {
@@ -18,23 +20,53 @@ describe('SENTRY_CONFIG DSN resolution', () => {
     return ((await vi.importActual('./sentry')) as typeof import('./sentry')).SENTRY_CONFIG
   }
 
-  it('should use VITE_SENTRY_DSN when set', async () => {
-    setEnv('https://key@o1.ingest.sentry.io/123')
-    expect((await getSentryConfig()).dsn).toBe('https://key@o1.ingest.sentry.io/123')
+  describe('build-time env (import.meta.env)', () => {
+    it('should use VITE_SENTRY_DSN when set', async () => {
+      setEnv('https://key@o1.ingest.sentry.io/123')
+      expect((await getSentryConfig()).dsn).toBe('https://key@o1.ingest.sentry.io/123')
+    })
+
+    it('should fall back to empty string when env is absent', async () => {
+      setEnv(undefined)
+      expect((await getSentryConfig()).dsn).toBe('')
+    })
+
+    it('should fall back to empty string when env is empty', async () => {
+      setEnv('')
+      expect((await getSentryConfig()).dsn).toBe('')
+    })
+
+    it('should fall back to empty string when env is whitespace', async () => {
+      setEnv('   ')
+      expect((await getSentryConfig()).dsn).toBe('')
+    })
   })
 
-  it('should fall back to empty string when env is absent', async () => {
-    setEnv(undefined)
-    expect((await getSentryConfig()).dsn).toBe('')
-  })
+  describe('runtime config (window.__RUNTIME_CONFIG__)', () => {
+    it('should prefer runtime config over build-time env', async () => {
+      setEnv('https://buildtime@o1.ingest.sentry.io/0')
+      ;(window as Record<string, unknown>).__RUNTIME_CONFIG__ = {
+        VITE_SENTRY_DSN: 'https://runtime@o1.ingest.sentry.io/1',
+      }
+      expect((await getSentryConfig()).dsn).toBe('https://runtime@o1.ingest.sentry.io/1')
+    })
 
-  it('should fall back to empty string when env is empty', async () => {
-    setEnv('')
-    expect((await getSentryConfig()).dsn).toBe('')
-  })
+    it('should fall back to build-time env when runtime config is absent', async () => {
+      setEnv('https://buildtime@o1.ingest.sentry.io/0')
+      expect((await getSentryConfig()).dsn).toBe('https://buildtime@o1.ingest.sentry.io/0')
+    })
 
-  it('should fall back to empty string when env is whitespace', async () => {
-    setEnv('   ')
-    expect((await getSentryConfig()).dsn).toBe('')
+    it('should fall back to empty string when neither is set', async () => {
+      setEnv(undefined)
+      expect((await getSentryConfig()).dsn).toBe('')
+    })
+
+    it('should fall back to build-time env when runtime config is empty', async () => {
+      setEnv('https://buildtime@o1.ingest.sentry.io/0')
+      ;(window as Record<string, unknown>).__RUNTIME_CONFIG__ = {
+        VITE_SENTRY_DSN: '',
+      }
+      expect((await getSentryConfig()).dsn).toBe('https://buildtime@o1.ingest.sentry.io/0')
+    })
   })
 })

--- a/src/config/sentry.ts
+++ b/src/config/sentry.ts
@@ -1,9 +1,16 @@
-const DEFAULT_DSN = ''
-
-const envDsn = import.meta.env.VITE_SENTRY_DSN?.trim() || DEFAULT_DSN
+/**
+ * Resolve the Sentry DSN from runtime config (window.__RUNTIME_CONFIG__),
+ * then fall back to the build-time Vite env var, then to empty string.
+ */
+function resolveDsn(): string {
+  if (typeof window !== 'undefined' && window.__RUNTIME_CONFIG__?.VITE_SENTRY_DSN) {
+    return window.__RUNTIME_CONFIG__.VITE_SENTRY_DSN.trim()
+  }
+  return import.meta.env.VITE_SENTRY_DSN?.trim() || ''
+}
 
 export const SENTRY_CONFIG = {
-  dsn: envDsn,
+  dsn: resolveDsn(),
 } as const
 
 export type SentryConfig = typeof SENTRY_CONFIG

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -10,8 +10,18 @@ interface ImportMetaEnv {
   readonly VITE_API_RATE_LIMIT_MAX: string
   readonly VITE_API_RATE_LIMIT_WINDOW_MS: string
   readonly VITE_API_RATE_LIMIT_ENABLED: string
+  readonly VITE_SENTRY_DSN: string
 }
 
 interface ImportMeta {
   readonly env: ImportMetaEnv
+}
+
+/** Runtime config injected by the server via <script> in index.html. */
+interface RuntimeConfig {
+  readonly VITE_SENTRY_DSN?: string
+}
+
+interface Window {
+  __RUNTIME_CONFIG__?: RuntimeConfig
 }


### PR DESCRIPTION
## Summary

Expose the Sentry DSN as a runtime environment variable, so it can be configured at deployment time without rebuilding the application.

## Changes

- **`src/config/sentry.ts`**: Added `resolveDsn()` function that checks `window.__RUNTIME_CONFIG__?.VITE_SENTRY_DSN` first, then falls back to `import.meta.env.VITE_SENTRY_DSN` (build-time), then to empty string.
- **`src/vite-env.d.ts`**: Added `VITE_SENTRY_DSN` to `ImportMetaEnv`, added `RuntimeConfig` interface, and extended `Window` with `__RUNTIME_CONFIG__`.
- **`src/config/sentry.test.ts`**: Added 4 new tests covering runtime config resolution (priority, fallback, absent, empty).
- **`index.html`**: Added `<script>` placeholder for server-side runtime config injection.

## Testing

All 8 tests pass (4 existing + 4 new):

```
✓ src/config/sentry.test.ts (8 tests) 37ms
```

Closes #920